### PR TITLE
[ag-grid theme] Add back .editable-numeric-cell 

### DIFF
--- a/.changeset/fuzzy-foxes-grin.md
+++ b/.changeset/fuzzy-foxes-grin.md
@@ -2,7 +2,7 @@
 "@salt-ds/ag-grid-theme": minor
 ---
 
-Add two new cell class names in salt ag-grid theme. These can be used instead of where the current `.editable-numeric-cell` 
+Add two new cell class names in salt ag-grid theme. These can be used instead of `.editable-numeric-cell`
 
 - `.numeric-cell` used on static cells that contain numeric values
 - `.editable-cell` used on editable cells

--- a/.changeset/fuzzy-foxes-grin.md
+++ b/.changeset/fuzzy-foxes-grin.md
@@ -1,14 +1,8 @@
 ---
-"@salt-ds/ag-grid-theme": major
+"@salt-ds/ag-grid-theme": minor
 ---
 
-Separate static numeric and editable cell class names in salt ag-grid theme,
+Add two new cell class names in salt ag-grid theme. These can be used instead of where the current `.editable-numeric-cell` 
 
-Before:
-
-- `.editable-numeric-cell`
-
-After:
-
-- `.numeric-cell`
-- `.editable-cell`
+- `.numeric-cell` used on static cells that contain numeric values
+- `.editable-cell` used on editable cells

--- a/packages/ag-grid-theme/css/_salt-ag-theme-mixin.scss
+++ b/packages/ag-grid-theme/css/_salt-ag-theme-mixin.scss
@@ -196,20 +196,24 @@
     z-index: 1;
   }
 
+  .editable-numeric-cell,
   .ag-cell.numeric-cell {
     text-align: right;
     justify-content: flex-end;
   }
 
+  .editable-numeric-cell,
   .ag-cell.editable-cell {
     border: solid 1px var(--agGrid-cell-borderColor-editable);
   }
 
+  .editable-numeric-cell.ag-cell-focus:focus,
   .ag-cell.editable-cell.ag-cell-focus:focus {
     overflow: visible;
     clip-path: inset(0, 0);
   }
 
+  .ag-cell.editable-numeric-cell.ag-cell-focus:focus:before,
   .ag-cell.editable-cell.ag-cell-focus:focus:before {
     content: "";
     position: absolute;


### PR DESCRIPTION
### Description
We want to avoid breaking changes for now so I added back the `.editable-numeric-cell` in ag-grid theme. The two new class names can be used in tandem.