### PR TITLE
Palette success token change

### DIFF
--- a/.changeset/smooth-rules-drum.md
+++ b/.changeset/smooth-rules-drum.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/theme": minor
+---
+
+Theme update: changed the value of `--salt-palette-success-border` and `--salt-palette-success-foreground` to `--salt-color-green-400` in dark mode to fix accessibility issues

--- a/packages/theme/css/foundations/palette.css
+++ b/packages/theme/css/foundations/palette.css
@@ -206,8 +206,8 @@
   --salt-palette-info-border: var(--salt-color-blue-500);
   --salt-palette-info-foreground: var(--salt-color-blue-500);
   --salt-palette-success-background-emphasize: var(--salt-color-green-900);
-  --salt-palette-success-border: var(--salt-color-green-500);
-  --salt-palette-success-foreground: var(--salt-color-green-500);
+  --salt-palette-success-border: var(--salt-color-green-400);
+  --salt-palette-success-foreground: var(--salt-color-green-400);
   --salt-palette-warning-background-emphasize: var(--salt-color-orange-900);
   --salt-palette-warning-border: var(--salt-color-orange-500);
   --salt-palette-warning-foreground: var(--salt-color-orange-500);


### PR DESCRIPTION
Success foreground and border tokens in dark mode now use `--salt-color-green-400` to fix accessibility issue found in data grid work