### PR TITLE
Palette warning token change

### DIFF
--- a/.changeset/orange-sloths-count.md
+++ b/.changeset/orange-sloths-count.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/theme": minor
+---
+
+Theme update: changed the value of `--salt-palette-warning-border` and `--salt-palette-warning-foreground` to `--salt-color-orange-700` in light mode to fix accessibility issues

--- a/packages/theme/css/foundations/palette.css
+++ b/packages/theme/css/foundations/palette.css
@@ -79,8 +79,8 @@
   --salt-palette-success-border: var(--salt-color-green-500);
   --salt-palette-success-foreground: var(--salt-color-green-500);
   --salt-palette-warning-background-emphasize: var(--salt-color-orange-10);
-  --salt-palette-warning-border: var(--salt-color-orange-500);
-  --salt-palette-warning-foreground: var(--salt-color-orange-500);
+  --salt-palette-warning-border: var(--salt-color-orange-700);
+  --salt-palette-warning-foreground: var(--salt-color-orange-700);
 
   /* Measure */
   --salt-palette-measured-fill: var(--salt-color-blue-500);


### PR DESCRIPTION
Warning foreground and border tokens in light mode now use `--salt-color-orange-700` to fix accessibility issue found in data grid work