### PR TITLE
Add color name to color

### DIFF
--- a/packages/lab/src/__tests__/color-chooser/Color.spec.ts
+++ b/packages/lab/src/__tests__/color-chooser/Color.spec.ts
@@ -17,6 +17,24 @@ describe("Color", () => {
       expect(newColor.rgba).toEqual({ a: 1, b: 255, g: 255, r: 255 });
     });
   });
+  describe("get colorName", () => {
+    it("should get white value", () => {
+      const newColor = Color.makeColorFromRGB(255, 255, 255, 1);
+      expect(newColor.colorName).toEqual("White");
+    });
+    it("should get transparent value", () => {
+      const newColor = Color.makeColorFromRGB(12, 34, 56, 0);
+      expect(newColor.colorName).toEqual("Transparent");
+    });
+    it("should get the salt palette name", () => {
+      const newColor = Color.makeColorFromRGB(214, 85, 19, 1);
+      expect(newColor.colorName).toEqual("Orange700");
+    });
+    it("should get undefined with unknown color", () => {
+      const newColor = Color.makeColorFromRGB(1, 2, 3, 1);
+      expect(newColor.colorName).toBeUndefined();
+    });
+  });
   describe("makeColorFromHex", () => {
     it("should make the correct color object with 6 digit hex", () => {
       const newColor = Color.makeColorFromHex("#4E8FC0");

--- a/packages/lab/src/__tests__/color-chooser/ColorHelpers.spec.ts
+++ b/packages/lab/src/__tests__/color-chooser/ColorHelpers.spec.ts
@@ -51,6 +51,24 @@ describe("Color chooser helpers", () => {
     it("should just return the hex value with no alpha if it is not a Salt color and alpha slider is disabled", () => {
       expect(getColorNameByHexValue("#D1F4C780", true)).toEqual("#D1F4C7");
     });
+
+    describe("WHEN disableFallBackToHex", () => {
+      it("should get the correct Salt color name if passed 6 digit hex", () => {
+        expect(
+          getColorNameByHexValue("#D1F4C9", false, undefined, true)
+        ).toEqual("Green10");
+      });
+      it("should get the correct Salt color name if passed 8 digit hex", () => {
+        expect(
+          getColorNameByHexValue("#D1F4C980", false, undefined, true)
+        ).toEqual("Green10");
+      });
+      it("should just return undefined if it is not a Salt color and alpha slider is disabled", () => {
+        expect(
+          getColorNameByHexValue("#D1F4C780", true, undefined, true)
+        ).toBeUndefined();
+      });
+    });
   });
   describe("convertColorMapValueToHex", () => {
     it("Should convert rgb string into hex value", () => {

--- a/packages/lab/src/__tests__/color-chooser/color-utils.spec.tsx
+++ b/packages/lab/src/__tests__/color-chooser/color-utils.spec.tsx
@@ -1,0 +1,17 @@
+import { isTransparent } from "../../color-chooser/color-utils";
+
+describe("isTransparent", () => {
+  test("should be false WHEN given 6 digits hex", () => {
+    expect(isTransparent("#123123")).toBe(false);
+  });
+  test("should be false WHEN given nothing", () => {
+    expect(isTransparent()).toBe(false);
+  });
+  test("should be false WHEN given 8 digits hex and alpha not 0", () => {
+    expect(isTransparent("#12312308")).toBe(false);
+  });
+  test("should be true WHEN given 8 digits hex and alpha is 0", () => {
+    expect(isTransparent("#00000000")).toBe(true);
+    expect(isTransparent("#12345600")).toBe(true);
+  });
+});

--- a/packages/lab/src/color-chooser/Color.ts
+++ b/packages/lab/src/color-chooser/Color.ts
@@ -1,4 +1,5 @@
 import tinycolor from "tinycolor2";
+import { getColorNameByHexValue } from "./ColorHelpers";
 
 export type RGBAValue = {
   r: number;
@@ -23,6 +24,16 @@ export class Color {
       b: this.color.toRgb().b,
       a: this.color.toRgb().a,
     };
+  }
+
+  /** E.g. Orange800 */
+  public get colorName(): string | undefined {
+    return getColorNameByHexValue(
+      this.color.toHex8String(),
+      false,
+      undefined,
+      true
+    );
   }
 
   static makeColorFromHex(hexValue: string | undefined): Color | undefined {

--- a/packages/lab/src/color-chooser/ColorHelpers.ts
+++ b/packages/lab/src/color-chooser/ColorHelpers.ts
@@ -5,7 +5,9 @@ import { isTransparent } from "./color-utils";
 export function getColorNameByHexValue(
   hexValue: string | undefined,
   disableAlpha = false,
-  saltColorOverrides?: Record<string, string>
+  saltColorOverrides?: Record<string, string>,
+  /** Whe disabled, color names not recognized will be undefined instead of hex values */
+  disableFallBackToHex = false
 ): string | undefined {
   const hexNoAlpha = hexValueWithoutAlpha(hexValue);
   const saltColors = saltColorOverrides ?? saltColorMap;
@@ -36,7 +38,7 @@ export function getColorNameByHexValue(
     return hexValue.charAt(0) + hexValue.slice(1).toLowerCase();
   }
 
-  return getHexValue(hexValue, disableAlpha);
+  return disableFallBackToHex ? undefined : getHexValue(hexValue, disableAlpha);
 }
 
 export function hexValueWithoutAlpha(

--- a/packages/lab/src/color-chooser/color-utils.ts
+++ b/packages/lab/src/color-chooser/color-utils.ts
@@ -1,3 +1,3 @@
 export const isTransparent = (color?: string): boolean => {
-  return color?.toLowerCase() === "#00000000";
+  return color ? /#[\da-f]{6}00/i.test(color) : false;
 };


### PR DESCRIPTION
Currently when choosing color using `ColorChooser`, `Color` object doesn't contain color name (e.g. orange 700) even if picking color from the swatches.  Adding `colorName` so at least there is a way to get the information when needed.

Also fixed `isTransparent` so any hex with `00` alpha value will return true.