### PR TITLE
@ignore some CSS comments

### DIFF
--- a/packages/core/src/button/Button.css
+++ b/packages/core/src/button/Button.css
@@ -7,7 +7,7 @@
   --button-focused-outline-offset: var(--uitk-focused-outline-offset);
 }
 
-/* Icon API */
+/* Icon API @ignore */
 .uitkButton {
   --uitkIcon-letter-spacing: 0;
 }
@@ -24,7 +24,7 @@
   --button-text-color-hover: var(--uitk-actionable-cta-text-color-hover);
 }
 
-/* Icon API in "CTA" variant */
+/* Icon API in "CTA" variant @ignore */
 .uitkButton-cta {
   --uitkIcon-color: var(--uitk-actionable-cta-icon-color);
 }
@@ -51,7 +51,7 @@
   --button-text-color-hover: var(--uitk-actionable-primary-text-color-hover);
 }
 
-/* Icon API in "primary" variant */
+/* Icon API in "primary" variant @ignore */
 .uitkButton-primary {
   --uitkIcon-color: var(--uitk-actionable-primary-icon-color);
 }
@@ -80,7 +80,7 @@
   --button-font-weight: var(--uitkButton-font-weight, --uitk-typography-weight-semiBold);
 }
 
-/* Icon API in "secondary" variant */
+/* Icon API in "secondary" variant @ignore */
 .uitkButton-secondary {
   --uitkIcon-color: var(--uitk-actionable-secondary-icon-color);
 }

--- a/tooling/css-variable-docgen-plugin/src/index.ts
+++ b/tooling/css-variable-docgen-plugin/src/index.ts
@@ -221,10 +221,16 @@ export function cssVariableDocgen(options: Options = {}): Plugin {
                 comments[this.selector.loc.start.line - 1]
               ) {
                 const name = generate(node);
-                classNames[name] = {
-                  name,
-                  description: comments[this.selector.loc.start.line - 1],
-                };
+                if (
+                  !comments[this.selector.loc.start.line - 1].includes(
+                    "@ignore"
+                  )
+                ) {
+                  classNames[name] = {
+                    name,
+                    description: comments[this.selector.loc.start.line - 1],
+                  };
+                }
               }
             },
           });


### PR DESCRIPTION
Need some mechanism to ignore some CSS class comments, e.g. Button has these "Icon API".


<img width="1050" alt="old button css comments" src="https://user-images.githubusercontent.com/5257855/165728966-0b2315d8-d75c-41b6-864b-ed021e341e23.png">


I'm stealing `@ignore` from JSDoc syntax, so new ones should show 

<img width="475" alt="new button css comments" src="https://user-images.githubusercontent.com/5257855/165729280-2f9e06a8-922e-46b2-b001-ac1fbe92c4b5.png">
