### PR TITLE
Remove component names and pascal case from Layout story titles

### DIFF
--- a/packages/core/src/__tests__/__e2e__/border-layout/BorderLayout.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/border-layout/BorderLayout.cy.tsx
@@ -4,14 +4,14 @@ import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessi
 import { BORDER_POSITION as borderAreas } from "@salt-ds/core";
 
 const composedStories = composeStories(borderStories);
-const { BorderLayoutAllPanels } = composedStories;
+const { AllPanels } = composedStories;
 
 describe("GIVEN a Border", () => {
   checkAccessibility(composedStories);
 
   describe("WHEN border items are provided", () => {
     it("THEN it should render them in the right positions", () => {
-      cy.mount(<BorderLayoutAllPanels />);
+      cy.mount(<AllPanels />);
 
       cy.get(".saltBorderLayout").should(
         "have.css",
@@ -47,7 +47,7 @@ describe("GIVEN a Border", () => {
 
   describe("WHEN no gap values are provided", () => {
     it("THEN it should not display a gap by default", () => {
-      cy.mount(<BorderLayoutAllPanels />);
+      cy.mount(<AllPanels />);
 
       cy.get(".saltBorderLayout").should("have.css", "column-gap", "0px");
 

--- a/packages/core/src/__tests__/__e2e__/flex-layout/FlexLayout.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/flex-layout/FlexLayout.cy.tsx
@@ -4,26 +4,26 @@ import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessi
 import { SaltProvider } from "@salt-ds/core";
 
 const composedStories = composeStories(flexStories);
-const { DefaultFlexLayout, FlexLayoutNested } = composedStories;
+const { Default, Nested } = composedStories;
 
 describe("GIVEN a Flex", () => {
   checkAccessibility(composedStories);
 
   describe("WHEN no props are provided", () => {
     it("THEN it should render with flex direction row", () => {
-      cy.mount(<DefaultFlexLayout />);
+      cy.mount(<Default />);
 
       cy.get(".saltFlexLayout").should("have.css", "flex-direction", "row");
     });
 
     it("THEN it should render with flex wrap", () => {
-      cy.mount(<DefaultFlexLayout />);
+      cy.mount(<Default />);
 
       cy.get(".saltFlexLayout").should("have.css", "flex-wrap", "wrap");
     });
 
     it("THEN it should render with a default gap", () => {
-      cy.mount(<DefaultFlexLayout />);
+      cy.mount(<Default />);
 
       cy.get(".saltFlexLayout").should("have.css", "column-gap", "24px");
 
@@ -31,7 +31,7 @@ describe("GIVEN a Flex", () => {
     });
 
     it("THEN nested items should not inherit css variables from parent", () => {
-      cy.mount(<FlexLayoutNested />);
+      cy.mount(<Nested />);
 
       cy.get(".saltFlexLayout").eq(0).should("have.css", "flex-wrap", "wrap");
       cy.get(".saltFlexLayout")
@@ -49,7 +49,7 @@ describe("GIVEN a Flex", () => {
 
   describe("WHEN a separator value is provided", () => {
     it("THEN it should render a separator", () => {
-      cy.mount(<DefaultFlexLayout separators wrap={false} />);
+      cy.mount(<Default separators wrap={false} />);
 
       cy.get(".saltFlexLayout").should(
         "have.class",
@@ -60,7 +60,7 @@ describe("GIVEN a Flex", () => {
 
   describe("WHEN wrap is set to false", () => {
     it("THEN it should render with no flex wrap", () => {
-      cy.mount(<DefaultFlexLayout wrap={false} />);
+      cy.mount(<Default wrap={false} />);
 
       cy.get(".saltFlexLayout").should("have.css", "flex-wrap", "nowrap");
     });
@@ -82,7 +82,7 @@ describe("GIVEN a Flex", () => {
         viewportWidth: 1921,
       },
       () => {
-        cy.mount(<DefaultFlexLayout wrap={wrap} />);
+        cy.mount(<Default wrap={wrap} />);
 
         cy.get(".saltFlexLayout").should("have.css", "flex-wrap", "nowrap");
       }
@@ -95,7 +95,7 @@ describe("GIVEN a Flex", () => {
         viewportWidth: 961,
       },
       () => {
-        cy.mount(<DefaultFlexLayout wrap={wrap} />);
+        cy.mount(<Default wrap={wrap} />);
 
         cy.get(".saltFlexLayout").should("have.css", "flex-wrap", "wrap");
       }
@@ -108,7 +108,7 @@ describe("GIVEN a Flex", () => {
         viewportWidth: 700,
       },
       () => {
-        cy.mount(<DefaultFlexLayout wrap={wrap} />);
+        cy.mount(<Default wrap={wrap} />);
 
         cy.get(".saltFlexLayout").should("have.css", "flex-wrap", "wrap");
       }
@@ -121,7 +121,7 @@ describe("GIVEN a Flex", () => {
         viewportWidth: 600,
       },
       () => {
-        cy.mount(<DefaultFlexLayout wrap={wrap} />);
+        cy.mount(<Default wrap={wrap} />);
 
         cy.get(".saltFlexLayout").should("have.css", "flex-wrap", "wrap");
       }
@@ -154,7 +154,7 @@ describe("GIVEN a Flex", () => {
       () => {
         cy.mount(
           <SaltProvider breakpoints={breakpoints}>
-            <DefaultFlexLayout wrap={wrap} />
+            <Default wrap={wrap} />
           </SaltProvider>
         );
 
@@ -171,7 +171,7 @@ describe("GIVEN a Flex", () => {
       () => {
         cy.mount(
           <SaltProvider breakpoints={breakpoints}>
-            <DefaultFlexLayout wrap={wrap} />
+            <Default wrap={wrap} />
           </SaltProvider>
         );
 
@@ -188,7 +188,7 @@ describe("GIVEN a Flex", () => {
       () => {
         cy.mount(
           <SaltProvider breakpoints={breakpoints}>
-            <DefaultFlexLayout wrap={wrap} />
+            <Default wrap={wrap} />
           </SaltProvider>
         );
 
@@ -205,7 +205,7 @@ describe("GIVEN a Flex", () => {
       () => {
         cy.mount(
           <SaltProvider breakpoints={breakpoints}>
-            <DefaultFlexLayout wrap={wrap} />
+            <Default wrap={wrap} />
           </SaltProvider>
         );
 

--- a/packages/core/src/__tests__/__e2e__/flow-layout/FlowLayout.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/flow-layout/FlowLayout.cy.tsx
@@ -3,20 +3,20 @@ import * as flowStories from "@stories/flow-layout.stories";
 import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
 
 const composedStories = composeStories(flowStories);
-const { DefaultFlowLayout } = composedStories;
+const { Default } = composedStories;
 
 describe("GIVEN a Flow", () => {
   checkAccessibility(composedStories);
 
   describe("WHEN no props are provided", () => {
     it("THEN it should wrap by default", () => {
-      cy.mount(<DefaultFlowLayout />);
+      cy.mount(<Default />);
 
       cy.get(".saltFlexLayout").should("have.css", "flex-wrap", "wrap");
     });
 
     it("THEN it should render with a default gap", () => {
-      cy.mount(<DefaultFlowLayout />);
+      cy.mount(<Default />);
 
       cy.get(".saltFlexLayout").should("have.css", "column-gap", "24px");
 

--- a/packages/core/src/__tests__/__e2e__/grid-layout/GridLayout.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/grid-layout/GridLayout.cy.tsx
@@ -4,7 +4,7 @@ import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessi
 import { SaltProvider } from "@salt-ds/core";
 
 const composedStories = composeStories(gridStories);
-const { DefaultGridLayout, GridLayoutNested } = composedStories;
+const { Default, Nested } = composedStories;
 
 const testElementsNumber = (elements: number) =>
   new RegExp(`^(\\d*\\.?\\d*px *){${elements}}$`);
@@ -15,7 +15,7 @@ describe("GIVEN a Grid", () => {
   describe("WHEN no props are provided", () => {
     it("THEN it should render 12 columns and 1 row", () => {
       // Passing empty columns to test default, as example needs columns for accessibility purposes.
-      cy.mount(<DefaultGridLayout columns={{}} />);
+      cy.mount(<Default columns={{}} />);
 
       cy.get(".saltGridLayout")
         .invoke("css", "grid-template-columns")
@@ -27,14 +27,14 @@ describe("GIVEN a Grid", () => {
     });
 
     it("THEN it should render with a default gap", () => {
-      cy.mount(<DefaultGridLayout />);
+      cy.mount(<Default />);
 
       cy.get(".saltGridLayout").should("have.css", "column-gap", "24px");
 
       cy.get(".saltGridLayout").should("have.css", "row-gap", "24px");
     });
     it("THEN nested items should not inherit css variables from parent", () => {
-      cy.mount(<GridLayoutNested />);
+      cy.mount(<Nested />);
 
       cy.get(".saltGridLayout").eq(0).should("have.css", "column-gap", "48px");
       cy.get(".saltGridLayout")
@@ -63,7 +63,7 @@ describe("GIVEN a Grid", () => {
     const rows = 3;
 
     it("THEN it should render multiple columns and rows", () => {
-      cy.mount(<DefaultGridLayout columns={columns} rows={rows} />);
+      cy.mount(<Default columns={columns} rows={rows} />);
 
       cy.get(".saltGridLayout")
         .invoke("css", "grid-template-columns")
@@ -86,7 +86,7 @@ describe("GIVEN a Grid", () => {
         viewportWidth: 1921,
       },
       () => {
-        cy.mount(<DefaultGridLayout columns={columns} rows={rows} />);
+        cy.mount(<Default columns={columns} rows={rows} />);
 
         cy.get(".saltGridLayout")
           .invoke("css", "grid-template-columns")
@@ -105,7 +105,7 @@ describe("GIVEN a Grid", () => {
         viewportWidth: 961,
       },
       () => {
-        cy.mount(<DefaultGridLayout columns={columns} rows={rows} />);
+        cy.mount(<Default columns={columns} rows={rows} />);
 
         cy.get(".saltGridLayout")
           .invoke("css", "grid-template-columns")
@@ -124,7 +124,7 @@ describe("GIVEN a Grid", () => {
         viewportWidth: 700,
       },
       () => {
-        cy.mount(<DefaultGridLayout columns={columns} rows={rows} />);
+        cy.mount(<Default columns={columns} rows={rows} />);
 
         cy.get(".saltGridLayout")
           .invoke("css", "grid-template-columns")
@@ -143,7 +143,7 @@ describe("GIVEN a Grid", () => {
         viewportWidth: 600,
       },
       () => {
-        cy.mount(<DefaultGridLayout columns={columns} rows={rows} />);
+        cy.mount(<Default columns={columns} rows={rows} />);
 
         cy.get(".saltGridLayout")
           .invoke("css", "grid-template-columns")
@@ -177,7 +177,7 @@ describe("GIVEN a Grid", () => {
       () => {
         cy.mount(
           <SaltProvider breakpoints={breakpoints}>
-            <DefaultGridLayout columns={columns} rows={rows} />
+            <Default columns={columns} rows={rows} />
           </SaltProvider>
         );
 
@@ -200,7 +200,7 @@ describe("GIVEN a Grid", () => {
       () => {
         cy.mount(
           <SaltProvider breakpoints={breakpoints}>
-            <DefaultGridLayout columns={columns} rows={rows} />
+            <Default columns={columns} rows={rows} />
           </SaltProvider>
         );
 
@@ -223,7 +223,7 @@ describe("GIVEN a Grid", () => {
       () => {
         cy.mount(
           <SaltProvider breakpoints={breakpoints}>
-            <DefaultGridLayout columns={columns} rows={rows} />
+            <Default columns={columns} rows={rows} />
           </SaltProvider>
         );
 
@@ -246,7 +246,7 @@ describe("GIVEN a Grid", () => {
       () => {
         cy.mount(
           <SaltProvider breakpoints={breakpoints}>
-            <DefaultGridLayout columns={columns} rows={rows} />
+            <Default columns={columns} rows={rows} />
           </SaltProvider>
         );
 

--- a/packages/core/src/__tests__/__e2e__/split-layout/SplitLayout.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/split-layout/SplitLayout.cy.tsx
@@ -3,14 +3,14 @@ import * as splitStories from "@stories/split-layout.stories";
 import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
 
 const composedStories = composeStories(splitStories);
-const { DefaultSplitLayout } = composedStories;
+const { Default } = composedStories;
 
 describe("GIVEN a Split", () => {
   checkAccessibility(composedStories);
 
   describe("WHEN no props are provided", () => {
     it("THEN it should not wrap before the default small breakpoint", () => {
-      cy.mount(<DefaultSplitLayout />);
+      cy.mount(<Default />);
 
       cy.get(".saltFlexLayout").should("have.css", "flex-wrap", "nowrap");
       cy.get(".saltFlexLayout").should("have.css", "flex-direction", "row");
@@ -20,7 +20,7 @@ describe("GIVEN a Split", () => {
       "THEN it should wrap at the default small breakpoint",
       { viewportWidth: 599 },
       () => {
-        cy.mount(<DefaultSplitLayout />);
+        cy.mount(<Default />);
         cy.get(".saltFlexLayout").should(
           "have.css",
           "flex-direction",
@@ -30,7 +30,7 @@ describe("GIVEN a Split", () => {
     );
 
     it("THEN it should render with a default gap", () => {
-      cy.mount(<DefaultSplitLayout />);
+      cy.mount(<Default />);
 
       cy.get(".saltFlexLayout").should("have.css", "column-gap", "24px");
 
@@ -58,7 +58,7 @@ describe("GIVEN a Split", () => {
 
     it("THEN it should render as expected", () => {
       cy.mount(
-        <DefaultSplitLayout startItem={<LeftItem />} endItem={<RightItem />} />
+        <Default startItem={<LeftItem />} endItem={<RightItem />} />
       );
 
       cy.get(".saltFlexLayout")
@@ -75,7 +75,7 @@ describe("GIVEN a Split", () => {
 
   describe("WHEN passing the gap prop", () => {
     it("THEN it should render with a new gap value", () => {
-      cy.mount(<DefaultSplitLayout gap={2} />);
+      cy.mount(<Default gap={2} />);
 
       cy.get(".saltFlexLayout").should("have.css", "column-gap", "16px");
 

--- a/packages/core/src/__tests__/__e2e__/split-layout/SplitLayout.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/split-layout/SplitLayout.cy.tsx
@@ -57,9 +57,7 @@ describe("GIVEN a Split", () => {
     );
 
     it("THEN it should render as expected", () => {
-      cy.mount(
-        <Default startItem={<LeftItem />} endItem={<RightItem />} />
-      );
+      cy.mount(<Default startItem={<LeftItem />} endItem={<RightItem />} />);
 
       cy.get(".saltFlexLayout")
         .children()

--- a/packages/core/src/__tests__/__e2e__/stack-layout/StackLayout.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/stack-layout/StackLayout.cy.tsx
@@ -3,20 +3,20 @@ import * as stackStories from "@stories/stack-layout.stories";
 import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
 
 const composedStories = composeStories(stackStories);
-const { DefaultStackLayout } = composedStories;
+const { Default } = composedStories;
 
 describe("GIVEN a Stack", () => {
   checkAccessibility(composedStories);
 
   describe("WHEN no props are provided", () => {
     it("THEN it should not wrap by default", () => {
-      cy.mount(<DefaultStackLayout />);
+      cy.mount(<Default />);
 
       cy.get(".saltFlexLayout").should("have.css", "flex-wrap", "nowrap");
     });
 
     it("THEN it should render with a default gap", () => {
-      cy.mount(<DefaultStackLayout />);
+      cy.mount(<Default />);
 
       cy.get(".saltFlexLayout").should("have.css", "column-gap", "24px");
 
@@ -24,7 +24,7 @@ describe("GIVEN a Stack", () => {
     });
 
     it("THEN it should render as a column by default", () => {
-      cy.mount(<DefaultStackLayout />);
+      cy.mount(<Default />);
 
       cy.get(".saltFlexLayout").should("have.css", "flex-direction", "column");
     });
@@ -32,7 +32,7 @@ describe("GIVEN a Stack", () => {
 
   describe("WHEN row direction is provided", () => {
     it("THEN it should render in a row", () => {
-      cy.mount(<DefaultStackLayout direction="row" />);
+      cy.mount(<Default direction="row" />);
 
       cy.get(".saltFlexLayout").should("have.css", "flex-direction", "row");
     });
@@ -40,7 +40,7 @@ describe("GIVEN a Stack", () => {
 
   describe("WHEN a separator value is provided", () => {
     it("THEN it should render a separator", () => {
-      cy.mount(<DefaultStackLayout separators />);
+      cy.mount(<Default separators />);
 
       cy.get(".saltFlexLayout").should(
         "have.class",

--- a/packages/core/stories/border-item.stories.tsx
+++ b/packages/core/stories/border-item.stories.tsx
@@ -2,7 +2,7 @@ import { BorderLayout, BorderItem } from "@salt-ds/core";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import "./layout-stories.css";
 export default {
-  title: "Core/Layout/BorderLayout/BorderItem",
+  title: "Core/Layout/Border Layout/Border Item",
   component: BorderItem,
   argTypes: {
     position: {

--- a/packages/core/stories/border-layout.doc.stories.mdx
+++ b/packages/core/stories/border-layout.doc.stories.mdx
@@ -4,7 +4,7 @@ import { CSSClassTable } from "css-variable-docgen-components";
 import HelpAndSupport from "docs/blocks/help-and-support.doc.mdx";
 
 <Meta
-  title="Documentation/Core/Layout/BorderLayout"
+  title="Documentation/Core/Layout/Border Layout"
   component={BorderLayout}
   subcomponents={{ BorderItem }}
   parameters={{
@@ -12,32 +12,32 @@ import HelpAndSupport from "docs/blocks/help-and-support.doc.mdx";
   }}
 />
 
-# Border layout
+# Border Layout
 
 Defines the main content regions of an application, region or widget, such as a footer, header or side navigation.
-The border layout is built using [Grid layout](?path=/docs/documentation-core-layout-gridlayout--page) and it is intended for laying out large sections of content, such as pages, where there is at least a main area with a header and footer.
+The Border Layout is built using [Grid layout](?path=/docs/documentation-core-layout-grid-layout--page) and it is intended for laying out large sections of content, such as pages, where there is at least a main area with a header and footer.
 
 <Canvas>
-  <Story id="core-layout-borderlayout--border-layout-all-panels" />
+  <Story id="core-layout-border-layout--all-panels" />
 </Canvas>
 
-## Use Border layout when...
+## Use Border Layout when...
 
 You want a fixed layout with a flexible main region.
 
-### Don't use Border layout when...
+### Don't use Border Layout when...
 
-You want a customized layout that you can control in both row and column dimensions. In this case we recommend you having a look at [Grid layout](?path=/docs/documentation-core-layout-gridlayout--page).
+You want a customized layout that you can control in both row and column dimensions. In this case we recommend you having a look at [Grid layout](?path=/docs/documentation-core-layout-grid-layout--page).
 
 ### Examples
 
-#### Border Item inside default border layout
+#### Border Item inside default Border Layout
 
 The border item wrapper allows you to select the right position for your content to be displayed at - `north`, `west`, `center`, `east` or `south`.  
 It also provides access to other properties such as alignment and sticky behavior.
 
 <Canvas>
-  <Story id="core-layout-borderlayout-borderitem--border-item-wrapper" />
+  <Story id="core-layout-border-layout-border-item--border-item-wrapper" />
 </Canvas>
 
 #### Fixed panels
@@ -45,10 +45,10 @@ It also provides access to other properties such as alignment and sticky behavio
 You can have a responsive `center` region while the `west` and `east` panels remain with a fixed width as the content changes.
 
 <Canvas>
-  <Story id="core-layout-borderlayout--border-layout-fixed-panels" />
+  <Story id="core-layout-border-layout--fixed-panels" />
 </Canvas>
 
-## Configuring Border layout
+## Configuring Border Layout
 
 ### API
 

--- a/packages/core/stories/border-layout.stories.tsx
+++ b/packages/core/stories/border-layout.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import "./layout-stories.css";
 
 export default {
-  title: "Core/Layout/BorderLayout",
+  title: "Core/Layout/Border Layout",
   component: BorderLayout,
   subcomponents: { BorderItem },
   argTypes: {
@@ -56,10 +56,10 @@ const Template: ComponentStory<typeof BorderLayout> = (args) => {
   );
 };
 
-export const BorderLayoutAllPanels = Template.bind({});
-BorderLayoutAllPanels.args = {};
+export const AllPanels = Template.bind({});
+AllPanels.args = {};
 
-const NoRightPanel: ComponentStory<typeof BorderLayout> = (args) => {
+const NoRightPanelTemplate: ComponentStory<typeof BorderLayout> = (args) => {
   return (
     <BorderLayout {...args}>
       <BorderItem position="north">
@@ -91,10 +91,10 @@ const NoRightPanel: ComponentStory<typeof BorderLayout> = (args) => {
   );
 };
 
-export const BorderLayoutNoRightPanel = NoRightPanel.bind({});
-BorderLayoutNoRightPanel.args = {};
+export const NoRightPanel = NoRightPanelTemplate.bind({});
+NoRightPanel.args = {};
 
-const NoLeftPanel: ComponentStory<typeof BorderLayout> = (args) => {
+const NoLeftPanelTemplate: ComponentStory<typeof BorderLayout> = (args) => {
   return (
     <BorderLayout {...args}>
       <BorderItem position="north">
@@ -126,10 +126,10 @@ const NoLeftPanel: ComponentStory<typeof BorderLayout> = (args) => {
   );
 };
 
-export const BorderLayoutNoLeftPanel = NoLeftPanel.bind({});
-BorderLayoutNoLeftPanel.args = {};
+export const NoLeftPanel = NoLeftPanelTemplate.bind({});
+NoLeftPanel.args = {};
 
-const NoHeader: ComponentStory<typeof BorderLayout> = (args) => {
+const NoHeaderTemplate: ComponentStory<typeof BorderLayout> = (args) => {
   return (
     <BorderLayout {...args}>
       <BorderItem position="west">
@@ -161,10 +161,10 @@ const NoHeader: ComponentStory<typeof BorderLayout> = (args) => {
   );
 };
 
-export const BorderLayoutNoHeader = NoHeader.bind({});
-BorderLayoutNoHeader.args = {};
+export const NoHeader = NoHeaderTemplate.bind({});
+NoHeader.args = {};
 
-const FixedPanels: ComponentStory<typeof BorderLayout> = (args) => {
+const FixedPanelsTemplate: ComponentStory<typeof BorderLayout> = (args) => {
   return (
     <BorderLayout {...args} style={{ width: "60vw" }}>
       <BorderItem position="north">
@@ -208,5 +208,5 @@ const FixedPanels: ComponentStory<typeof BorderLayout> = (args) => {
   );
 };
 
-export const BorderLayoutFixedPanels = FixedPanels.bind({});
-BorderLayoutFixedPanels.args = {};
+export const FixedPanels = FixedPanelsTemplate.bind({});
+FixedPanels.args = {};

--- a/packages/core/stories/flex-item.stories.tsx
+++ b/packages/core/stories/flex-item.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import "./layout-stories.css";
 
 export default {
-  title: "Core/Layout/FlexLayout/FlexItem",
+  title: "Core/Layout/Flex Layout/Flex Item",
   component: FlexItem,
   argTypes: {
     align: {

--- a/packages/core/stories/flex-layout.doc.stories.mdx
+++ b/packages/core/stories/flex-layout.doc.stories.mdx
@@ -4,7 +4,7 @@ import { CSSClassTable } from "css-variable-docgen-components";
 import HelpAndSupport from "docs/blocks/help-and-support.doc.mdx";
 
 <Meta
-  title="Documentation/Core/Layout/FlexLayout"
+  title="Documentation/Core/Layout/Flex Layout"
   component={FlexLayout}
   subcomponents={{ FlexItem }}
   parameters={{
@@ -12,58 +12,58 @@ import HelpAndSupport from "docs/blocks/help-and-support.doc.mdx";
   }}
 />
 
-# Flex layout
+# Flex Layout
 
-Flex layout dictates a horizontal or vertical order and direction for UI elements.
+Flex Layout dictates a horizontal or vertical order and direction for UI elements.
 The height is driven by the child elements.
 
 It can be used for cases in which the direction needs complex customization that can't be achieved by stack or flow layouts.
 For example, in layouts where the direction needs to change depending on the viewport.
 
-For layouts where you need to control the two dimensions, see [Grid layout](?path=/docs/documentation-core-layout-gridlayout--page).
+For layouts where you need to control the two dimensions, see [Grid layout](?path=/docs/documentation-core-layout-grid-layout--page).
 
 <Canvas>
-  <Story id="core-layout-flexlayout--default-flex-layout" />
+  <Story id="core-layout-flex-layout--default" />
 </Canvas>
 
-## Use Flex layout when...
+## Use Flex Layout when...
 
 You want a layout that flows in a single dimension, where the dimension changes depending on something external like viewport size.
 
-### Don't use Flex layout when...
+### Don't use Flex Layout when...
 
-You want your layout to have a constant direction. In this case we recommend you having a look at [Stack layout](?path=/docs/documentation-core-layout-stacklayout--page) or [Flow layout](?path=/docs/documentation-core-layout-flowlayout--page).
+You want your layout to have a constant direction. In this case we recommend you having a look at [Stack layout](?path=/docs/documentation-core-layout-stack-layout--page) or [Flow layout](?path=/docs/documentation-core-layout-flow-layout--page).
 
 ### Examples
 
-#### Flex Item inside default flex layout
+#### Flex Item inside default Flex Layout
 
 A flex item allows more complex controls to the default behavior of a flex child, like defining the priority with which an element grows/shrink and its alignment.
 
 <Canvas>
-  <Story id="core-layout-flexlayout-flexitem--flex-item-wrapper" />
+  <Story id="core-layout-flex-layout-flex-item--flex-item-wrapper" />
 </Canvas>
 
-#### Flex layout with separators
+#### Flex Layout with separators
 
-Flex layout allows for separators between items that will by default display centered `separators={true}` but can be customized to sit on the left or right of a children.
+Flex Layout allows for separators between items that will by default display centered `separators={true}` but can be customized to sit on the left or right of a children.
 The separators span across the width of the layout component if the direction is row and the height if the direction is columns.
-The Flex layout gap will apply to both sides of the separator line.
+The Flex Layout gap will apply to both sides of the separator line.
 
 <Canvas>
-  <Story id="core-layout-flexlayout--flex-layout-with-separators" />
+  <Story id="core-layout-flex-layout--with-separators" />
 </Canvas>
 
 #### Responsive
 
-Flex layout supports the use of responsive props, so you can define different behaviors based on viewport size.
+Flex Layout supports the use of responsive props, so you can define different behaviors based on viewport size.
 You can use the default breakpoints or pass in your own to the `SaltProvider`.
 
 <Canvas>
-  <Story id="core-layout-flexlayout--flex-layout-using-responsive-props" />
+  <Story id="core-layout-flex-layout--using-responsive-props" />
 </Canvas>
 
-## Configuring Flex layout
+## Configuring Flex Layout
 
 ### API
 
@@ -84,11 +84,11 @@ direction={{ xs: "row", sm: "column", lg: "row", md: "column", xl: "row" }}
 
 ## Related components
 
-The flex layout is used in the following components:
+The Flex Layout is used in the following components:
 
-- [Stack layout](?path=/docs/documentation-core-layout-stacklayout--page)
-- [Flow layout](?path=/docs/documentation-core-layout-flowlayout--page)
-- [Split layout](?path=/docs/documentation-core-layout-splitlayout--page)
+- [Stack layout](?path=/docs/documentation-core-layout-stack-layout--page)
+- [Flow layout](?path=/docs/documentation-core-layout-flow-layout--page)
+- [Split layout](?path=/docs/documentation-core-layout-split-layout--page)
 
 ### Classes
 

--- a/packages/core/stories/flex-layout.doc.stories.mdx
+++ b/packages/core/stories/flex-layout.doc.stories.mdx
@@ -86,9 +86,9 @@ direction={{ xs: "row", sm: "column", lg: "row", md: "column", xl: "row" }}
 
 The Flex Layout is used in the following components:
 
-- [Stack layout](?path=/docs/documentation-core-layout-stack-layout--page)
-- [Flow layout](?path=/docs/documentation-core-layout-flow-layout--page)
-- [Split layout](?path=/docs/documentation-core-layout-split-layout--page)
+- [Stack Layout](?path=/docs/documentation-core-layout-stack-layout--page)
+- [Flow Layout](?path=/docs/documentation-core-layout-flow-layout--page)
+- [Split Layout](?path=/docs/documentation-core-layout-split-layout--page)
 
 ### Classes
 

--- a/packages/core/stories/flex-layout.stories.tsx
+++ b/packages/core/stories/flex-layout.stories.tsx
@@ -4,7 +4,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import "./layout-stories.css";
 
 export default {
-  title: "Core/Layout/FlexLayout",
+  title: "Core/Layout/Flex Layout",
   component: FlexLayout,
   subcomponents: { FlexItem },
   argTypes: {
@@ -41,10 +41,10 @@ export default {
   args: {
     gap: 3,
   },
-  excludeStories: ["FlexLayoutNestedExample"],
+  excludeStories: ["NestedExample"],
 } as ComponentMeta<typeof FlexLayout>;
 
-const DefaultFlexLayoutStory: ComponentStory<typeof FlexLayout> = (args) => {
+const DefaultStory: ComponentStory<typeof FlexLayout> = (args) => {
   return (
     <FlexLayout {...args}>
       {Array.from({ length: 5 }, (_, index) => (
@@ -55,8 +55,8 @@ const DefaultFlexLayoutStory: ComponentStory<typeof FlexLayout> = (args) => {
     </FlexLayout>
   );
 };
-export const DefaultFlexLayout = DefaultFlexLayoutStory.bind({});
-DefaultFlexLayout.args = {
+export const Default = DefaultStory.bind({});
+Default.args = {
   wrap: true,
 };
 const SeparatedItemsStory: ComponentStory<typeof FlexLayout> = (args) => {
@@ -70,8 +70,8 @@ const SeparatedItemsStory: ComponentStory<typeof FlexLayout> = (args) => {
     </FlexLayout>
   );
 };
-export const FlexLayoutWithSeparators = SeparatedItemsStory.bind({});
-FlexLayoutWithSeparators.args = {
+export const WithSeparators = SeparatedItemsStory.bind({});
+WithSeparators.args = {
   separators: "center",
   wrap: false,
   direction: { sm: "row", xs: "column" },
@@ -95,8 +95,8 @@ const Responsive: ComponentStory<typeof FlexLayout> = (args) => {
     </FlexLayout>
   );
 };
-export const FlexLayoutUsingResponsiveProps = Responsive.bind({});
-FlexLayoutUsingResponsiveProps.args = {
+export const UsingResponsiveProps = Responsive.bind({});
+UsingResponsiveProps.args = {
   justify: "start",
   direction: {
     xs: "column",
@@ -109,7 +109,7 @@ FlexLayoutUsingResponsiveProps.args = {
   },
 };
 
-const FlexLayoutNestedExample: ComponentStory<typeof FlexLayout> = (args) => {
+const NestedExample: ComponentStory<typeof FlexLayout> = (args) => {
   return (
     <FlexLayout {...args}>
       <div className="layout-content">Item 1</div>
@@ -120,8 +120,8 @@ const FlexLayoutNestedExample: ComponentStory<typeof FlexLayout> = (args) => {
     </FlexLayout>
   );
 };
-export const FlexLayoutNested = FlexLayoutNestedExample.bind({});
-FlexLayoutNested.args = {
+export const Nested = NestedExample.bind({});
+Nested.args = {
   justify: "space-between",
   wrap: true,
   gap: 6,
@@ -136,9 +136,7 @@ const flagsList: string[] = [
   "Antigua and Barbuda",
   "Argentina",
 ];
-export const FlexLayoutPolymorphicList: ComponentStory<typeof FlexLayout> = (
-  args
-) => {
+export const PolymorphicList: ComponentStory<typeof FlexLayout> = (args) => {
   return (
     <FlexLayout {...args} as="ol" direction="column">
       {Array.from({ length: flagsList.length }, (_, index) => (

--- a/packages/core/stories/flow-layout.doc.stories.mdx
+++ b/packages/core/stories/flow-layout.doc.stories.mdx
@@ -3,33 +3,33 @@ import { FlowLayout } from "@salt-ds/core";
 import HelpAndSupport from "docs/blocks/help-and-support.doc.mdx";
 
 <Meta
-  title="Documentation/Core/Layout/FlowLayout"
+  title="Documentation/Core/Layout/Flow Layout"
   component={FlowLayout}
   parameters={{
     viewMode: "docs",
   }}
 />
 
-# Flow layout
+# Flow Layout
 
-Flow layout dictates a horizontal order and direction for UI elements.
+Flow Layout dictates a horizontal order and direction for UI elements.
 It builds from flex layout, the height is driven by the child elements.
 
 It can be used for cases in which the direction needs to be consistently horizontal, for example a interdependent group of buttons.
 
 <Canvas>
-  <Story id="core-layout-flowlayout--default-flow-layout" />
+  <Story id="core-layout-flow-layout--default-flow-layout" />
 </Canvas>
 
-## Use Flow layout when...
+## Use Flow Layout when...
 
 You want to build responsive layouts that will wrap into two rows as soon as there is not enough space on the viewport.
 
-### Don't use Flow layout when...
+### Don't use Flow Layout when...
 
-You want the direction to have more complex customization. In this case we recommend you having a look at [Flex layout](?path=/docs/documentation-core-layout-flexlayout--page).
+You want the direction to have more complex customization. In this case we recommend you having a look at [Flex layout](?path=/docs/documentation-core-layout-flex-layout--page).
 
-## Configuring Flow layout
+## Configuring Flow Layout
 
 ### API
 

--- a/packages/core/stories/flow-layout.doc.stories.mdx
+++ b/packages/core/stories/flow-layout.doc.stories.mdx
@@ -18,7 +18,7 @@ It builds from flex layout, the height is driven by the child elements.
 It can be used for cases in which the direction needs to be consistently horizontal, for example a interdependent group of buttons.
 
 <Canvas>
-  <Story id="core-layout-flow-layout--default-flow-layout" />
+  <Story id="core-layout-flow-layout--default" />
 </Canvas>
 
 ## Use Flow Layout when...

--- a/packages/core/stories/flow-layout.stories.tsx
+++ b/packages/core/stories/flow-layout.stories.tsx
@@ -4,7 +4,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import "./layout-stories.css";
 
 export default {
-  title: "Core/Layout/FlowLayout",
+  title: "Core/Layout/Flow Layout",
   component: FlowLayout,
   argTypes: {
     align: {
@@ -20,7 +20,7 @@ export default {
   },
 } as ComponentMeta<typeof FlowLayout>;
 
-const DefaultFlowLayoutStory: ComponentStory<typeof FlowLayout> = (args) => {
+const DefaultStory: ComponentStory<typeof FlowLayout> = (args) => {
   return (
     <FlowLayout className="layout-container" {...args}>
       {Array.from({ length: 12 }, (_, index) => (
@@ -31,5 +31,5 @@ const DefaultFlowLayoutStory: ComponentStory<typeof FlowLayout> = (args) => {
     </FlowLayout>
   );
 };
-export const DefaultFlowLayout = DefaultFlowLayoutStory.bind({});
-DefaultFlowLayout.args = {};
+export const Default = DefaultStory.bind({});
+Default.args = {};

--- a/packages/core/stories/grid-item.stories.tsx
+++ b/packages/core/stories/grid-item.stories.tsx
@@ -2,7 +2,7 @@ import { GridItem, GridLayout } from "@salt-ds/core";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import "./layout-stories.css";
 export default {
-  title: "Core/Layout/GridLayout/GridItem",
+  title: "Core/Layout/Grid Layout/Grid Item",
   component: GridItem,
   argTypes: {
     colSpan: { control: { type: "number" } },

--- a/packages/core/stories/grid-layout.doc.stories.mdx
+++ b/packages/core/stories/grid-layout.doc.stories.mdx
@@ -46,7 +46,7 @@ A grid item allows more complex controls to the default behavior of a grid child
 You have an item that needs to take the space of more than one row/column or when you have an item that requires a different alignment to the component's default.
 
 <Canvas>
-  <Story id="core-layout-grid-layout-griditem--grid-item-wrapper" />
+  <Story id="core-layout-grid-layout-grid-item--grid-item-wrapper" />
 </Canvas>
 
 #### Responsive

--- a/packages/core/stories/grid-layout.doc.stories.mdx
+++ b/packages/core/stories/grid-layout.doc.stories.mdx
@@ -102,7 +102,7 @@ columns={{ xs: 1, sm: 2, lg: 12, md: 12, xl: 12 }}
 
 The Grid Layout is used in the following components
 
-- [Border layout](?path=/docs/documentation-core-layout-border-layout--page)
+- [Border Layout](?path=/docs/documentation-core-layout-border-layout--page)
 
 ### Classes
 

--- a/packages/core/stories/grid-layout.doc.stories.mdx
+++ b/packages/core/stories/grid-layout.doc.stories.mdx
@@ -12,32 +12,32 @@ import HelpAndSupport from "docs/blocks/help-and-support.doc.mdx";
   }}
 />
 
-# Grid layout
+# Grid Layout
 
 Defines an equally distributed layout system using columns and rows which provides consistent and responsive layouts for building both components and application pages.
-The grid layout defaults to a 12 column grid with one row, but you can customize it using the `columns` and `rows` props.
+The Grid Layout defaults to a 12 column grid with one row, but you can customize it using the `columns` and `rows` props.
 For more complex layouts, it supports spanning across columns and rows.
 
 <Canvas>
-  <Story id="core-layout-gridlayout--default-grid-layout" />
+  <Story id="core-layout-grid-layout--default" />
 </Canvas>
 
-## Use Grid layout when...
+## Use Grid Layout when...
 
 Your content is best displayed using a configurable number of columns and rows.
 
-Grid layout can take any number of children, and will by default display them in a 12 column grid (items after the 12th one will wrap).
+Grid Layout can take any number of children, and will by default display them in a 12 column grid (items after the 12th one will wrap).
 In order to change the number of columns displayed in the grid, you can reduce or increase the value of the `columns` prop.
 
-Grid layout is useful when you want to control the layout in both row and column dimensions, and it can achieve more complex forms when used in combination with `GridItems`.
+Grid Layout is useful when you want to control the layout in both row and column dimensions, and it can achieve more complex forms when used in combination with `GridItems`.
 
-### Don't use Grid layout when...
+### Don't use Grid Layout when...
 
-You want your layout to flow in a single dimension. In this case we recommend you having a look at [Stack layout](?path=/docs/documentation-core-layout-stacklayout--page), [Flow layout](?path=/docs/documentation-core-layout-flowlayout--page) or [Flex layout](?path=/docs/documentation-core-layout-flexlayout--page).
+You want your layout to flow in a single dimension. In this case we recommend you having a look at [Stack layout](?path=/docs/documentation-core-layout-stack-layout--page), [Flow layout](?path=/docs/documentation-core-layout-flow-layout--page) or [Flex layout](?path=/docs/documentation-core-layout-flex-layout--page).
 
 ### Examples
 
-#### Grid Item inside default grid layout
+#### Grid Item inside default Grid Layout
 
 A grid item allows more complex controls to the default behavior of a grid child, like defining how many rows or columns it will span, and its alignment.
 
@@ -46,7 +46,7 @@ A grid item allows more complex controls to the default behavior of a grid child
 You have an item that needs to take the space of more than one row/column or when you have an item that requires a different alignment to the component's default.
 
 <Canvas>
-  <Story id="core-layout-gridlayout-griditem--grid-item-wrapper" />
+  <Story id="core-layout-grid-layout-griditem--grid-item-wrapper" />
 </Canvas>
 
 #### Responsive
@@ -60,7 +60,7 @@ You can use the default breakpoints or pass in your own to the `SaltProvider`.
 The flow of the grid is dependent on the viewport size.
 
 <Canvas>
-  <Story id="core-layout-gridlayout--grid-layout-responsive-view-with-custom-breakpoints" />
+  <Story id="core-layout-grid-layout--responsive-view-with-custom-breakpoints" />
 </Canvas>
 
 #### Simple usage
@@ -68,7 +68,7 @@ The flow of the grid is dependent on the viewport size.
 The simple usage example shows `GridLayout` and `GridItems` being used to build a page footer where the first column takes up the most amount of space.
 
 <Canvas>
-  <Story id="core-layout-gridlayout--grid-layout-footer" />
+  <Story id="core-layout-grid-layout--footer" />
 </Canvas>
 
 #### Composite usage
@@ -76,10 +76,10 @@ The simple usage example shows `GridLayout` and `GridItems` being used to build 
 The composite usage example shows a responsive blog built using `ResponsiveProps`.
 
 <Canvas>
-  <Story id="core-layout-gridlayout--grid-layout-composite" />
+  <Story id="core-layout-grid-layout--composite" />
 </Canvas>
 
-## Configuring Grid layout
+## Configuring Grid Layout
 
 ### API
 
@@ -100,9 +100,9 @@ columns={{ xs: 1, sm: 2, lg: 12, md: 12, xl: 12 }}
 
 ## Related components
 
-The grid layout is used in the following components
+The Grid Layout is used in the following components
 
-- [Border layout](?path=/docs/documentation-core-layout-borderlayout--page)
+- [Border layout](?path=/docs/documentation-core-layout-border-layout--page)
 
 ### Classes
 

--- a/packages/core/stories/grid-layout.stories.tsx
+++ b/packages/core/stories/grid-layout.stories.tsx
@@ -10,7 +10,7 @@ import { ThumbsUpIcon } from "@salt-ds/icons";
 import "./layout-stories.css";
 
 export default {
-  title: "Core/Layout/GridLayout",
+  title: "Core/Layout/Grid Layout",
   component: GridLayout,
   subcomponents: { GridItem },
   argTypes: {
@@ -38,8 +38,8 @@ const Template: ComponentStory<typeof GridLayout> = (args) => {
     </GridLayout>
   );
 };
-export const DefaultGridLayout = Template.bind({});
-DefaultGridLayout.args = {
+export const Default = Template.bind({});
+Default.args = {
   columns: { xs: 1, sm: 3, md: 6, lg: 9, xl: 12 },
 };
 
@@ -68,9 +68,8 @@ const ResponsiveView: ComponentStory<typeof GridLayout> = (args) => {
   );
 };
 
-export const GridLayoutResponsiveViewWithCustomBreakpoints =
-  ResponsiveView.bind({});
-GridLayoutResponsiveViewWithCustomBreakpoints.args = {
+export const ResponsiveViewWithCustomBreakpoints = ResponsiveView.bind({});
+ResponsiveViewWithCustomBreakpoints.args = {
   columns: { xs: 1, md: 6, lg: 12 },
   rows: { md: 8, lg: 3 },
 };
@@ -91,7 +90,7 @@ const footerColumns = Object.keys(footerLinks).map((header, index) => (
   </div>
 ));
 
-const Footer: ComponentStory<typeof GridLayout> = (args) => {
+const FooterTemplate: ComponentStory<typeof GridLayout> = (args) => {
   return (
     <GridLayout {...args}>
       <GridItem
@@ -110,8 +109,8 @@ const Footer: ComponentStory<typeof GridLayout> = (args) => {
     </GridLayout>
   );
 };
-export const GridLayoutFooter = Footer.bind({});
-GridLayoutFooter.args = {
+export const Footer = FooterTemplate.bind({});
+Footer.args = {
   columnGap: { xs: 2, md: 8 },
   columns: { xs: 1, sm: 2, md: 6 },
 };
@@ -210,8 +209,8 @@ const Blog: ComponentStory<typeof GridLayout> = (args) => {
     </div>
   );
 };
-export const GridLayoutComposite = Blog.bind({});
-GridLayoutComposite.args = {
+export const Composite = Blog.bind({});
+Composite.args = {
   as: "main",
   columns: { xs: 1, sm: 2, lg: 4 },
 };
@@ -227,5 +226,5 @@ const GridLayoutNestedExample: ComponentStory<typeof GridLayout> = () => {
     </GridLayout>
   );
 };
-export const GridLayoutNested = GridLayoutNestedExample.bind({});
-GridLayoutNested.args = {};
+export const Nested = GridLayoutNestedExample.bind({});
+Nested.args = {};

--- a/packages/core/stories/layouts.doc.stories.mdx
+++ b/packages/core/stories/layouts.doc.stories.mdx
@@ -13,50 +13,50 @@ Layout componentry was created to help you build consistent and responsive layou
 Built on top of CSS Grid and Flexbox, the layout components give spacial consistency out of the box,
 they allow for easy responsive behavior and customization.
 
-## [Border layout](/docs/documentation-core-layout-borderlayout--page)
+## [Border layout](/docs/documentation-core-layout-border-layout--page)
 
 Defines the main content regions of an application, region or widget, such as a footer, header or side navigation.
 
 <Canvas>
-  <Story id="core-layout-borderlayout--border-layout-all-panels" />
+  <Story id="core-layout-border-layout--all-panels" />
 </Canvas>
 
-## [Flex layout](/docs/documentation-core-layout-flexlayout--page)
+## [Flex layout](/docs/documentation-core-layout-flex-layout--page)
 
 Dictates a vertical or horizontal order and direction for UI elements. Does not wrap by default.
 
 <Canvas>
-  <Story id="core-layout-flexlayout--default-flex-layout" />
+  <Story id="core-layout-flex-layout--default" />
 </Canvas>
 
-## [Flow layout](/docs/documentation-core-layout-flowlayout--page)
+## [Flow layout](/docs/documentation-core-layout-flow-layout--page)
 
 Dictates a horizontal order and direction for UI elements. Wraps by default.
 
 <Canvas>
-  <Story id="core-layout-flowlayout--default-flow-layout" />
+  <Story id="core-layout-flow-layout--default" />
 </Canvas>
 
-## [Grid layout](/docs/documentation-core-layout-gridlayout--page)
+## [Grid layout](/docs/documentation-core-layout-grid-layout--page)
 
 Defines an equally distributed layout system using columns and rows.
 
 <Canvas>
-  <Story id="core-layout-gridlayout-griditem--grid-item-wrapper" />
+  <Story id="core-layout-grid-layout-grid-item--grid-item-wrapper" />
 </Canvas>
 
-## [Split layout](/docs/documentation-core-layout-splitlayout--page)
+## [Split layout](/docs/documentation-core-layout-split-layout--page)
 
 Defines start and end regions for UI elements within a container, such as a button bar
 
 <Canvas>
-  <Story id="core-layout-splitlayout--default-split-layout" />
+  <Story id="core-layout-split-layout--default" />
 </Canvas>
 
-## [Stack layout](/docs/documentation-core-layout-stacklayout--page)
+## [Stack layout](/docs/documentation-core-layout-stack-layout--page)
 
 Dictates a vertical order and direction for UI elements.
 
 <Canvas>
-  <Story id="core-layout-stacklayout--default-stack-layout" />
+  <Story id="core-layout-stack-layout--default" />
 </Canvas>

--- a/packages/core/stories/salt-provider.doc.stories.mdx
+++ b/packages/core/stories/salt-provider.doc.stories.mdx
@@ -90,7 +90,7 @@ function MyComponent() {
 
 ## <a name="breakpoints"></a>Breakpoints
 
-The `breakpoints` prop on `SaltProvider` can be used to customize the CSS media queries that custom hooks like `useBreakpoints` and `useCurrentBreakpoint` are using internally. These hooks are usually used to enable the responsive props, where you can pass multiple values (one per breakpoint) or a single value that would take effect across all different screen sizes. These props can mostly be found in the layout components for now. Refer to the [FlexLayout](/docs/documentation-core-layout-flexlayout--page) component documentation for a good example of this.
+The `breakpoints` prop on `SaltProvider` can be used to customize the CSS media queries that custom hooks like `useBreakpoints` and `useCurrentBreakpoint` are using internally. These hooks are usually used to enable the responsive props, where you can pass multiple values (one per breakpoint) or a single value that would take effect across all different screen sizes. These props can mostly be found in the layout components for now. Refer to the [FlexLayout](/docs/documentation-core-layout-flex-layout--page) component documentation for a good example of this.
 
 The default value is the following breakpoint size mapping object.
 

--- a/packages/core/stories/split-layout.doc.stories.mdx
+++ b/packages/core/stories/split-layout.doc.stories.mdx
@@ -4,42 +4,42 @@ import { CSSClassTable } from "css-variable-docgen-components";
 import HelpAndSupport from "docs/blocks/help-and-support.doc.mdx";
 
 <Meta
-  title="Documentation/Core/Layout/SplitLayout"
+  title="Documentation/Core/Layout/Split Layout"
   component={SplitLayout}
   parameters={{
     viewMode: "docs",
   }}
 />
 
-# Split layout
+# Split Layout
 
 Defines regions in opposite horizontal/vertical ends for UI elements separated within a span, such as a button bar.
 The horizontal `SplitLayout` can be controlled to break into another row based on the viewport size by the responsive prop `direction`.
 
 <Canvas>
-  <Story id="core-layout-splitlayout--default-split-layout" />
+  <Story id="core-layout-split-layout--default" />
 </Canvas>
 
-## Use Split layout when...
+## Use Split Layout when...
 
 There are 2 defined areas required to be in the opposite horizontal ends of a container,
 for example if 2 `ButtonBar` components need to be in a header.
 
-### Don't use Split layout when...
+### Don't use Split Layout when...
 
-Your layout requires more than 2 regions. In this case we recommend you having a look at [Flow layout](?path=/docs/documentation-core-layout-flowlayout--page).
+Your layout requires more than 2 regions. In this case we recommend you having a look at [Flow layout](?path=/docs/documentation-core-layout-flow-layout--page).
 
 ### Examples
 
 #### Simple usage
 
-The simple usage examples shows 2 groups of buttons inside a Split layout.
+The simple usage examples shows 2 groups of buttons inside a Split Layout.
 
 <Canvas>
-  <Story id="core-layout-splitlayout--split-layout-simple-usage" />
+  <Story id="core-layout-split-layout--simple-usage" />
 </Canvas>
 
-## Configuring Split layout
+## Configuring Split Layout
 
 ### API
 

--- a/packages/core/stories/split-layout.stories.tsx
+++ b/packages/core/stories/split-layout.stories.tsx
@@ -104,27 +104,27 @@ const DefaultSplitLayoutStory: ComponentStory<typeof SplitLayout> = (args) => (
   <SplitLayout {...args} />
 );
 
-export const DefaultSplitLayout = DefaultSplitLayoutStory.bind({});
-DefaultSplitLayout.args = {
+export const Default = DefaultSplitLayoutStory.bind({});
+Default.args = {
   startItem: startItem,
   endItem: endItem,
   direction: { xs: "column", sm: "row" },
 };
 
-export const EndOnlySplitLayout = DefaultSplitLayoutStory.bind({});
-EndOnlySplitLayout.args = {
+export const EndOnly = DefaultSplitLayoutStory.bind({});
+EndOnly.args = {
   endItem: endItem,
 };
 
-export const SplitLayoutSimpleUsage = DefaultSplitLayoutStory.bind({});
-SplitLayoutSimpleUsage.args = {
+export const SimpleUsage = DefaultSplitLayoutStory.bind({});
+SimpleUsage.args = {
   startItem: startButtonsItem,
   endItem: endButtonsItem,
   direction: { xs: "column", sm: "row" },
 };
 
-export const VerticalSplitLayout = DefaultSplitLayoutStory.bind({});
-VerticalSplitLayout.args = {
+export const Vertical = DefaultSplitLayoutStory.bind({});
+Vertical.args = {
   align: "center",
   startItem: topItem,
   endItem: bottomItem,

--- a/packages/core/stories/stack-layout.doc.stories.mdx
+++ b/packages/core/stories/stack-layout.doc.stories.mdx
@@ -10,42 +10,42 @@ import HelpAndSupport from "docs/blocks/help-and-support.doc.mdx";
   }}
 />
 
-# Stack layout
+# Stack Layout
 
-Stack layout dictates a vertical or horizontal order and direction for UI elements.
+Stack Layout dictates a vertical or horizontal order and direction for UI elements.
 It builds from flex layout, the height is driven by the child elements, and there are visual separators that can be turned on/off (default) between items.
 
 It can be used with `column` direction for cases in which the direction needs to be consistently vertical, for example a list.
 It can be used with `row` direction to layout static components or information in a horizontal orientation, such as metric data displays, contact information or page filters.
 
 <Canvas>
-  <Story id="core-layout-stacklayout--default-stack-layout" />
+  <Story id="core-layout-stack-layout--default-stack-layout" />
 </Canvas>
 
-## Use Stack layout when...
+## Use Stack Layout when...
 
 - You need a layout that is consistently horizontal or vertical.
 - You need your items to be either scrollable.
 - You want the layout to change direction depending on breakpoints.
 
-### Don't use Stack layout when...
+### Don't use Stack Layout when...
 
-- You want children to wrap by default. In this case we recommend you having a look at [Flow layout](?path=/docs/documentation-core-layout-flowlayout--page).
-- You want the direction to have more complex customization. In this case we recommend you having a look at [Flex layout](?path=/docs/documentation-core-layout-flexlayout--page).
+- You want children to wrap by default. In this case we recommend you having a look at [Flow layout](?path=/docs/documentation-core-layout-flow-layout--page).
+- You want the direction to have more complex customization. In this case we recommend you having a look at [Flex layout](?path=/docs/documentation-core-layout-flex-layout--page).
 
 ### Examples
 
-#### Stack layout with separators
+#### Stack Layout with separators
 
-Stack layout allows for separators between items that will by default display centered `separators={true}` but can be customized to sit on the left or right of a children.
+Stack Layout allows for separators between items that will by default display centered `separators={true}` but can be customized to sit on the left or right of a children.
 The separators span across the width of the layout component if the direction is row and the height if the direction is columns.
-The Stack layout gap will apply to both sides of the separator line.
+The Stack Layout gap will apply to both sides of the separator line.
 
 <Canvas>
-  <Story id="core-layout-stacklayout--stack-layout-with-separators" />
+  <Story id="core-layout-stack-layout--with-separators" />
 </Canvas>
 
-## Configuring Stack layout
+## Configuring Stack Layout
 
 ### API
 

--- a/packages/core/stories/stack-layout.doc.stories.mdx
+++ b/packages/core/stories/stack-layout.doc.stories.mdx
@@ -19,7 +19,7 @@ It can be used with `column` direction for cases in which the direction needs to
 It can be used with `row` direction to layout static components or information in a horizontal orientation, such as metric data displays, contact information or page filters.
 
 <Canvas>
-  <Story id="core-layout-stack-layout--default-stack-layout" />
+  <Story id="core-layout-stack-layout--default" />
 </Canvas>
 
 ## Use Stack Layout when...

--- a/packages/core/stories/stack-layout.stories.tsx
+++ b/packages/core/stories/stack-layout.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import "./layout-stories.css";
 
 export default {
-  title: "Core/Layout/StackLayout",
+  title: "Core/Layout/Stack Layout",
   component: StackLayout,
   argTypes: {
     align: {
@@ -35,8 +35,8 @@ const DefaultStackLayoutStory: ComponentStory<typeof StackLayout> = (args) => {
     </StackLayout>
   );
 };
-export const DefaultStackLayout = DefaultStackLayoutStory.bind({});
-DefaultStackLayout.args = {};
+export const Default = DefaultStackLayoutStory.bind({});
+Default.args = {};
 
 const SeparatorsStory: ComponentStory<typeof FlexLayout> = (args) => {
   return (
@@ -49,8 +49,8 @@ const SeparatorsStory: ComponentStory<typeof FlexLayout> = (args) => {
     </StackLayout>
   );
 };
-export const StackLayoutWithSeparators = SeparatorsStory.bind({});
-StackLayoutWithSeparators.args = {
+export const WithSeparators = SeparatorsStory.bind({});
+WithSeparators.args = {
   separators: "center",
   direction: { sm: "row", xs: "column" },
 };

--- a/packages/lab/src/__tests__/__e2e__/deck-layout/DeckLayout.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/deck-layout/DeckLayout.cy.tsx
@@ -3,14 +3,14 @@ import * as deckStories from "@stories/deck-layout.stories";
 import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
 
 const composedStories = composeStories(deckStories);
-const { DefaultDeckLayout } = composedStories;
+const { Default } = composedStories;
 
 describe("Given a deck layout", () => {
   checkAccessibility(composedStories);
 
   describe("WHEN no custom values are provided", () => {
     it("THEN it should render with default values", () => {
-      cy.mount(<DefaultDeckLayout />);
+      cy.mount(<Default />);
       cy.get(".saltDeckItem").should("have.length", 6);
       cy.get(".saltDeckItem")
         .eq(0)
@@ -22,13 +22,13 @@ describe("Given a deck layout", () => {
   });
   describe("WHEN an active index is provided", () => {
     it("THEN it should render in right DeckItem", () => {
-      cy.mount(<DefaultDeckLayout activeIndex={1} />);
+      cy.mount(<Default activeIndex={1} />);
       cy.get(".saltDeckItem")
         .eq(1)
         .should("have.class", "saltDeckItem-static-current");
     });
     it("THEN it should navigate trough items", () => {
-      cy.mount(<DefaultDeckLayout activeIndex={1} animation="slide" />);
+      cy.mount(<Default activeIndex={1} animation="slide" />);
       cy.get(".saltDeckItem")
         .eq(0)
         .should("have.class", "saltDeckItem-slide-previous");
@@ -70,7 +70,7 @@ describe("Given a deck layout", () => {
   });
   describe("WHEN animation and direction values are provided", () => {
     it("THEN deck should have vertical animation classes if direction is vertical", () => {
-      cy.mount(<DefaultDeckLayout direction="vertical" animation="slide" />);
+      cy.mount(<Default direction="vertical" animation="slide" />);
 
       cy.get(".saltDeckLayout-animate").should(
         "have.class",
@@ -78,7 +78,7 @@ describe("Given a deck layout", () => {
       );
     });
     it("THEN deck should have horizontal animation classes if direction is horizontal", () => {
-      cy.mount(<DefaultDeckLayout animation="slide" />);
+      cy.mount(<Default animation="slide" />);
       cy.get(".saltDeckLayout-animate").should(
         "have.class",
         "saltDeckLayout-slide-horizontal"

--- a/packages/lab/src/__tests__/__e2e__/layer-layout/LayerLayout.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/layer-layout/LayerLayout.cy.tsx
@@ -3,18 +3,12 @@ import * as layerStories from "@stories/layer-layout.stories";
 
 const composedStories = composeStories(layerStories);
 
-const {
-  DefaultLayerLayout,
-  LayerLayoutTop,
-  LayerLayoutRight,
-  LayerLayoutLeft,
-  LayerLayoutBottom,
-} = composedStories;
+const { Default, Top, Right, Left, Bottom } = composedStories;
 
 describe("GIVEN a Layer", () => {
   describe("WHEN scrim is enabled", () => {
     it("THEN it should display a scrim by default", () => {
-      cy.mount(<DefaultLayerLayout />);
+      cy.mount(<Default />);
 
       cy.findByRole("button", { name: /Open Layer/i }).click();
 
@@ -24,7 +18,7 @@ describe("GIVEN a Layer", () => {
 
   describe("WHEN scrim is disabled", () => {
     it("THEN it should not display a scrim", () => {
-      cy.mount(<DefaultLayerLayout disableScrim={true} />);
+      cy.mount(<Default disableScrim={true} />);
 
       cy.findByRole("button", { name: /Open Layer/i }).click();
 
@@ -34,7 +28,7 @@ describe("GIVEN a Layer", () => {
 
   describe("WHEN a position is not provided", () => {
     it("THEN it should default to a center position", () => {
-      cy.mount(<DefaultLayerLayout />);
+      cy.mount(<Default />);
 
       cy.findByRole("button", { name: /Open Layer/i }).click();
 
@@ -44,7 +38,7 @@ describe("GIVEN a Layer", () => {
 
   describe("WHEN a position is provided", () => {
     it("THEN it should render at the top", () => {
-      cy.mount(<LayerLayoutTop />);
+      cy.mount(<Top />);
 
       cy.findByRole("button", { name: /Open Layer/i }).click();
 
@@ -52,7 +46,7 @@ describe("GIVEN a Layer", () => {
     });
 
     it("THEN it should render on the right hand side", () => {
-      cy.mount(<LayerLayoutRight />);
+      cy.mount(<Right />);
 
       cy.findByRole("button", { name: /Open Layer/i }).click();
 
@@ -60,7 +54,7 @@ describe("GIVEN a Layer", () => {
     });
 
     it("THEN it should render on the left hand side", () => {
-      cy.mount(<LayerLayoutLeft />);
+      cy.mount(<Left />);
 
       cy.findByRole("button", { name: /Open Layer/i }).click();
 
@@ -68,7 +62,7 @@ describe("GIVEN a Layer", () => {
     });
 
     it("THEN it should render at the bottom", () => {
-      cy.mount(<LayerLayoutBottom />);
+      cy.mount(<Bottom />);
 
       cy.findByRole("button", { name: /Open Layer/i }).click();
 
@@ -84,7 +78,7 @@ describe("GIVEN a Layer", () => {
         viewportWidth: 700,
       },
       () => {
-        cy.mount(<DefaultLayerLayout />);
+        cy.mount(<Default />);
 
         cy.findByRole("button", { name: /Open Layer/i }).click();
 
@@ -104,7 +98,7 @@ describe("GIVEN a Layer", () => {
         viewportWidth: 961,
       },
       () => {
-        cy.mount(<DefaultLayerLayout fullScreenAtBreakpoint="md" />);
+        cy.mount(<Default fullScreenAtBreakpoint="md" />);
 
         cy.findByRole("button", { name: /Open Layer/i }).click();
 
@@ -122,7 +116,7 @@ describe("GIVEN a Layer", () => {
         viewportWidth: 1821,
       },
       () => {
-        cy.mount(<DefaultLayerLayout fullScreenAtBreakpoint="xl" />);
+        cy.mount(<Default fullScreenAtBreakpoint="xl" />);
 
         cy.findByRole("button", { name: /Open Layer/i }).click();
 
@@ -136,7 +130,7 @@ describe("GIVEN a Layer", () => {
 
   describe("WHEN a layer component is closed", () => {
     it("THEN it should display an exit animation", () => {
-      cy.mount(<DefaultLayerLayout />);
+      cy.mount(<Default />);
 
       cy.findByRole("button", { name: /Open Layer/i }).click();
 
@@ -161,7 +155,7 @@ describe("GIVEN a Layer", () => {
         viewportWidth: 700,
       },
       () => {
-        cy.mount(<DefaultLayerLayout />);
+        cy.mount(<Default />);
 
         cy.findByRole("button", { name: /Open Layer/i }).click();
 

--- a/packages/lab/src/__tests__/__e2e__/parent-child-layout/ParentChildLayout.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/parent-child-layout/ParentChildLayout.cy.tsx
@@ -3,13 +3,12 @@ import * as parentChildStories from "@stories/parent-child-layout.stories";
 
 const composedStories = composeStories(parentChildStories);
 
-const { DefaultParentChildLayout, SaltParentChildLayoutStacked } =
-  composedStories;
+const { Default, SaltStacked } = composedStories;
 
 describe("GIVEN a Parent and Child", () => {
   describe("WHEN no gap values are provided", () => {
     it("THEN it should display a gap by default", () => {
-      cy.mount(<DefaultParentChildLayout />);
+      cy.mount(<Default />);
 
       cy.get(".saltParentChildLayout").should("have.css", "column-gap", "24px");
 
@@ -21,7 +20,7 @@ describe("GIVEN a Parent and Child", () => {
     const parent = ["a", "b", "c", "d", "e"];
 
     it("THEN it should render as expected", () => {
-      cy.mount(<DefaultParentChildLayout parent={parent} />);
+      cy.mount(<Default parent={parent} />);
 
       cy.get(".saltParentChildItem")
         .first()
@@ -33,7 +32,7 @@ describe("GIVEN a Parent and Child", () => {
     const child = ["a", "b", "c", "d", "e"];
 
     it("THEN it should render as expected", () => {
-      cy.mount(<DefaultParentChildLayout child={child} />);
+      cy.mount(<Default child={child} />);
 
       // Make sure both child and parent are rendered before running next test `eq`
       cy.get(".saltParentChildItem").should("have.length", 2);
@@ -49,7 +48,7 @@ describe("GIVEN a Parent and Child", () => {
         viewportWidth: 1921,
       },
       () => {
-        cy.mount(<DefaultParentChildLayout />);
+        cy.mount(<Default />);
         cy.get(".saltParentChildItem").should("have.length", 2);
       }
     );
@@ -61,7 +60,7 @@ describe("GIVEN a Parent and Child", () => {
         viewportWidth: 700,
       },
       () => {
-        cy.mount(<DefaultParentChildLayout />);
+        cy.mount(<Default />);
         cy.get(".saltParentChildItem").should("have.length", 1);
       }
     );
@@ -69,7 +68,7 @@ describe("GIVEN a Parent and Child", () => {
 
   describe("WHEN in stacked view", () => {
     it("THEN it should only display the parent by default", () => {
-      cy.mount(<SaltParentChildLayoutStacked />);
+      cy.mount(<SaltStacked />);
 
       cy.get(".saltParentChildItem").should("have.length", 1);
 
@@ -79,7 +78,7 @@ describe("GIVEN a Parent and Child", () => {
     });
 
     it("THEN it should change to the child view when the button is clicked", () => {
-      cy.mount(<SaltParentChildLayoutStacked />);
+      cy.mount(<SaltStacked />);
 
       cy.findByRole("button", { name: /Show child/i }).click();
 
@@ -91,14 +90,14 @@ describe("GIVEN a Parent and Child", () => {
     });
 
     it("THEN it should change the direction of animations", () => {
-      cy.mount(<SaltParentChildLayoutStacked orientation="vertical" />);
+      cy.mount(<SaltStacked orientation="vertical" />);
 
       cy.get(".saltParentChildItem").should(
         "have.class",
         "saltParentChildItem-slide-bottom"
       );
 
-      cy.mount(<SaltParentChildLayoutStacked orientation="horizontal" />);
+      cy.mount(<SaltStacked orientation="horizontal" />);
 
       cy.get(".saltParentChildItem").should(
         "have.class",

--- a/packages/lab/stories/deck-layout.doc.stories.mdx
+++ b/packages/lab/stories/deck-layout.doc.stories.mdx
@@ -5,42 +5,42 @@ import { DefaultDeckLayout } from "./deck-layout.stories";
 import HelpAndSupport from "docs/blocks/help-and-support.doc.mdx";
 
 <Meta
-  title="Documentation/Lab/Layout/DeckLayout"
+  title="Documentation/Lab/Layout/Deck Layout"
   component={DeckLayout}
   subcomponents={{ DeckItem }}
 />
 
-# Deck layout
+# Deck Layout
 
-The deck layout defines pages of content that appear within the same specified region, one at a time.
+The Deck Layout defines pages of content that appear within the same specified region, one at a time.
 
 It allows motion customization (`slide` or `fade`) and a custom direction for the animations (`horizontal` or `vertical`).
 
 This layout component also allows you to assign the initial page to be rendered via the `activeIndex` prop.
 
 <Canvas>
-  <Story id="lab-layout-decklayout--default-deck-layout" />
+  <Story id="lab-layout-deck-layout--default" />
 </Canvas>
 
-## Use Deck layout when...
+## Use Deck Layout when...
 
 You need to display a collection of children (pages). You may also choose to control the movement between pages by using buttons or tabs.
 
-### Don't use Deck layout when...
+### Don't use Deck Layout when...
 
-Instead you want your content to be displayed in a layer above the existing page. In this case we recommend you having a look at [Layer layout](?path=/docs/documentation-lab-layout-layerlayout--page).
+Instead you want your content to be displayed in a layer above the existing page. In this case we recommend you having a look at [Layer layout](?path=/docs/documentation-lab-layout-layer-layout--page).
 
 ### Example
 
 #### Deck used with tabstrip
 
-This example shows how the deck layout can be used in conjunction with `Tabstrip`. You can enable animations by setting the `animation` prop.
+This example shows how the Deck Layout can be used in conjunction with `Tabstrip`. You can enable animations by setting the `animation` prop.
 
 <Canvas>
-  <Story id="lab-layout-decklayout--deck-in-tabstrip" />
+  <Story id="lab-layout-deck-layout--deck-in-tabstrip" />
 </Canvas>
 
-## Configuring Deck layout
+## Configuring Deck Layout
 
 ### API
 

--- a/packages/lab/stories/deck-layout.stories.tsx
+++ b/packages/lab/stories/deck-layout.stories.tsx
@@ -59,8 +59,8 @@ const DefaultDeckLayoutStory: ComponentStory<typeof DeckLayout> = (args) => {
     </>
   );
 };
-export const DefaultDeckLayout = DefaultDeckLayoutStory.bind({});
-DefaultDeckLayout.args = {};
+export const Default = DefaultDeckLayoutStory.bind({});
+Default.args = {};
 
 const WithTabStrip: ComponentStory<typeof DeckLayout> = (args) => {
   const [activeTabIndex, setActiveTabIndex] = useState(0);

--- a/packages/lab/stories/layer-layout.doc.stories.mdx
+++ b/packages/lab/stories/layer-layout.doc.stories.mdx
@@ -5,7 +5,7 @@ import { DefaultLayerLayout } from "./layer-layout.stories";
 import HelpAndSupport from "docs/blocks/help-and-support.doc.mdx";
 
 <Meta
-  title="Documentation/Lab/Layout/LayerLayout"
+  title="Documentation/Lab/Layout/Layer Layout"
   component={LayerLayout}
   parameters={{
     viewMode: "docs",
@@ -19,7 +19,7 @@ The Layer layout defines a layer above the existing layout structure for UI elem
 It can be used to build dialog or drawer components and it can be positioned in different parts of the screen.
 
 <Canvas>
-  <Story id="lab-layout-layerlayout--default-layer-layout" />
+  <Story id="lab-layout-layer-layout--default" />
 </Canvas>
 
 ## Use Layer layout when...
@@ -32,7 +32,7 @@ The Layer layout displays a scrim and animations by default but you can disable 
 
 ### Don't use Layer layout when...
 
-Instead you want your content to be split between pages or tabs. In this case we recommend you having a look at [Deck layout](?path=/docs/documentation-lab-layout-decklayout--page).
+Instead you want your content to be split between pages or tabs. In this case we recommend you having a look at [Deck layout](?path=/docs/documentation-lab-layout-deck-layout--page).
 
 ### Examples
 
@@ -43,25 +43,25 @@ The component will be displayed in the center position by default but you can cu
 ##### Top positioned
 
 <Canvas>
-  <Story id="lab-layout-layerlayout--layer-layout-top" />
+  <Story id="lab-layout-layer-layout--top" />
 </Canvas>
 
 ##### Right positioned
 
 <Canvas>
-  <Story id="lab-layout-layerlayout--layer-layout-right" />
+  <Story id="lab-layout-layer-layout--right" />
 </Canvas>
 
 ##### Left positioned
 
 <Canvas>
-  <Story id="lab-layout-layerlayout--layer-layout-left" />
+  <Story id="lab-layout-layer-layout--left" />
 </Canvas>
 
 ##### Bottom positioned
 
 <Canvas>
-  <Story id="lab-layout-layerlayout--layer-layout-bottom" />
+  <Story id="lab-layout-layer-layout--bottom" />
 </Canvas>
 
 #### Reduced motion
@@ -69,7 +69,7 @@ The component will be displayed in the center position by default but you can cu
 You can customize or disable the animations using the `prefers-reduced-motion` CSS media feature.
 
 <Canvas>
-  <Story id="lab-layout-layerlayout--layer-reduced-motion" />
+  <Story id="lab-layout-layer-layout--reduced-motion" />
 </Canvas>
 
 ## Configuring Layer layout

--- a/packages/lab/stories/layer-layout.stories.tsx
+++ b/packages/lab/stories/layer-layout.stories.tsx
@@ -12,7 +12,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import "./layout-stories.css";
 
 export default {
-  title: "Lab/Layout/LayerLayout",
+  title: "Lab/Layout/Layer Layout",
   component: LayerLayout,
   argTypes: {
     position: {
@@ -79,12 +79,12 @@ const DefaultLayerLayoutStory: ComponentStory<typeof LayerLayout> = (args) => {
   );
 };
 
-export const DefaultLayerLayout = DefaultLayerLayoutStory.bind({});
-DefaultLayerLayout.args = {
+export const Default = DefaultLayerLayoutStory.bind({});
+Default.args = {
   position: "center",
 };
 
-const Top: ComponentStory<typeof LayerLayout> = (args) => {
+const TopTemplate: ComponentStory<typeof LayerLayout> = (args) => {
   const [open, setOpen] = useState(false);
 
   const show = () => setOpen(true);
@@ -101,12 +101,12 @@ const Top: ComponentStory<typeof LayerLayout> = (args) => {
   );
 };
 
-export const LayerLayoutTop = Top.bind({});
-LayerLayoutTop.args = {
+export const Top = TopTemplate.bind({});
+Top.args = {
   position: "top",
 };
 
-const Right: ComponentStory<typeof LayerLayout> = (args) => {
+const RightTemplate: ComponentStory<typeof LayerLayout> = (args) => {
   const [open, setOpen] = useState(false);
 
   const show = () => setOpen(true);
@@ -123,12 +123,12 @@ const Right: ComponentStory<typeof LayerLayout> = (args) => {
   );
 };
 
-export const LayerLayoutRight = Right.bind({});
-LayerLayoutRight.args = {
+export const Right = RightTemplate.bind({});
+Right.args = {
   position: "right",
 };
 
-const Left: ComponentStory<typeof LayerLayout> = (args) => {
+const LeftTemplate: ComponentStory<typeof LayerLayout> = (args) => {
   const [open, setOpen] = useState(false);
 
   const show = () => setOpen(true);
@@ -145,12 +145,12 @@ const Left: ComponentStory<typeof LayerLayout> = (args) => {
   );
 };
 
-export const LayerLayoutLeft = Left.bind({});
-LayerLayoutLeft.args = {
+export const Left = LeftTemplate.bind({});
+Left.args = {
   position: "left",
 };
 
-const Bottom: ComponentStory<typeof LayerLayout> = (args) => {
+const BottomTemplate: ComponentStory<typeof LayerLayout> = (args) => {
   const [open, setOpen] = useState(false);
 
   const show = () => setOpen(true);
@@ -167,12 +167,12 @@ const Bottom: ComponentStory<typeof LayerLayout> = (args) => {
   );
 };
 
-export const LayerLayoutBottom = Bottom.bind({});
-LayerLayoutBottom.args = {
+export const Bottom = BottomTemplate.bind({});
+Bottom.args = {
   position: "bottom",
 };
 
-const CustomFullScreenAnimation: ComponentStory<typeof LayerLayout> = (
+const CustomFullScreenAnimationTemplate: ComponentStory<typeof LayerLayout> = (
   args
 ) => {
   const [open, setOpen] = useState(false);
@@ -216,21 +216,21 @@ const CustomFullScreenAnimation: ComponentStory<typeof LayerLayout> = (
   );
 };
 
-export const LayerCustomFullScreenAnimation = CustomFullScreenAnimation.bind(
+export const CustomFullScreenAnimation = CustomFullScreenAnimationTemplate.bind(
   {}
 );
 
-LayerCustomFullScreenAnimation.args = {
+CustomFullScreenAnimation.args = {
   position: "bottom",
 };
 
-LayerCustomFullScreenAnimation.parameters = {
+CustomFullScreenAnimation.parameters = {
   viewport: {
     defaultViewport: "mobile1",
   },
 };
 
-const ReducedMotion: ComponentStory<typeof LayerLayout> = (args) => {
+const ReducedMotionTemplate: ComponentStory<typeof LayerLayout> = (args) => {
   const [open, setOpen] = useState(false);
 
   const show = () => setOpen(true);
@@ -254,7 +254,7 @@ const ReducedMotion: ComponentStory<typeof LayerLayout> = (args) => {
   );
 };
 
-export const LayerReducedMotion = ReducedMotion.bind({});
+export const ReducedMotion = ReducedMotionTemplate.bind({});
 
 const LayerLayoutCenterExample: ComponentStory<typeof LayerLayout> = (args) => {
   const [open, setOpen] = useState(true);
@@ -288,8 +288,8 @@ const LayerLayoutCenterExample: ComponentStory<typeof LayerLayout> = (args) => {
   );
 };
 
-export const LayerLayoutCenterSimpleUsage = LayerLayoutCenterExample.bind({});
-LayerLayoutCenterSimpleUsage.args = {
+export const CenterSimpleUsage = LayerLayoutCenterExample.bind({});
+CenterSimpleUsage.args = {
   position: "center",
 };
 
@@ -335,8 +335,8 @@ const LayerLayoutLeftExample: ComponentStory<typeof LayerLayout> = (args) => {
   );
 };
 
-export const LayerLayoutLeftSimpleUsage = LayerLayoutLeftExample.bind({});
-LayerLayoutLeftSimpleUsage.args = {
+export const LeftSimpleUsage = LayerLayoutLeftExample.bind({});
+LeftSimpleUsage.args = {
   position: "left",
 };
 
@@ -373,8 +373,8 @@ const LayerLayoutTopExample: ComponentStory<typeof LayerLayout> = (args) => {
   );
 };
 
-export const LayerLayoutTopSimpleUsage = LayerLayoutTopExample.bind({});
-LayerLayoutTopSimpleUsage.args = {
+export const TopSimpleUsage = LayerLayoutTopExample.bind({});
+TopSimpleUsage.args = {
   position: "top",
 };
 
@@ -414,8 +414,8 @@ const LayerLayoutRightExample: ComponentStory<typeof LayerLayout> = (args) => {
   );
 };
 
-export const LayerLayoutRightSimpleUsage = LayerLayoutRightExample.bind({});
-LayerLayoutRightSimpleUsage.args = {
+export const RightSimpleUsage = LayerLayoutRightExample.bind({});
+RightSimpleUsage.args = {
   position: "right",
 };
 
@@ -461,7 +461,7 @@ const LayerLayoutBottomExample: ComponentStory<typeof LayerLayout> = (args) => {
   );
 };
 
-export const LayerLayoutBottomSimpleUsage = LayerLayoutBottomExample.bind({});
-LayerLayoutBottomSimpleUsage.args = {
+export const BottomSimpleUsage = LayerLayoutBottomExample.bind({});
+BottomSimpleUsage.args = {
   position: "bottom",
 };

--- a/packages/lab/stories/layouts.doc.stories.mdx
+++ b/packages/lab/stories/layouts.doc.stories.mdx
@@ -13,28 +13,28 @@ Layout componentry was created to help you build consistent and responsive layou
 Built on top of CSS Grid and Flexbox, the layout components give spacial consistency out of the box,
 they allow for easy responsive behavior and customization.
 
-## [Parent Child](/docs/documentation-lab-layout-parentchildlayout--page)
+## [Parent Child](/docs/documentation-lab-layout-parent-child-layout--page)
 
 Displays a hierarchical structure comprising of a main content area and an accompanying parent region, used to drive the content that is displayed.
 
 <Canvas>
-  <Story id="lab-layout-parentchildlayout--default-parent-child-layout" />
+  <Story id="lab-layout-parent-child-layout--default" />
 </Canvas>
 
-## [Deck layout](/docs/documentation-lab-layout-decklayout--page)
+## [Deck layout](/docs/documentation-lab-layout-deck-layout--page)
 
 Defines pages of content that appear within the same specified region, one at a time
 
 <Canvas>
-  <Story id="lab-layout-decklayout--default-deck-layout" />
+  <Story id="lab-layout-deck-layout--default" />
 </Canvas>
 
-## [Layer layout](/docs/documentation-lab-layout-layerlayout--page)
+## [Layer layout](/docs/documentation-lab-layout-layer-layout--page)
 
 Defines a layer above the existing layout structure for UI elements to be displayed in.
 
 It can be used to build dialog or drawer components and it can be positioned in different parts of the screen.
 
 <Canvas>
-  <Story id="lab-layout-layerlayout--default-layer-layout" />
+  <Story id="lab-layout-layer-layout--default" />
 </Canvas>

--- a/packages/lab/stories/parent-child-layout.doc.stories.mdx
+++ b/packages/lab/stories/parent-child-layout.doc.stories.mdx
@@ -3,29 +3,29 @@ import { ParentChildLayout } from "@salt-ds/lab";
 import HelpAndSupport from "docs/blocks/help-and-support.doc.mdx";
 
 <Meta
-  title="Documentation/Lab/Layout/ParentChildLayout"
+  title="Documentation/Lab/Layout/Parent Child Layout"
   component={ParentChildLayout}
   parameters={{
     viewMode: "docs",
   }}
 />
 
-# Parent Child layout
+# Parent Child Layout
 
 Displays a hierarchical structure comprising of a main content area and an accompanying parent region, used to drive the content that is displayed.
-The parent and child layout is built using [Flex layout](?path=/docs/documentation-core-layout-flexlayout--page) and it is intended for displaying two related layers such as navigation and associated content or a preferences dialog.
+The parent and child layout is built using [Flex layout](?path=/docs/documentation-core-layout-flex-layout--page) and it is intended for displaying two related layers such as navigation and associated content or a preferences dialog.
 
 <Canvas>
-  <Story id="lab-layout-parentchildlayout--default-parent-child-layout" />
+  <Story id="lab-layout-parent-child-layout--default" />
 </Canvas>
 
-## Use Parent Child layout when...
+## Use Parent Child Layout when...
 
 You want your layout to be split into two regions in a responsive manner.
 
-### Don't use Parent Child layout when...
+### Don't use Parent Child Layout when...
 
-You want your layout to flow in a single dimension. In this case we recommend you having a look at [Stack layout](?path=/docs/documentation-core-layout-stacklayout--page), [Flow layout](?path=/docs/documentation-core-layout-flowlayout--page) or [Flex layout](?path=/docs/documentation-core-layout-flexlayout--page).
+You want your layout to flow in a single dimension. In this case we recommend you having a look at [Stack layout](?path=/docs/documentation-core-layout-stack-layout--page), [Flow layout](?path=/docs/documentation-core-layout-flow-layout--page) or [Flex layout](?path=/docs/documentation-core-layout-flex-layout--page).
 
 ### Examples
 
@@ -34,7 +34,7 @@ You want your layout to flow in a single dimension. In this case we recommend yo
 The parent and child component changes to a stacked view once it approaches a specified breakpoint that can be customized via the `stackedAtBreakpoint` prop.
 
 <Canvas>
-  <Story id="lab-layout-parentchildlayout--toolkit-parent-child-layout-stacked" />
+  <Story id="lab-layout-parent-child-layout--toolkit-stacked" />
 </Canvas>
 
 #### Reduced motion
@@ -42,18 +42,18 @@ The parent and child component changes to a stacked view once it approaches a sp
 You can customize or disable the animations using the `prefers-reduced-motion` CSS media feature.
 
 <Canvas>
-  <Story id="lab-layout-parentchildlayout--salt-parent-child-layout-reduced-motion" />
+  <Story id="lab-layout-parent-child-layout--salt-reduced-motion" />
 </Canvas>
 
 #### Composite usage
 
-This example shows a number of Salt components being used in conjunction with Parent Child layout to build a responsive page.
+This example shows a number of Salt components being used in conjunction with Parent Child Layout to build a responsive page.
 
 <Canvas>
-  <Story id="lab-layout-parentchildlayout--parent-child-layout-composite" />
+  <Story id="lab-layout-parent-child-layout--composite" />
 </Canvas>
 
-## Configuring Parent Child layout
+## Configuring Parent Child Layout
 
 ### API
 

--- a/packages/lab/stories/parent-child-layout.stories.tsx
+++ b/packages/lab/stories/parent-child-layout.stories.tsx
@@ -20,7 +20,7 @@ import {
 import "./layout-stories.css";
 
 export default {
-  title: "Lab/Layout/ParentChildLayout",
+  title: "Lab/Layout/Parent Child Layout",
   component: ParentChildLayout,
   argTypes: {
     stackedAtBreakpoint: {
@@ -61,8 +61,8 @@ const DefaultParentChildLayoutStory: ComponentStory<
   );
 };
 
-export const DefaultParentChildLayout = DefaultParentChildLayoutStory.bind({});
-DefaultParentChildLayout.args = { parent, child };
+export const Default = DefaultParentChildLayoutStory.bind({});
+Default.args = { parent, child };
 
 const Stacked: ComponentStory<typeof ParentChildLayout> = (args) => {
   const [currentView, setCurrentView] = useState<StackedViewElement>("parent");
@@ -94,8 +94,8 @@ const Stacked: ComponentStory<typeof ParentChildLayout> = (args) => {
   );
 };
 
-export const SaltParentChildLayoutStacked = Stacked.bind({});
-SaltParentChildLayoutStacked.args = {
+export const SaltStacked = Stacked.bind({});
+SaltStacked.args = {
   stackedAtBreakpoint: "xl",
 };
 
@@ -135,8 +135,8 @@ const ReducedMotion: ComponentStory<typeof ParentChildLayout> = (args) => {
   );
 };
 
-export const SaltParentChildLayoutReducedMotion = ReducedMotion.bind({});
-SaltParentChildLayoutReducedMotion.args = {
+export const SaltReducedMotion = ReducedMotion.bind({});
+SaltReducedMotion.args = {
   stackedAtBreakpoint: "xl",
 };
 
@@ -296,7 +296,7 @@ const Dashboard: ComponentStory<typeof ParentChildLayout> = (args) => {
   );
 };
 
-export const ParentChildLayoutComposite = Dashboard.bind({});
-ParentChildLayoutComposite.args = {
+export const Composite = Dashboard.bind({});
+Composite.args = {
   stackedAtBreakpoint,
 };

--- a/site/docs/components/_index/components-list.tsx
+++ b/site/docs/components/_index/components-list.tsx
@@ -184,7 +184,7 @@ export const componentDetails: ComponentDetails[] = [
     designStatus: ComponentStatus.NOT_APPLICABLE,
     availableInCoreSince: "1.0.0",
     storybookUrl:
-      "https://storybook.saltdesignsystem.com/?path=/docs/documentation-core-layout-borderlayout--page",
+      "https://storybook.saltdesignsystem.com/?path=/docs/documentation-core-layout-border-layout--page",
   },
   {
     name: "Breadcrumbs",
@@ -341,7 +341,7 @@ export const componentDetails: ComponentDetails[] = [
     designStatus: ComponentStatus.NOT_APPLICABLE,
     availableInCoreSince: "1.0.0",
     storybookUrl:
-      "https://storybook.saltdesignsystem.com/?path=/docs/documentation-core-layout-flexlayout--page",
+      "https://storybook.saltdesignsystem.com/?path=/docs/documentation-core-layout-flex-layout--page",
   },
   {
     name: "Flow Layout",
@@ -351,7 +351,7 @@ export const componentDetails: ComponentDetails[] = [
     designStatus: ComponentStatus.NOT_APPLICABLE,
     availableInCoreSince: "1.0.0",
     storybookUrl:
-      "https://storybook.saltdesignsystem.com/?path=/docs/documentation-core-layout-flowlayout--page",
+      "https://storybook.saltdesignsystem.com/?path=/docs/documentation-core-layout-flow-layout--page",
   },
   {
     name: "Form Field",
@@ -374,7 +374,7 @@ export const componentDetails: ComponentDetails[] = [
     designStatus: ComponentStatus.READY,
     availableInCoreSince: "1.0.0",
     storybookUrl:
-      "https://storybook.saltdesignsystem.com/?path=/docs/documentation-core-layout-gridlayout--page",
+      "https://storybook.saltdesignsystem.com/?path=/docs/documentation-core-layout-grid-layout--page",
   },
   {
     name: "Icon",
@@ -585,7 +585,7 @@ export const componentDetails: ComponentDetails[] = [
     designStatus: ComponentStatus.NOT_APPLICABLE,
     availableInCoreSince: "1.0.0",
     storybookUrl:
-      "https://storybook.saltdesignsystem.com/?path=/docs/documentation-core-layout-stacklayout--page",
+      "https://storybook.saltdesignsystem.com/?path=/docs/documentation-core-layout-stack-layout--page",
   },
   {
     name: "Status Indicator",


### PR DESCRIPTION
Remove component names from Layout stories to match the new IA across components
Update story names to have a space to match other components e.g. Aria Announcer, Salt Provider, Layer Layout
see #1087