### PR TITLE
default flex to nowrap and overflow visible

### DIFF
--- a/packages/lab/src/layout/FlexLayout/FlexLayout.css
+++ b/packages/lab/src/layout/FlexLayout/FlexLayout.css
@@ -3,7 +3,7 @@
   --uitkFlexLayout-gap-multiplier: 1;
   --uitkFlexLayout-layout-display: flex;
   --uitkFlexLayout-direction: row;
-  --uitkFlexLayout-wrap: wrap;
+  --uitkFlexLayout-wrap: nowrap;
   --uitkFlexLayout-justify: flex-start;
   --uitkFlexLayout-align: stretch;
   --uitkFlexLayout-separator: var(--uitk-separable-border-width);
@@ -17,7 +17,6 @@
   flex-wrap: var(--uitkFlexLayout-wrap);
   justify-content: var(--uitkFlexLayout-justify);
   align-items: var(--uitkFlexLayout-align);
-  overflow: hidden;
 }
 
 .uitkFlexLayout-separator {

--- a/packages/lab/src/layout/FlexLayout/FlexLayout.tsx
+++ b/packages/lab/src/layout/FlexLayout/FlexLayout.tsx
@@ -60,7 +60,7 @@ export const FlexLayout = forwardRef<HTMLDivElement, FlexLayoutProps>(
       justify,
       separators,
       style,
-      wrap = true,
+      wrap,
       ...rest
     },
     ref
@@ -72,7 +72,7 @@ export const FlexLayout = forwardRef<HTMLDivElement, FlexLayoutProps>(
 
     const flexGap = useResponsiveProp(gap, 1);
     const flexDirection = useResponsiveProp(direction, "row");
-    const flexWrap = useResponsiveProp(wrap, true);
+    const flexWrap = useResponsiveProp(wrap, false);
 
     const flexLayoutStyles = {
       ...style,

--- a/packages/lab/stories/layout/flex-layout.stories.tsx
+++ b/packages/lab/stories/layout/flex-layout.stories.tsx
@@ -1,11 +1,15 @@
 import {
-  FLEX_ALIGNMENT_BASE,
-  FLEX_CONTENT_ALIGNMENT_BASE,
+  Checkbox,
+  Dropdown,
   FlexItem,
   FlexLayout,
+  FormField,
+  FLEX_ALIGNMENT_BASE,
+  FLEX_CONTENT_ALIGNMENT_BASE,
 } from "@jpmorganchase/uitk-lab";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { FlexContent } from "./flex-item.stories";
+import { useState } from "react";
 
 export default {
   title: "Layout/FlexLayout",
@@ -58,12 +62,12 @@ ToolkitFlexLayout.argTypes = {
 const Responsive: ComponentStory<typeof FlexLayout> = (args) => {
   return (
     <FlexLayout
-      direction={{
-        xs: "column",
-        sm: "column",
-        md: "row",
-        lg: "row",
-        xl: "row",
+      wrap={{
+        xs: true,
+        sm: true,
+        md: true,
+        lg: false,
+        xl: false,
       }}
       {...args}
     >
@@ -76,6 +80,52 @@ const Responsive: ComponentStory<typeof FlexLayout> = (args) => {
   );
 };
 export const ToolkitFlexLayoutResponsive = Responsive.bind({});
-ToolkitFlexLayoutResponsive.args = {};
+ToolkitFlexLayoutResponsive.args = {
+  direction: {
+    xs: "column",
+    md: "row",
+  },
+  wrap: {
+    xs: true,
+    lg: false,
+  },
+};
 
 ToolkitFlexLayoutResponsive.argTypes = {};
+
+const colorFormats = ["Hex", "HSV"];
+
+const Forms: ComponentStory<typeof FlexLayout> = (args) => {
+  const [showMode, setShowMode] = useState(colorFormats[0]);
+  const [showContrast, setShowContrast] = useState(false);
+  return (
+    <FlexLayout {...args}>
+      <FormField
+        label="Show as"
+        labelPlacement="left"
+        className="ColorInpsector-preferences-showAs"
+      >
+        <Dropdown
+          source={colorFormats}
+          selectedItem={showMode}
+          onChange={(_, item) => setShowMode(item || "")}
+        />
+      </FormField>
+      <Checkbox
+        label="Contrast"
+        checked={showContrast}
+        onChange={(_, checked) => setShowContrast(checked)}
+      />
+    </FlexLayout>
+  );
+};
+export const ToolkitFormInFlexLayout = Forms.bind({});
+ToolkitFormInFlexLayout.args = {
+  gap: 1,
+  wrap: {
+    xs: true,
+    sm: false,
+  },
+};
+
+ToolkitFormInFlexLayout.argTypes = {};


### PR DESCRIPTION
`overflow:hidden` is hiding focus rings, I reverted to the default and we should add to our documentation something about using responsive props if the layouts are overlapping.

`wrap: nowrap` is the css default, which we can change in any FlexLayout based layout that requires it differently, but we should probably keep the default behaviour here to avoid confusion.