### PR TITLE
Fix ag-grid uitk theme floating filter input height in High density

### DIFF
--- a/.changeset/seven-dogs-repeat.md
+++ b/.changeset/seven-dogs-repeat.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/ag-grid-theme": patch
+---
+
+Fix ag-grid uitk theme floating filter input height for High density

--- a/.changeset/seven-dogs-repeat.md
+++ b/.changeset/seven-dogs-repeat.md
@@ -2,4 +2,4 @@
 "@salt-ds/ag-grid-theme": patch
 ---
 
-Fix ag-grid uitk theme floating filter input height for High density
+Fix ag-grid uitk theme floating filter input height in High density

--- a/packages/ag-grid-theme/css/uitk-ag-theme.scss
+++ b/packages/ag-grid-theme/css/uitk-ag-theme.scss
@@ -219,7 +219,7 @@ $ag-theme-uitk-params-high: map-merge(
     font-size: 10px,
     header-column-separator-height: 10px,
     cell-horizontal-padding: 5px,
-    list-item-height: 60px,
+    list-item-height: 24px,
     icon-size: 12px,
   )
 );


### PR DESCRIPTION
### Changes in this PR

The `list-item-height` variable was set to 60px (same height as "touch" density) for HD.
This was making the dropdown element inside the floating filter taller than it should be in HD.

### Before
![image](https://user-images.githubusercontent.com/15366204/221846674-c11bb3d7-aef2-4022-8545-7962ddfcb817.png)


### After
![image](https://user-images.githubusercontent.com/15366204/221846178-6e4e6eba-7f29-45eb-81f3-82f841028029.png)
