### PR TITLE
Fix flex layouts polymorphic prop

### DIFF
--- a/.changeset/beige-bulldogs-brush.md
+++ b/.changeset/beige-bulldogs-brush.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": minor
+---
+
+extending `as` property from `FlexLayout` to `Stacklayout` and `FlowLayout` so they can use polymorphic behaviour

--- a/packages/core/src/flow-layout/FlowLayout.tsx
+++ b/packages/core/src/flow-layout/FlowLayout.tsx
@@ -2,6 +2,9 @@ import { ElementType, forwardRef, HTMLAttributes } from "react";
 import { FlexLayout, FlexLayoutProps } from "../flex-layout";
 
 export interface FlowLayoutProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * The HTML element used for the root node.
+   */
   as?: FlexLayoutProps<ElementType>["as"];
   /**
    * Defines the default behavior for how flex items are laid out along the cross axis on the current line, default is "stretch".

--- a/packages/core/src/flow-layout/FlowLayout.tsx
+++ b/packages/core/src/flow-layout/FlowLayout.tsx
@@ -1,26 +1,39 @@
-import { ElementType, forwardRef, HTMLAttributes } from "react";
+import { ElementType, forwardRef, ReactElement } from "react";
 import { FlexLayout, FlexLayoutProps } from "../flex-layout";
+import { PolymorphicComponentPropWithRef, PolymorphicRef } from "../utils";
 
-export interface FlowLayoutProps extends HTMLAttributes<HTMLDivElement> {
-  /**
-   * The HTML element used for the root node.
-   */
-  as?: FlexLayoutProps<ElementType>["as"];
-  /**
-   * Defines the default behavior for how flex items are laid out along the cross axis on the current line, default is "stretch".
-   */
-  align?: FlexLayoutProps<ElementType>["align"];
-  /**
-   * Controls the space between items, default is 3.
-   */
-  gap?: FlexLayoutProps<ElementType>["gap"];
-  /**
-   * Defines the alignment along the main axis, default is "start"
-   */
-  justify?: FlexLayoutProps<ElementType>["justify"];
-}
-export const FlowLayout = forwardRef<HTMLDivElement, FlowLayoutProps>(
-  function FlowLayout({ ...rest }, ref) {
-    return <FlexLayout direction="row" ref={ref} wrap {...rest} />;
+export type FlowLayoutProps<T extends ElementType> =
+  PolymorphicComponentPropWithRef<
+    T,
+    {
+      /**
+       * The HTML element used for the root node.
+       */
+      as?: FlexLayoutProps<ElementType>["as"];
+      /**
+       * Defines the default behavior for how flex items are laid out along the cross axis on the current line, default is "stretch".
+       */
+      align?: FlexLayoutProps<ElementType>["align"];
+      /**
+       * Controls the space between items, default is 3.
+       */
+      gap?: FlexLayoutProps<ElementType>["gap"];
+      /**
+       * Defines the alignment along the main axis, default is "start"
+       */
+      justify?: FlexLayoutProps<ElementType>["justify"];
+    }
+  >;
+
+type FlowLayoutComponent = <T extends ElementType = "div">(
+  props: FlowLayoutProps<T>
+) => ReactElement | null;
+
+export const FlowLayout: FlowLayoutComponent = forwardRef(
+  <T extends ElementType = "div">(
+    { ...props }: FlexLayoutProps<T>,
+    ref?: PolymorphicRef<T>
+  ) => {
+    return <FlexLayout direction="row" ref={ref} wrap {...props} />;
   }
 );

--- a/packages/core/src/flow-layout/FlowLayout.tsx
+++ b/packages/core/src/flow-layout/FlowLayout.tsx
@@ -27,9 +27,13 @@ type FlowLayoutComponent = <T extends ElementType = "div">(
 
 export const FlowLayout: FlowLayoutComponent = forwardRef(
   <T extends ElementType = "div">(
-    { ...props }: FlexLayoutProps<T>,
+    { children, ...rest }: FlowLayoutProps<T>,
     ref?: PolymorphicRef<T>
   ) => {
-    return <FlexLayout direction="row" ref={ref} wrap {...props} />;
+    return (
+      <FlexLayout direction="row" ref={ref} wrap {...rest}>
+        {children}
+      </FlexLayout>
+    );
   }
 );

--- a/packages/core/src/flow-layout/FlowLayout.tsx
+++ b/packages/core/src/flow-layout/FlowLayout.tsx
@@ -7,10 +7,6 @@ export type FlowLayoutProps<T extends ElementType> =
     T,
     {
       /**
-       * The HTML element used for the root node.
-       */
-      as?: FlexLayoutProps<ElementType>["as"];
-      /**
        * Defines the default behavior for how flex items are laid out along the cross axis on the current line, default is "stretch".
        */
       align?: FlexLayoutProps<ElementType>["align"];

--- a/packages/core/src/flow-layout/FlowLayout.tsx
+++ b/packages/core/src/flow-layout/FlowLayout.tsx
@@ -2,6 +2,7 @@ import { ElementType, forwardRef, HTMLAttributes } from "react";
 import { FlexLayout, FlexLayoutProps } from "../flex-layout";
 
 export interface FlowLayoutProps extends HTMLAttributes<HTMLDivElement> {
+  as?: FlexLayoutProps<ElementType>["as"];
   /**
    * Defines the default behavior for how flex items are laid out along the cross axis on the current line, default is "stretch".
    */

--- a/packages/core/src/stack-layout/StackLayout.tsx
+++ b/packages/core/src/stack-layout/StackLayout.tsx
@@ -27,9 +27,13 @@ type StackLayoutComponent = <T extends ElementType = "div">(
 
 export const StackLayout: StackLayoutComponent = forwardRef(
   <T extends ElementType = "div">(
-    { ...props }: FlexLayoutProps<T>,
+    { children, ...rest }: StackLayoutProps<T>,
     ref?: PolymorphicRef<T>
   ) => {
-    return <FlexLayout direction="column" ref={ref} {...props} />;
+    return (
+      <FlexLayout direction="column" ref={ref} {...rest}>
+        {children}
+      </FlexLayout>
+    );
   }
 );

--- a/packages/core/src/stack-layout/StackLayout.tsx
+++ b/packages/core/src/stack-layout/StackLayout.tsx
@@ -1,27 +1,39 @@
-import { ElementType, forwardRef, HTMLAttributes } from "react";
+import { ElementType, forwardRef, ReactElement } from "react";
 import { FlexLayout, FlexLayoutProps } from "../flex-layout";
+import { PolymorphicComponentPropWithRef, PolymorphicRef } from "../utils";
 
-export interface StackLayoutProps extends HTMLAttributes<HTMLDivElement> {
-  /**
-   * The HTML element used for the root node.
-   */
-  as?: FlexLayoutProps<ElementType>["as"];
-  /**
-   * Defines the default behavior for how flex items are laid out along the cross axis on the current line, default is "stretch".
-   */
-  align?: FlexLayoutProps<ElementType>["align"];
-  /**
-   * Controls the space between items, default is 3.
-   */
-  gap?: FlexLayoutProps<ElementType>["gap"];
-  /**
-   * Adds a separator between elements, default is false.
-   */
-  separators?: FlexLayoutProps<ElementType>["separators"];
-}
+export type StackLayoutProps<T extends ElementType> =
+  PolymorphicComponentPropWithRef<
+    T,
+    {
+      /**
+       * The HTML element used for the root node.
+       */
+      as?: FlexLayoutProps<ElementType>["as"];
+      /**
+       * Defines the default behavior for how flex items are laid out along the cross axis on the current line, default is "stretch".
+       */
+      align?: FlexLayoutProps<ElementType>["align"];
+      /**
+       * Controls the space between items, default is 3.
+       */
+      gap?: FlexLayoutProps<ElementType>["gap"];
+      /**
+       * Adds a separator between elements, default is false.
+       */
+      separators?: FlexLayoutProps<ElementType>["separators"];
+    }
+  >;
 
-export const StackLayout = forwardRef<HTMLDivElement, StackLayoutProps>(
-  function StackLayout(props, ref) {
+type StackLayoutComponent = <T extends ElementType = "div">(
+  props: StackLayoutProps<T>
+) => ReactElement | null;
+
+export const StackLayout: StackLayoutComponent = forwardRef(
+  <T extends ElementType = "div">(
+    { ...props }: FlexLayoutProps<T>,
+    ref?: PolymorphicRef<T>
+  ) => {
     return <FlexLayout direction="column" ref={ref} {...props} />;
   }
 );

--- a/packages/core/src/stack-layout/StackLayout.tsx
+++ b/packages/core/src/stack-layout/StackLayout.tsx
@@ -2,6 +2,9 @@ import { ElementType, forwardRef, HTMLAttributes } from "react";
 import { FlexLayout, FlexLayoutProps } from "../flex-layout";
 
 export interface StackLayoutProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * The HTML element used for the root node.
+   */
   as?: FlexLayoutProps<ElementType>["as"];
   /**
    * Defines the default behavior for how flex items are laid out along the cross axis on the current line, default is "stretch".

--- a/packages/core/src/stack-layout/StackLayout.tsx
+++ b/packages/core/src/stack-layout/StackLayout.tsx
@@ -7,10 +7,6 @@ export type StackLayoutProps<T extends ElementType> =
     T,
     {
       /**
-       * The HTML element used for the root node.
-       */
-      as?: FlexLayoutProps<ElementType>["as"];
-      /**
        * Defines the default behavior for how flex items are laid out along the cross axis on the current line, default is "stretch".
        */
       align?: FlexLayoutProps<ElementType>["align"];

--- a/packages/core/src/stack-layout/StackLayout.tsx
+++ b/packages/core/src/stack-layout/StackLayout.tsx
@@ -2,6 +2,7 @@ import { ElementType, forwardRef, HTMLAttributes } from "react";
 import { FlexLayout, FlexLayoutProps } from "../flex-layout";
 
 export interface StackLayoutProps extends HTMLAttributes<HTMLDivElement> {
+  as?: FlexLayoutProps<ElementType>["as"];
   /**
    * Defines the default behavior for how flex items are laid out along the cross axis on the current line, default is "stretch".
    */


### PR DESCRIPTION
Previous change from `extend FlexLayoutProps` to `extend HTMLAttributes` for components built from `FlexLayout` to avoid them inheriting all of `FlexLayout` props meant they no longer had access to its polymorphic `as` property.
This change allows `StackLayout` and `FlowLayout` to use the polymorphic prop.