### PR TITLE
small tweaks to utils, useful in Tabs

### DIFF
--- a/packages/core/src/utils/makePrefixer.ts
+++ b/packages/core/src/utils/makePrefixer.ts
@@ -1,4 +1,5 @@
+export type ClassNamePrefixer = (...names: string[]) => string;
 export const makePrefixer =
-  (prefix: string): ((...names: string[]) => string) =>
+  (prefix: string): ClassNamePrefixer =>
   (...names: string[]): string =>
     [prefix, ...names].join("-");

--- a/packages/lab/src/utils/useId.ts
+++ b/packages/lab/src/utils/useId.ts
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
+// Why would we ever want to wait unti post render to know our id ?
 export function useId(idOverride?: string): string {
   const [defaultId, setDefaultId] = useState(idOverride);
   const id = idOverride || defaultId;
@@ -12,4 +13,11 @@ export function useId(idOverride?: string): string {
     }
   }, [defaultId]);
   return id as string;
+}
+
+export function useIdMemo(idOverride?: string): string {
+  const id = useMemo(() => {
+    return idOverride ?? `uitk-${Math.round(Math.random() * 1e5)}`;
+  }, [idOverride]);
+  return id;
 }


### PR DESCRIPTION
useId only assigns an id after initial render . This is pretty much never the behaviour I want. Because a number of tests rely on the existing behaviour, I've added a new variant, that uses useMemo rather than useEffect.

I hope we can eventually replace the original version with the new version