### PR TITLE
Fix broken introduction by temporarily remove LinkTo

### DIFF
--- a/packages/theme/stories/introduction.stories.mdx
+++ b/packages/theme/stories/introduction.stories.mdx
@@ -143,7 +143,7 @@ The UI Toolkit provides a component `ToolkitProvider` for React users that takes
 </ToolkitProvider>
 ```
 
-See <a aria-label="Toolkitprovider docs" href="http://localhost:6006/?path=/docs/Toolkit-released-Toolkit-provider-docs--nested-Toolkit-provider">ToolkitProvider Docs</a>.
+See ToolkitProvider docs.
 
 #### Theme variants - Light/Dark, Density
 


### PR DESCRIPTION
`LinkTo` breaks in production build, in `/?path=/story/documentation-styles-and-theming-introduction--page` page.

Suspecting this is to do with vite builder can't revolve correctly on subroute package import, as all other exports from the top level of `@storybook/addon-links` package are not default exports.