### PR TITLE
Fix color difference vs Figma

### DIFF
--- a/packages/theme/css/foundations/color.css
+++ b/packages/theme/css/foundations/color.css
@@ -20,7 +20,7 @@
   --uitk-color-red-300: rgb(255, 89, 66);
   --uitk-color-red-400: rgb(237, 65, 42);
   --uitk-color-red-500: rgb(227, 43, 22);
-  --uitk-color-red-600: rgb(196, 32, 16);
+  --uitk-color-red-600: rgb(196, 48, 16);
   --uitk-color-red-700: rgb(166, 21, 11);
   --uitk-color-red-800: rgb(136, 10, 5);
   --uitk-color-red-900: rgb(106, 0, 0);
@@ -74,7 +74,7 @@
   --uitk-color-blue-20: rgb(183, 222, 246);
   --uitk-color-blue-30: rgb(164, 213, 244);
   --uitk-color-blue-40: rgb(144, 204, 242);
-  --uitk-color-blue-50: rgb(125, 195, 240);
+  --uitk-color-blue-50: rgb(125, 195, 242);
   --uitk-color-blue-100: rgb(100, 177, 228);
   --uitk-color-blue-200: rgb(75, 159, 216);
   --uitk-color-blue-300: rgb(51, 141, 205);


### PR DESCRIPTION
Was testing a Figma plugin (https://github.com/origami-z/export-to-css-variables), found out the auto generated css variable has different values.

In Figma "Color Palette" file
- Red 600 is `#C43010`
- Blue 50 is `#7DC3F2`

# ⚠️  Pending Designer Confirmation