### PR TITLE
Tweak shadow-5 token

### DIFF
--- a/.changeset/bright-hats-argue.md
+++ b/.changeset/bright-hats-argue.md
@@ -2,7 +2,7 @@
 "@salt-ds/theme": patch
 ---
 
-Tweak shadow token value
+Fixed the shadow token value
 
 ```diff
 - --salt-shadow-5: 0 12px 40px 5px var(--salt-shadow-5-color);

--- a/.changeset/bright-hats-argue.md
+++ b/.changeset/bright-hats-argue.md
@@ -1,0 +1,10 @@
+---
+"@salt-ds/theme": patch
+---
+
+Tweak shadow token value
+
+```diff
+- --salt-shadow-5: 0 12px 40px 5px var(--salt-shadow-5-color);
++ --salt-shadow-5: 0 12px 40px 0 var(--salt-shadow-5-color);
+```

--- a/packages/theme/css/foundations/shadow.css
+++ b/packages/theme/css/foundations/shadow.css
@@ -20,5 +20,5 @@
   --salt-shadow-2: 0 2px 4px 0 var(--salt-shadow-2-color);
   --salt-shadow-3: 0 4px 8px 0 var(--salt-shadow-3-color);
   --salt-shadow-4: 0 6px 10px 0 var(--salt-shadow-4-color);
-  --salt-shadow-5: 0 12px 40px 5px var(--salt-shadow-5-color);
+  --salt-shadow-5: 0 12px 40px 0 var(--salt-shadow-5-color);
 }


### PR DESCRIPTION
The spread has the old spec value of 5px, needs replacing to be consistently 0 across shadows