### PR TITLE
Test global css in :root

### DIFF
--- a/packages/theme/css/foundations/color.css
+++ b/packages/theme/css/foundations/color.css
@@ -1,11 +1,9 @@
-.uitk-light,
-.uitk-dark {
+:root {
   --uitk-color-white: rgb(255, 255, 255);
   --uitk-color-black: rgb(0, 0, 0);
 }
 
-.uitk-light,
-.uitk-dark {
+:root {
   /* Color palette will stay the same no matter of theming */
   --uitk-color-white: rgb(255, 255, 255);
   --uitk-color-black: rgb(0, 0, 0);

--- a/packages/theme/css/foundations/fade.css
+++ b/packages/theme/css/foundations/fade.css
@@ -1,5 +1,4 @@
-.uitk-light,
-.uitk-dark {
+:root {
   /* Used in container */
   --uitk-color-grey-20-fade-40: rgba(234, 237, 239, 0.4);
   --uitk-color-grey-600-fade-40: rgba(47, 49, 54, 0.4);

--- a/packages/theme/css/foundations/size.css
+++ b/packages/theme/css/foundations/size.css
@@ -1,9 +1,6 @@
 /** Size */
 /* Think twice if you're using these directly. It's better to use density invariant ones below, e.g. `--uitk-size-regular-unit` */
-.uitk-density-touch,
-.uitk-density-low,
-.uitk-density-medium,
-.uitk-density-high {
+:root {
   /* Do we need this? if so, does this name makes sense? */
   --uitk-size-basis-unit: 4px;
 

--- a/packages/theme/css/foundations/spacing.css
+++ b/packages/theme/css/foundations/spacing.css
@@ -1,8 +1,5 @@
 /** Spacing */
-.uitk-density-touch,
-.uitk-density-low,
-.uitk-density-medium,
-.uitk-density-high {
+:root {
   --uitk-spacing-touch: 16px;
   --uitk-spacing-low: 12px;
   --uitk-spacing-medium: 8px;

--- a/packages/theme/css/foundations/typography.css
+++ b/packages/theme/css/foundations/typography.css
@@ -1,7 +1,4 @@
-.uitk-density-touch,
-.uitk-density-low,
-.uitk-density-medium,
-.uitk-density-high {
+:root {
   --uitk-typography-font-family: uitk-sans;
 
   --uitk-typography-weight-light: 300;

--- a/packages/theme/css/foundations/zindex.css
+++ b/packages/theme/css/foundations/zindex.css
@@ -1,7 +1,4 @@
-.uitk-density-touch,
-.uitk-density-low,
-.uitk-density-medium,
-.uitk-density-high {
+:root {
   --uitk-zindex-default: 1;
   --uitk-zindex-popout: 1000;
   --uitk-zindex-docked: 1050;

--- a/packages/theme/global.css
+++ b/packages/theme/global.css
@@ -1,6 +1,6 @@
-/** 
+/**
  * Have some global styles to simulate more realistic app. Currently only for Storybook.
- * We don't have a universal set of styling on each component, e.g. some component set font-family some don't. 
+ * We don't have a universal set of styling on each component, e.g. some component set font-family some don't.
  *
  * It would be nice to do these as a global reset, so each component doesn't need to set these.
  * - font-family
@@ -15,6 +15,8 @@ p {
 
 body {
   font-family: "uitk-sans";
+  color: var(--uitk-text-primary-color);
+  background-color: var(--uitk-container-background);
 }
 
 uitk-theme {


### PR DESCRIPTION
We can potentially offer better light/dark theme support by supplying a bit more in `global.css`. However, `body` won't get variables, so testing moving some to `:root` scope.

Note: storybook contains other css defined in `.sb-show-main`, so won't be the best testing bed for this.

However we do need something else for storybook as well, e.g flex layout (`/?path=/story/layout-flexlayout--toolkit-flex-layout&args=gap:1&globals=theme:dark`). 

![flex layout in dark theme](https://user-images.githubusercontent.com/5257855/167256815-4bb4504d-7983-47ca-973d-c006431aaac9.png)

![image](https://user-images.githubusercontent.com/5257855/167256848-720dc7cc-60ff-4e5d-a004-4a27c45809bc.png)

