### PR TITLE
[ag-grid-theme] Separate generic numeric and editable cell classes, and fix corner tag

### DIFF
--- a/.changeset/fuzzy-foxes-grin.md
+++ b/.changeset/fuzzy-foxes-grin.md
@@ -1,0 +1,14 @@
+---
+"@salt-ds/ag-grid-theme": major
+---
+
+Separate static numeric and editable cell class names in salt ag-grid theme,
+
+Before:
+
+- `.editable-numeric-cell`
+
+After:
+
+- `.numeric-cell`
+- `.editable-cell`

--- a/packages/ag-grid-theme/css/_salt-ag-theme-mixin.scss
+++ b/packages/ag-grid-theme/css/_salt-ag-theme-mixin.scss
@@ -203,11 +203,16 @@
     border: solid 1px var(--agGrid-cell-borderColor-editable);
   }
 
+  .ag-cell.editable-cell.ag-cell-focus:focus {
+    overflow: visible;
+    clip-path: inset(0, 0);
+  }
+
   .ag-cell.editable-cell.ag-cell-focus:focus:before {
     content: "";
     position: absolute;
-    top: 0;
-    left: 0;
+    top: -2px;
+    left: -2px;
     border-top: 0 solid transparent;
     border-left: var(--agGrid-editableCell-cornerTag-size) solid
       var(--agGrid-cursor-borderColor);

--- a/packages/ag-grid-theme/css/_salt-ag-theme-mixin.scss
+++ b/packages/ag-grid-theme/css/_salt-ag-theme-mixin.scss
@@ -194,13 +194,16 @@
     z-index: 1;
   }
 
-  .ag-cell.editable-numeric-cell {
-    border: solid 1px var(--agGrid-cell-borderColor-editable);
+  .ag-cell.numeric-cell {
     text-align: right;
     justify-content: flex-end;
   }
 
-  .ag-cell.editable-numeric-cell.ag-cell-focus:focus:before {
+  .ag-cell.editable-cell {
+    border: solid 1px var(--agGrid-cell-borderColor-editable);
+  }
+
+  .ag-cell.editable-cell.ag-cell-focus:focus:before {
     content: "";
     position: absolute;
     top: 0;

--- a/packages/ag-grid-theme/stories/ag-grid.doc.stories.mdx
+++ b/packages/ag-grid-theme/stories/ag-grid.doc.stories.mdx
@@ -79,7 +79,7 @@ import '@salt-ds/ag-grid-theme/salt-ag-theme.css';
 
 #### CSS class names for Salt AG Grid theme
 
-For light mode,
+For light mode, add one the following class names to the element wrapping ag-grid:
 
 ```
 .ag-theme-salt-high-light
@@ -88,7 +88,7 @@ For light mode,
 .ag-theme-salt-touch-light
 ```
 
-For dark mode,
+For dark mode, add one the following class names to the element wrapping ag-grid:
 
 ```
 .ag-theme-salt-high-dark
@@ -97,11 +97,23 @@ For dark mode,
 .ag-theme-salt-touch-dark
 ```
 
-For variants,
+For variants, add one the following class names to the element wrapping ag-grid:
 
 ```
 .ag-theme-salt-variant-secondary
 .ag-theme-salt-variant-zebra
+```
+
+For editable fields, add this class name to the `cellClass` array in your column definition:
+
+```
+.editable-cell
+```
+
+For fields displaying numeric values add this class name to the `cellClass` array in your column definition:
+
+```
+.editable-cell
 ```
 
 ## Examples

--- a/packages/ag-grid-theme/stories/dependencies/columnSpanningExampleColumns.ts
+++ b/packages/ag-grid-theme/stories/dependencies/columnSpanningExampleColumns.ts
@@ -29,6 +29,7 @@ const columnSpanningExampleColumns = [
     headerName: "Population",
     field: "population",
     pinned: "left",
+    cellClass: ["numeric-cell"],
   },
 ];
 

--- a/packages/ag-grid-theme/stories/dependencies/customFilterExampleColumns.ts
+++ b/packages/ag-grid-theme/stories/dependencies/customFilterExampleColumns.ts
@@ -29,6 +29,7 @@ const customFilterExampleColumns: ColDef[] = [
     filter: "agNumberColumnFilter",
     suppressMenu: true,
     floatingFilter: true,
+    cellClass: ["numeric-cell"],
   },
 ];
 

--- a/packages/ag-grid-theme/stories/dependencies/dataGridExampleColumns.ts
+++ b/packages/ag-grid-theme/stories/dependencies/dataGridExampleColumns.ts
@@ -30,7 +30,7 @@ const dataGridExampleColumns = [
     field: "population",
     filter: "agNumberColumnFilter",
     editable: true,
-    cellClass: ["editable-numeric-cell"],
+    cellClass: ["numeric-cell", "editable-cell"],
   },
 ];
 export default dataGridExampleColumns;

