### PR TITLE
Add new opacity token in palette for readonly backgrounds

### DIFF
--- a/.changeset/shy-kids-cheer.md
+++ b/.changeset/shy-kids-cheer.md
@@ -2,7 +2,7 @@
 "@salt-ds/theme": minor
 ---
 
-Add new opacity token for readonly backgrounds
+Added a new opacity token for readonly backgrounds
 
 ```diff
 - --salt-color-white-fade-background-readonly: rgba(255, 255, 255, var(--salt-palette-opacity-readonly));

--- a/.changeset/shy-kids-cheer.md
+++ b/.changeset/shy-kids-cheer.md
@@ -1,0 +1,17 @@
+---
+"@salt-ds/theme": minor
+---
+
+Add new opacity token for readonly backgrounds
+
+```diff
+- --salt-color-white-fade-background-readonly: rgba(255, 255, 255, var(--salt-palette-opacity-readonly));
+- --salt-color-gray-20-fade-background-readonly: rgba(234, 237, 239, var(--salt-palette-opacity-readonly));
+- --salt-color-gray-600-fade-background-readonly: rgba(47, 49, 54, var(--salt-palette-opacity-readonly));
+- --salt-color-gray-800-fade-background-readonly: rgba(36, 37, 38, var(--salt-palette-opacity-readonly));
++ --salt-palette-opacity-background-readonly: var(--salt-opacity-1)
++ --salt-color-white-fade-background-readonly: rgba(255, 255, 255, var(--salt-palette-opacity-background-readonly));
++ --salt-color-gray-20-fade-background-readonly: rgba(234, 237, 239, var(--salt-palette-opacity-background-readonly));
++ --salt-color-gray-600-fade-background-readonly: rgba(47, 49, 54, var(--salt-palette-opacity-background-readonly));
++ --salt-color-gray-800-fade-background-readonly: rgba(36, 37, 38, var(--salt-palette-opacity-background-readonly));
+```

--- a/packages/theme/css/foundations/fade.css
+++ b/packages/theme/css/foundations/fade.css
@@ -30,10 +30,10 @@
   --salt-color-orange-600-fade-background: rgba(224, 101, 25, var(--salt-palette-opacity-background));
   --salt-color-white-fade-background: rgba(255, 255, 255, var(--salt-palette-opacity-background));
 
-  --salt-color-white-fade-background-readonly: rgba(255, 255, 255, var(--salt-palette-opacity-readonly));
-  --salt-color-gray-20-fade-background-readonly: rgba(234, 237, 239, var(--salt-palette-opacity-readonly));
-  --salt-color-gray-600-fade-background-readonly: rgba(47, 49, 54, var(--salt-palette-opacity-readonly));
-  --salt-color-gray-800-fade-background-readonly: rgba(36, 37, 38, var(--salt-palette-opacity-readonly));
+  --salt-color-white-fade-background-readonly: rgba(255, 255, 255, var(--salt-palette-opacity-background-readonly));
+  --salt-color-gray-20-fade-background-readonly: rgba(234, 237, 239, var(--salt-palette-opacity-background-readonly));
+  --salt-color-gray-600-fade-background-readonly: rgba(47, 49, 54, var(--salt-palette-opacity-background-readonly));
+  --salt-color-gray-800-fade-background-readonly: rgba(36, 37, 38, var(--salt-palette-opacity-background-readonly));
 
   --salt-color-black-fade-backdrop: rgba(36, 37, 38, var(--salt-palette-opacity-backdrop));
 

--- a/packages/theme/css/foundations/palette.css
+++ b/packages/theme/css/foundations/palette.css
@@ -1,6 +1,7 @@
 /* Opacities */
 .salt-theme {
   --salt-palette-opacity-background: var(--salt-opacity-3);
+  --salt-palette-opacity-background-readonly: var(--salt-opacity-1);
   --salt-palette-opacity-border: var(--salt-opacity-3);
   --salt-palette-opacity-border-readonly: var(--salt-opacity-2);
   --salt-palette-opacity-fill: var(--salt-opacity-3);


### PR DESCRIPTION
Added `--salt-palette-opacity-background-readonly: var(--salt-opacity-1)`

Appropriate fade tokens now point to this bg