### PR TITLE
Display components "N/A" label on mobile

### DIFF
--- a/site/docs/components/_index/ComponentsList.tsx
+++ b/site/docs/components/_index/ComponentsList.tsx
@@ -88,10 +88,12 @@ const ComponentStatusData = ({
     <span>{showReleaseDate ? `v${availableSince}` : null}</span>
   );
 
+  const activeStatus = status !== ComponentStatus.NOT_APPLICABLE;
+
   return (
     <div className={clsx(styles.status, styles[statusClass(status)])}>
-      {status !== ComponentStatus.NOT_APPLICABLE ? <StepActiveIcon /> : null}
-      {isMobileView ? (
+      {activeStatus ? <StepActiveIcon /> : null}
+      {isMobileView && activeStatus ? (
         mobileView
       ) : (
         <span>


### PR DESCRIPTION
Currently we don't display the components figma `N/A` status on mobile view