--- a/packages/ag-grid-theme/stories/dependencies/dataGridExampleRowGroupPanel.ts
+++ b/packages/ag-grid-theme/stories/dependencies/dataGridExampleRowGroupPanel.ts
@@ -20,6 +20,7 @@ const dataGridExampleRowGroupPanel = [
     headerName: "Population",
     field: "population",
     filter: "agNumberColumnFilter",
+    cellClass: ["numeric-cell"],
   },
 ];
 

--- a/packages/ag-grid-theme/stories/dependencies/dataGridExampleRowGrouping.ts
+++ b/packages/ag-grid-theme/stories/dependencies/dataGridExampleRowGrouping.ts
@@ -20,6 +20,7 @@ const dataGridExampleRowGrouping = [
     headerName: "Population",
     field: "population",
     filter: "agNumberColumnFilter",
+    cellClass: ["numeric-cell"],
   },
 ];
 

--- a/packages/ag-grid-theme/stories/dependencies/dataGridInfiniteScrollExampleColumns.ts
+++ b/packages/ag-grid-theme/stories/dependencies/dataGridInfiniteScrollExampleColumns.ts
@@ -34,7 +34,7 @@ const dataGridInfiniteScrollExampleColumns = [
     sortable: true,
     resizable: true,
     editable: true,
-    cellClass: ["editable-cell"],
+    cellClass: ["editable-cell", "numeric-cell"],
   },
 ];
 

--- a/packages/ag-grid-theme/stories/dependencies/masterDetailExampleData.ts
+++ b/packages/ag-grid-theme/stories/dependencies/masterDetailExampleData.ts
@@ -5,7 +5,7 @@ export const masterDetailExampleData = [
   },
   { field: "code" },
   { field: "capital" },
-  { field: "population" },
-  { field: "rating" },
+  { field: "population", cellClass: ["numeric-cell"] },
+  { field: "rating", cellClass: ["numeric-cell"] },
 ];
 export default masterDetailExampleData;

--- a/packages/ag-grid-theme/stories/dependencies/rowDragColumns.ts
+++ b/packages/ag-grid-theme/stories/dependencies/rowDragColumns.ts
@@ -17,7 +17,7 @@ const rowDragColumns = [
     field: "population",
     filter: "agNumberColumnFilter",
     editable: true,
-    cellClass: ["editable-cell"],
+    cellClass: ["editable-cell", "numeric-cell"],
   },
 ];
 

--- a/packages/ag-grid-theme/stories/examples/ColumnGroup.tsx
+++ b/packages/ag-grid-theme/stories/examples/ColumnGroup.tsx
@@ -28,8 +28,17 @@ const ColumnGroup = (props: AgGridReactProps) => {
 
 const columnsWithGrouping = (groupName: string) => [
   {
+    headerName: "",
+    field: "on",
+    checkboxSelection: true,
+    headerCheckboxSelection: true,
+    width: 38,
+    pinned: "left",
+    suppressMenu: true,
+  },
+  {
     headerName: groupName,
-    children: dataGridExampleColumns,
+    children: dataGridExampleColumns.slice(1),
   },
 ];
 


### PR DESCRIPTION
## Separate numeric and editable cell classes from `.editable-numeric-cell` to:
- `.editable-cell`
- `.numeric-cell`

Numeric cells can be editable or not, and we can have non-numeric editable cells. So that's the motivation for two separate 
classes (which can be composed together). Technically, we could remove the numeric class and let the user do that 
themselves but since we already handled text alignment in numeric cells I thought we keep it around

## Fix corner tag
Previously, `overflow: hidden` on the cell prevented us from placing the focused corner tag on top of border but with this change where we replace overflow with `clip-path` and now it is possible.

### Before
<img width="263" alt="Screenshot 2023-01-12 at 15 55 55" src="https://user-images.githubusercontent.com/8259681/212117805-38e7d663-e193-4ba9-87eb-982008478fe2.png">

### After
<img width="307" alt="Screenshot 2023-01-12 at 15 55 11" src="https://user-images.githubusercontent.com/8259681/212117806-36d35809-2e03-42ba-a24c-8686cfcc5f85.png">

