### PR TITLE
adds robots.txt file to site

### DIFF
--- a/site/static/robots.txt
+++ b/site/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.saltdesignsystem.com/sitemap.xml


### PR DESCRIPTION
FYI: Docusaurus does already output a `sitemap.xml` file, so linking to it from the `robots.txt` will work fine.