### PR TITLE
[RFC] Responsive props

### DIFF
--- a/packages/lab/src/breakpoints/BreakpointsContext.tsx
+++ b/packages/lab/src/breakpoints/BreakpointsContext.tsx
@@ -1,0 +1,16 @@
+import { createContext, useContext } from "react";
+
+import { BpType, BreakpointsContextType } from "./types";
+
+export const createBreakpointsContext = <BP extends BpType>() => {
+  const BreakpointsContext = createContext<BreakpointsContextType<BP>>(
+    {} as BreakpointsContextType<BP>
+  );
+
+  const useBreakpointsContext = () => useContext(BreakpointsContext);
+
+  return {
+    BreakpointsContext,
+    useBreakpointsContext,
+  };
+};

--- a/packages/lab/src/breakpoints/BreakpointsProvider.tsx
+++ b/packages/lab/src/breakpoints/BreakpointsProvider.tsx
@@ -1,15 +1,12 @@
 import { ReactNode, useState, useEffect, Context, useMemo } from "react";
 
 import {
-  // Breakpoints,
   BpType,
   Breakpoint,
   OrderedBreakpoints,
   BreakpointsContextType,
   BreakpointsOrder,
 } from "./types";
-
-// import { BreakpointsContext } from "./BreakpointsContext";
 
 const getBreakpointsOrder = <BP extends BpType>(
   orderedBreakpoints: OrderedBreakpoints<BP>
@@ -47,6 +44,7 @@ type GetBreakpointMatchersConfig<BP extends BpType> = {
   breakpoints: BP;
 };
 
+// Generated the MediaQueryList matchers which will be used to detect the current breakpoint
 const getBreakpointMatchers = <BP extends BpType>({
   orderedBreakpoints,
   breakpoints,
@@ -102,6 +100,7 @@ export const createBreakpointsProvider = <BP extends BpType>(
   breakpoints: BP,
   BreakpointsContext: Context<BreakpointsContextType<BP>>
 ) => {
+  // Generate breakpoint metadata and matchers in outer scope to maintain referential integrity for react hooks
   const orderedBreakpoints = getOrderedBreakpoints(breakpoints);
   const breakpointOrder = getBreakpointsOrder(orderedBreakpoints);
   const breakpointMatchers = getBreakpointMatchers({
@@ -114,6 +113,7 @@ export const createBreakpointsProvider = <BP extends BpType>(
       getCurrentBreakpoint({ breakpointMatchers, orderedBreakpoints })
     );
 
+    // setup the event handlers for detecting breakpoint changes
     useEffect(() => {
       const matchersCleanerupFns: (() => void)[] = [];
 

--- a/packages/lab/src/breakpoints/BreakpointsProvider.tsx
+++ b/packages/lab/src/breakpoints/BreakpointsProvider.tsx
@@ -1,0 +1,159 @@
+import { ReactNode, useState, useEffect, Context, useMemo } from "react";
+
+import {
+  // Breakpoints,
+  BpType,
+  Breakpoint,
+  OrderedBreakpoints,
+  BreakpointsContextType,
+  BreakpointsOrder,
+} from "./types";
+
+// import { BreakpointsContext } from "./BreakpointsContext";
+
+const getBreakpointsOrder = <BP extends BpType>(
+  orderedBreakpoints: OrderedBreakpoints<BP>
+): BreakpointsOrder<BP> => {
+  const breakpointsOrder = Object.fromEntries(
+    orderedBreakpoints.map((breakpoint, order) => [breakpoint, order] as const)
+  );
+
+  return breakpointsOrder as BreakpointsOrder<BP>;
+};
+
+const getOrderedBreakpoints = <T extends Record<string, number>>(
+  breakpoints: T
+): (keyof T)[] => {
+  return Object.entries(breakpoints)
+    .sort(([bpA, bpAValue], [bpB, bpBValue]) => {
+      return bpAValue - bpBValue;
+    })
+    .map(([bp], order) => {
+      return bp;
+    });
+};
+
+type BreakpointsProviderProps = {
+  children?: ReactNode;
+};
+
+type BreakpointMatchers<BP extends BpType> = Record<
+  Breakpoint<BP>,
+  MediaQueryList
+>;
+
+type GetBreakpointMatchersConfig<BP extends BpType> = {
+  orderedBreakpoints: OrderedBreakpoints<BP>;
+  breakpoints: BP;
+};
+
+const getBreakpointMatchers = <BP extends BpType>({
+  orderedBreakpoints,
+  breakpoints,
+}: GetBreakpointMatchersConfig<BP>): BreakpointMatchers<BP> => {
+  const breakpointMatchers = Object.fromEntries(
+    orderedBreakpoints.map((breakpoint, i) => {
+      let matchPattern: string;
+
+      if (i === 0) {
+        matchPattern = `(max-width: ${
+          breakpoints[orderedBreakpoints[i + 1]]
+        }px)`;
+      } else if (i === orderedBreakpoints.length - 1) {
+        matchPattern = `(min-width: ${breakpoints[breakpoint]}px)`;
+      } else {
+        matchPattern = `(min-width: ${
+          breakpoints[breakpoint]
+        }px) and (max-width: ${breakpoints[orderedBreakpoints[i + 1]]}px)`;
+      }
+
+      const match = window.matchMedia(matchPattern);
+
+      return [breakpoint, match] as const;
+    })
+  );
+
+  return breakpointMatchers as BreakpointMatchers<BP>;
+};
+
+type GetCurrentBreakpointConfig<BP extends BpType> = {
+  breakpointMatchers: BreakpointMatchers<BP>;
+  orderedBreakpoints: OrderedBreakpoints<BP>;
+};
+
+const getCurrentBreakpoint = <BP extends BpType>({
+  breakpointMatchers,
+  orderedBreakpoints,
+}: GetCurrentBreakpointConfig<BP>) => {
+  const currentBreakpoint = orderedBreakpoints.find((bp) => {
+    return breakpointMatchers[bp].matches;
+  });
+
+  if (!currentBreakpoint) {
+    throw new Error(
+      "Current viewport matches none of the specified breakpoints"
+    );
+  }
+
+  return currentBreakpoint;
+};
+
+export const createBreakpointsProvider = <BP extends BpType>(
+  breakpoints: BP,
+  BreakpointsContext: Context<BreakpointsContextType<BP>>
+) => {
+  const orderedBreakpoints = getOrderedBreakpoints(breakpoints);
+  const breakpointOrder = getBreakpointsOrder(orderedBreakpoints);
+  const breakpointMatchers = getBreakpointMatchers({
+    orderedBreakpoints,
+    breakpoints,
+  });
+
+  const BreakpointsProvider = ({ children }: BreakpointsProviderProps) => {
+    const [currentBreakpoint, setCurrentBreakpoint] = useState(() =>
+      getCurrentBreakpoint({ breakpointMatchers, orderedBreakpoints })
+    );
+
+    useEffect(() => {
+      const matchersCleanerupFns: (() => void)[] = [];
+
+      orderedBreakpoints.forEach((breakpoint, i) => {
+        const match = breakpointMatchers[breakpoint];
+
+        const handleChange = (e: MediaQueryListEvent) => {
+          if (e.matches) {
+            setCurrentBreakpoint(breakpoint);
+          }
+        };
+
+        match.addEventListener("change", handleChange);
+
+        matchersCleanerupFns.push(() => {
+          match.removeEventListener("change", handleChange);
+        });
+      });
+
+      return () => {
+        matchersCleanerupFns.forEach((cleanup) => cleanup());
+      };
+    }, []);
+
+    const value: BreakpointsContextType<BP> = useMemo(
+      () => ({
+        breakpoints,
+        breakpointOrder,
+        currentBreakpoint,
+        orderedBreakpoints,
+      }),
+      [currentBreakpoint]
+    );
+
+    return (
+      <BreakpointsContext.Provider value={value}>
+        {children}
+      </BreakpointsContext.Provider>
+    );
+  };
+
+  return BreakpointsProvider;
+};

--- a/packages/lab/src/breakpoints/ResponsiveChildren.tsx
+++ b/packages/lab/src/breakpoints/ResponsiveChildren.tsx
@@ -1,0 +1,29 @@
+import { ReactNode } from "react";
+import { BpType, ResponsiveProp } from "./types";
+
+import { UseResponsiveValue } from "./useResponsiveValue";
+
+type ResponsiveChildrenProps<BP extends BpType> = Omit<
+  ResponsiveProp<ReactNode, BP>,
+  "default"
+> & {
+  children: ReactNode;
+};
+
+export const createResponsiveChildren = <BP extends BpType>(
+  useResponsiveValue: UseResponsiveValue
+) => {
+  const ResponsiveChildren = ({
+    children: childrenProp,
+    ...rest
+  }: ResponsiveChildrenProps<BP>) => {
+    const children = useResponsiveValue({
+      ...rest,
+      default: childrenProp,
+    });
+
+    return <>{children}</>;
+  };
+
+  return ResponsiveChildren;
+};

--- a/packages/lab/src/breakpoints/ResponsiveChildren.tsx
+++ b/packages/lab/src/breakpoints/ResponsiveChildren.tsx
@@ -9,10 +9,18 @@ type ResponsiveChildrenProps<BP extends BpType> = Omit<
 > & {
   children: ReactNode;
 };
-
+/**
+ * ResponsiveChildren is a component which allows you to change the rendered component based on the viewport E.g.:
+ * <ResponsiveChildren
+ *    md={<h1>Medium Viewport Child</h1>}
+ * >
+ *    <h1>Default Child</h1>
+ * </ResponsiveChildren>`
+ */
 export const createResponsiveChildren = <BP extends BpType>(
   useResponsiveValue: UseResponsiveValue
 ) => {
+  //
   const ResponsiveChildren = ({
     children: childrenProp,
     ...rest

--- a/packages/lab/src/breakpoints/createResponsiveSystem.tsx
+++ b/packages/lab/src/breakpoints/createResponsiveSystem.tsx
@@ -1,0 +1,37 @@
+import { BpType } from "./types";
+
+import { createBreakpointsContext } from "./BreakpointsContext";
+import { createBreakpointsProvider } from "./BreakpointsProvider";
+import { createUseResponsiveProps } from "./useResponsiveProps";
+import { createUseResponsiveValue } from "./useResponsiveValue";
+import { createMakeResponsive } from "./makeResponsive";
+import { createResponsiveChildren } from "./ResponsiveChildren";
+
+export const createResponsiveSystem = <BP extends BpType>(breakpoints: BP) => {
+  const { BreakpointsContext, useBreakpointsContext } =
+    createBreakpointsContext<BP>();
+
+  const BreakpointsProvider = createBreakpointsProvider<BP>(
+    breakpoints,
+    BreakpointsContext
+  );
+
+  const useResponsiveProps = createUseResponsiveProps<BP>(
+    useBreakpointsContext
+  );
+  const useResponsiveValue = createUseResponsiveValue<BP>(
+    useBreakpointsContext
+  );
+
+  const makeResponsive = createMakeResponsive<BP>(useResponsiveProps);
+
+  const ResponsiveChildren = createResponsiveChildren<BP>(useResponsiveValue);
+
+  return {
+    ResponsiveChildren,
+    BreakpointsProvider,
+    useResponsiveProps,
+    useResponsiveValue,
+    makeResponsive,
+  };
+};

--- a/packages/lab/src/breakpoints/createResponsiveSystem.tsx
+++ b/packages/lab/src/breakpoints/createResponsiveSystem.tsx
@@ -7,6 +7,14 @@ import { createUseResponsiveValue } from "./useResponsiveValue";
 import { createMakeResponsive } from "./makeResponsive";
 import { createResponsiveChildren } from "./ResponsiveChildren";
 
+/*
+ * We provide a factory for creating the various responsive hooks/components.
+ * This allows consumers to create their own breakpoint system with:
+ *  - custom names
+ *  - custom number of breakpoints
+ *  - custom widths for each breakpoint.
+ * The types of all the generated system elements will then be typed appropriately to their system
+ */
 export const createResponsiveSystem = <BP extends BpType>(breakpoints: BP) => {
   const { BreakpointsContext, useBreakpointsContext } =
     createBreakpointsContext<BP>();

--- a/packages/lab/src/breakpoints/index.ts
+++ b/packages/lab/src/breakpoints/index.ts
@@ -1,0 +1,28 @@
+import { createResponsiveSystem } from "./createResponsiveSystem";
+export * from "./types";
+
+const DEFAULT_BREAKPOINTS = {
+  xs: 0,
+  sm: 600,
+  md: 960,
+  lg: 1280,
+  xl: 1920,
+} as const;
+
+const {
+  BreakpointsProvider,
+  useResponsiveProps,
+  useResponsiveValue,
+  makeResponsive,
+  ResponsiveChildren,
+} = createResponsiveSystem(DEFAULT_BREAKPOINTS);
+
+export {
+  BreakpointsProvider,
+  useResponsiveProps,
+  useResponsiveValue,
+  makeResponsive,
+  createResponsiveSystem,
+  ResponsiveChildren,
+  DEFAULT_BREAKPOINTS,
+};

--- a/packages/lab/src/breakpoints/makeResponsive.tsx
+++ b/packages/lab/src/breakpoints/makeResponsive.tsx
@@ -1,0 +1,36 @@
+import {
+  ComponentPropsWithoutRef,
+  ComponentPropsWithRef,
+  ElementType,
+  forwardRef,
+} from "react";
+
+import { ResponsiveProps, BpType } from "./types";
+
+import { UseResponsiveProps } from "./useResponsiveProps";
+
+export const createMakeResponsive = <BP extends BpType>(
+  useResponsiveProps: UseResponsiveProps
+) => {
+  const makeResponsive = <T extends ElementType>(Component: T) => {
+    const Wrapped = forwardRef(
+      (
+        responsiveProps: ResponsiveProps<ComponentPropsWithoutRef<T>, BP>,
+        ref: ComponentPropsWithRef<T>["ref"]
+      ) => {
+        const props = useResponsiveProps(responsiveProps);
+
+        const combined = {
+          ...props,
+          ref,
+        } as ComponentPropsWithRef<T>;
+
+        return <Component {...combined} />;
+      }
+    );
+
+    return Wrapped;
+  };
+
+  return makeResponsive;
+};

--- a/packages/lab/src/breakpoints/makeResponsive.tsx
+++ b/packages/lab/src/breakpoints/makeResponsive.tsx
@@ -9,6 +9,10 @@ import { ResponsiveProps, BpType } from "./types";
 
 import { UseResponsiveProps } from "./useResponsiveProps";
 
+/**
+ * makeResponsive is a higher-order component which will enable all the props of a provided Component to take responsive values.
+ * E.g. `const ResponsiveComponent = makeResponsive(Component)`
+ */
 export const createMakeResponsive = <BP extends BpType>(
   useResponsiveProps: UseResponsiveProps
 ) => {

--- a/packages/lab/src/breakpoints/types.ts
+++ b/packages/lab/src/breakpoints/types.ts
@@ -1,0 +1,27 @@
+export type BpType = Record<string, number>;
+
+export type BreakpointsOrder<BP extends BpType> = BP;
+
+export type Breakpoint<BP extends BpType> = keyof BP;
+
+export type OrderedBreakpoints<BP extends BpType> = Breakpoint<BP>[];
+
+export type BreakpointsContextType<BP extends BpType> = {
+  breakpoints: BP;
+  breakpointOrder: BreakpointsOrder<BP>;
+  currentBreakpoint: Breakpoint<BP>;
+  orderedBreakpoints: OrderedBreakpoints<BP>;
+};
+
+export type ResponsiveProp<V extends unknown, BP extends BpType> = {
+  default: V;
+} & Partial<{
+  [K in keyof BP]: V;
+}>;
+
+export type ResponsiveProps<
+  Props extends Record<string, unknown>,
+  BP extends BpType
+> = {
+  [K in keyof Props]: ResponsiveProp<Props[K], BP> | Props[K];
+};

--- a/packages/lab/src/breakpoints/useResponsiveProps.tsx
+++ b/packages/lab/src/breakpoints/useResponsiveProps.tsx
@@ -1,6 +1,10 @@
 import { ResponsiveProps, BpType, BreakpointsContextType } from "./types";
 import { getResolvedResponsiveValue } from "./utils";
 
+/**
+ * useResponsiveProps will convert each key in an object into a responsive prop
+ * It is used within makeResponsive to make all props of a component responsive
+ */
 export const createUseResponsiveProps = <BP extends BpType>(
   useBreakpointsContext: () => BreakpointsContextType<BP>
 ) => {

--- a/packages/lab/src/breakpoints/useResponsiveProps.tsx
+++ b/packages/lab/src/breakpoints/useResponsiveProps.tsx
@@ -1,0 +1,28 @@
+import { ResponsiveProps, BpType, BreakpointsContextType } from "./types";
+import { getResolvedResponsiveValue } from "./utils";
+
+export const createUseResponsiveProps = <BP extends BpType>(
+  useBreakpointsContext: () => BreakpointsContextType<BP>
+) => {
+  const useResponsiveProps = <
+    Props extends Record<string, unknown>,
+    InnerBP extends BpType = BP
+  >(
+    responsiveProps: ResponsiveProps<Props, InnerBP>
+  ): Props => {
+    const context = useBreakpointsContext();
+
+    const resolvedProps = Object.fromEntries(
+      Object.entries(responsiveProps).map(
+        ([prop, value]) =>
+          [prop, getResolvedResponsiveValue(value, context)] as const
+      )
+    );
+
+    return resolvedProps as Props;
+  };
+
+  return useResponsiveProps;
+};
+
+export type UseResponsiveProps = ReturnType<typeof createUseResponsiveProps>;

--- a/packages/lab/src/breakpoints/useResponsiveValue.tsx
+++ b/packages/lab/src/breakpoints/useResponsiveValue.tsx
@@ -1,0 +1,19 @@
+import { BpType, ResponsiveProp, BreakpointsContextType } from "./types";
+import { getResolvedResponsiveValue } from "./utils";
+
+export const createUseResponsiveValue = <BP extends BpType>(
+  useBreakpointsContext: () => BreakpointsContextType<BP>
+) => {
+  const useResponsiveValue = <V extends unknown, InnerBP extends BP>(
+    responsiveValue: ResponsiveProp<V, InnerBP> | V
+  ) => {
+    const context = useBreakpointsContext();
+    const resolvedValue = getResolvedResponsiveValue(responsiveValue, context);
+
+    return resolvedValue;
+  };
+
+  return useResponsiveValue;
+};
+
+export type UseResponsiveValue = ReturnType<typeof createUseResponsiveValue>;

--- a/packages/lab/src/breakpoints/useResponsiveValue.tsx
+++ b/packages/lab/src/breakpoints/useResponsiveValue.tsx
@@ -1,6 +1,11 @@
 import { BpType, ResponsiveProp, BreakpointsContextType } from "./types";
 import { getResolvedResponsiveValue } from "./utils";
 
+/**
+ * useResponsiveValue will return the resolved value of a configuration based on the current viewport
+ * E.g. for  `const value = useResponsiveValue({ default: 'red', lg: 'green })`
+ * value will be 'red' on small screens but 'green on screens above large'
+ */
 export const createUseResponsiveValue = <BP extends BpType>(
   useBreakpointsContext: () => BreakpointsContextType<BP>
 ) => {

--- a/packages/lab/src/breakpoints/utils.ts
+++ b/packages/lab/src/breakpoints/utils.ts
@@ -1,0 +1,49 @@
+import { ResponsiveProp, BreakpointsContextType, BpType } from "./types";
+
+export const isResponsiveValue = <V extends unknown, BP extends BpType>(
+  value: V | ResponsiveProp<V, BP>
+): value is ResponsiveProp<V, BP> => {
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    "default" in (value as Record<string, unknown>)
+  ) {
+    return true;
+  }
+  return false;
+};
+
+export const getResolvedResponsiveValue = <
+  V extends unknown,
+  BP extends BpType
+>(
+  responsiveValue: ResponsiveProp<V, BP> | V,
+  {
+    breakpointOrder,
+    currentBreakpoint,
+    orderedBreakpoints,
+  }: BreakpointsContextType<BP>
+) => {
+  if (!isResponsiveValue(responsiveValue)) {
+    return responsiveValue;
+  }
+
+  const { default: defaultValue, ...restValues } = responsiveValue;
+
+  let resolvedValue: V = defaultValue;
+
+  const currentOrder = breakpointOrder[currentBreakpoint];
+  let i: number = currentOrder;
+  while (i >= 0) {
+    const bp = orderedBreakpoints[i];
+    if (bp in restValues) {
+      resolvedValue = restValues[bp as keyof typeof restValues] as V;
+      break;
+    } else {
+      i = i - 1;
+    }
+  }
+
+  return resolvedValue;
+};

--- a/packages/lab/src/index.ts
+++ b/packages/lab/src/index.ts
@@ -20,6 +20,7 @@ export * from "./avatar";
 export * from "./badge";
 export * from "./banner";
 export * from "./breadcrumbs";
+export * from "./breakpoints";
 export * from "./button-bar";
 export * from "./calendar";
 export * from "./carousel";

--- a/packages/lab/stories/breakpoints.stories.tsx
+++ b/packages/lab/stories/breakpoints.stories.tsx
@@ -5,6 +5,7 @@ import {
   BreakpointsProvider,
   useResponsiveValue,
   useResponsiveProps,
+  createResponsiveSystem,
 } from "@salt-ds/lab";
 
 export default {
@@ -115,5 +116,30 @@ export const UseResponsivePropsExample = () => {
     <BreakpointsProvider>
       <UseResponsivePropsExampleContent />
     </BreakpointsProvider>
+  );
+};
+
+const customResponsiveSystem = createResponsiveSystem({
+  tiny: 0,
+  kindabig: 800,
+  mahoosive: 1200,
+});
+
+const CustomResponsiveCard = customResponsiveSystem.makeResponsive(Card);
+
+export const CustomBreakpointsExample = () => {
+  return (
+    <customResponsiveSystem.BreakpointsProvider>
+      <CustomResponsiveCard
+        style={{
+          default: { background: "red" },
+          tiny: { background: "tomato", color: "white" },
+          kindabig: { background: "goldenrod", color: "black" },
+          mahoosive: { background: "darkgrey", color: "white" },
+        }}
+      >
+        Card 1
+      </CustomResponsiveCard>
+    </customResponsiveSystem.BreakpointsProvider>
   );
 };

--- a/packages/lab/stories/breakpoints.stories.tsx
+++ b/packages/lab/stories/breakpoints.stories.tsx
@@ -1,0 +1,119 @@
+import { StackLayout, Button, Card } from "@salt-ds/core";
+import {
+  makeResponsive,
+  ResponsiveChildren,
+  BreakpointsProvider,
+  useResponsiveValue,
+  useResponsiveProps,
+} from "@salt-ds/lab";
+
+export default {
+  title: "Lab/Responsive Props",
+};
+
+const ResponsiveStackLayout = makeResponsive(StackLayout);
+
+export const MakeResponsiveExample = () => (
+  <BreakpointsProvider>
+    <ResponsiveStackLayout
+      gap={{
+        default: 0,
+        sm: 1,
+        md: 2,
+        lg: 3,
+        xl: 4,
+      }}
+      direction={{
+        default: "column",
+        md: "row",
+      }}
+    >
+      <Button>Button 1</Button>
+      <Button>Button 2</Button>
+      <Button>Button 3</Button>
+      <Button>Button 4</Button>
+    </ResponsiveStackLayout>
+  </BreakpointsProvider>
+);
+
+export const ResponsiveChildrenExample = () => {
+  return (
+    <BreakpointsProvider>
+      <ResponsiveChildren
+        xs={<h1>XS</h1>}
+        sm={<h1>SM</h1>}
+        md={<h1>MD</h1>}
+        lg={<h1>LG</h1>}
+        xl={<h1>XL</h1>}
+      >
+        <h1>Default</h1>
+      </ResponsiveChildren>
+    </BreakpointsProvider>
+  );
+};
+
+const UseResponsiveValueExampleContent = () => {
+  const backgroundColor = useResponsiveValue({
+    default: "blue",
+    xs: "red",
+    sm: "green",
+    md: "tomato",
+    lg: "goldenrod",
+    xl: "cyan",
+  });
+
+  return (
+    <BreakpointsProvider>
+      <Card
+        style={{
+          backgroundColor,
+        }}
+      >
+        Background changes with the viewport size
+      </Card>
+    </BreakpointsProvider>
+  );
+};
+
+export const UseResponsiveValueExample = () => {
+  return (
+    <BreakpointsProvider>
+      <UseResponsiveValueExampleContent />
+    </BreakpointsProvider>
+  );
+};
+
+const UseResponsivePropsExampleContent = () => {
+  const { backgroundColor, color } = useResponsiveProps({
+    color: {
+      default: "white",
+      lg: "black",
+    },
+    backgroundColor: {
+      default: "black",
+      sm: "darkgrey",
+      md: "darkblue",
+      lg: "lightpink",
+      xl: "white",
+    },
+  });
+
+  return (
+    <Card
+      style={{
+        backgroundColor,
+        color,
+      }}
+    >
+      Background and text color change but at different breakpoints
+    </Card>
+  );
+};
+
+export const UseResponsivePropsExample = () => {
+  return (
+    <BreakpointsProvider>
+      <UseResponsivePropsExampleContent />
+    </BreakpointsProvider>
+  );
+};


### PR DESCRIPTION
See [Storybook examples](https://aaa0656c.saltdesignsystem-storybook.pages.dev/?path=/story/lab-responsive-props--make-responsive-example)

The idea here is to allow consumers to add responsive behaviour to their components without baking the logic into every component in our design system. This leaves room for an alternative/similar system based off container queries which could be more useful in certain circumstances e.g. micro-frontends.

Consumers would need to add a `<BreakpointProvider>` at the root of their application.

They can then use various tools to add responsive behaviour
- `makeResponsive` is a higher-order-component which will turn all the props of a given component into responsive props e.g:

```jsx
<Component color="white" />
````

could then be used as 

````jsx
<ResponsiveComponent color={{ default: "white", lg: "black" }} />
````

- `useResponsiveValue` is a hook which will return a resolved value based on the viewport e.g:

`const value = useResponsiveValue({ default: 'Small', lg: 'Large' })`

value will be 'Small' on small viewports and 'Large' on large viewports

- `useResponsiveProps` is similar to `useResponsive value` except you pass an object to the hook, and each key/value pair in that object will be turned into it's own responsive prop. E.g:

```
const value = useResponsiveProps({ 
    text: {
        default: 'Small',
        lg: 'Large'
    },
    color: {
        default: 'red',
        md: 'green'
    }
})
```

On small screens text is 'Small' and color is 'red'. On medium screens text is still 'Small' and but color is 'green'. On large screens text is 'Large' and color is 'green'.

- ResponsiveChildren is a component which allows you to pass different ReactNodes to be used at different viewport sizes E.g.
```jsx
<ResponsiveChildren md={<h1>Medium</h1>)>
    <button>Default</button>
</ResponsiveChildren>
```
will show a button by default but on screens above medium it will show an h1.



Other things to note
- All components/hooks are typed with the appropriate breakpoints
- a responsive configuration must pass a 'default' value which will be used as a fallback if none of the provided breakpoint values are matched
- You don't have to use a responsive object for every prop of a component wrapped with `makeResponsive`. You can just provide a value as usual if you don't want that prop to have responsive behaviour.
- The implementation uses `matchMedia` under the hood. Components only re-render on breakpoint changes
- If a consumer is using different viewports then they can create their own responsive system using `createResponsiveSystem` e.g:

```
 const { 
    BreakpointsProvider,
    useResponsiveProps,
    useResponsiveValue,
    makeResponsive,
    ResponsiveChildren
} = createResponsiveSystem({ tiny: 0, kindabig: 800, mahoosive: 1000 });
```

All the returned components/hooks/HOC will then be typed appropriately.


We should also think about how we could make this available. There are currently no dependancies on the design system itself, and the responsive utilities can be used on any component (including primitives). So it could be a stand-alone package.

