### PR TITLE
Font family on text component

### DIFF
--- a/.changeset/real-numbers-shake.md
+++ b/.changeset/real-numbers-shake.md
@@ -1,0 +1,6 @@
+---
+"@salt-ds/core": patch
+---
+
+- Fix Text components doesn't have `--salt-text-fontFamily` applied.
+- Apply new font family variables from `@salt-ds/theme` to Text components

--- a/.changeset/tasty-goats-applaud.md
+++ b/.changeset/tasty-goats-applaud.md
@@ -2,7 +2,7 @@
 "@salt-ds/theme": patch
 ---
 
-New font family css variable for all text components which points to `--salt-text-fontFamily`.
+New font family css variable for all text components which point to `--salt-typography-fontFamily`.
 
 ```
 --salt-text-display1-fontFamily

--- a/.changeset/tasty-goats-applaud.md
+++ b/.changeset/tasty-goats-applaud.md
@@ -1,0 +1,16 @@
+---
+"@salt-ds/theme": patch
+---
+
+New font family css variable for all text components which points to `--salt-text-fontFamily`.
+
+```
+--salt-text-display1-fontFamily
+--salt-text-display2-fontFamily
+--salt-text-display3-fontFamily
+--salt-text-h1-fontFamily
+--salt-text-h2-fontFamily
+--salt-text-h3-fontFamily
+--salt-text-h4-fontFamily
+--salt-text-label-fontFamily
+```

--- a/packages/core/src/__tests__/__e2e__/text/Text.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/text/Text.cy.tsx
@@ -250,3 +250,16 @@ describe("GIVEN Text component with styleAs=display3", () => {
     });
   });
 });
+
+describe.only("GIVEN Text component within font family CSS var override", () => {
+  it("should have non-default font family applied", () => {
+    cy.mount(
+      <div style={{ "--salt-text-fontFamily": "Lato" } as React.CSSProperties}>
+        <Text>{textExample}</Text>
+      </div>
+    );
+    cy.get(".saltText")
+      .should("have.class", "saltText")
+      .and("have.css", "font-family", "Lato");
+  });
+});

--- a/packages/core/src/text/Text.css
+++ b/packages/core/src/text/Text.css
@@ -1,6 +1,7 @@
 /* Main css class. Style for body text */
 .saltText {
   color: var(--saltText-color, var(--text-color));
+  font-family: var(--saltText-fontFamily, var(--salt-text-fontFamily));
 }
 
 .saltText::selection {
@@ -48,6 +49,7 @@
 
 /* Display 1 */
 .saltText-display1.saltText {
+  font-family: var(--salt-text-display1-fontFamily);
   font-size: var(--salt-text-display1-fontSize);
   font-weight: var(--salt-text-display1-fontWeight);
   line-height: var(--salt-text-display1-lineHeight);
@@ -55,6 +57,7 @@
 
 /* Display 2 */
 .saltText-display2.saltText {
+  font-family: var(--salt-text-display2-fontFamily);
   font-size: var(--salt-text-display2-fontSize);
   font-weight: var(--salt-text-display2-fontWeight);
   line-height: var(--salt-text-display2-lineHeight);
@@ -62,6 +65,7 @@
 
 /* Display 3 */
 .saltText-display3.saltText {
+  font-family: var(--salt-text-display3-fontFamily);
   font-size: var(--salt-text-display3-fontSize);
   font-weight: var(--salt-text-display3-fontWeight);
   line-height: var(--salt-text-display3-lineHeight);
@@ -70,6 +74,7 @@
 /* Heading 1 */
 h1.saltText,
 .saltText-h1.saltText {
+  font-family: var(--salt-text-h1-fontFamily);
   font-size: var(--salt-text-h1-fontSize);
   font-weight: var(--salt-text-h1-fontWeight);
   line-height: var(--salt-text-h1-lineHeight);
@@ -90,6 +95,7 @@ h1.saltText small,
 /* Heading 2 */
 h2.saltText,
 .saltText-h2.saltText {
+  font-family: var(--salt-text-h2-fontFamily);
   font-size: var(--salt-text-h2-fontSize);
   font-weight: var(--salt-text-h2-fontWeight);
   line-height: var(--salt-text-h2-lineHeight);
@@ -110,6 +116,7 @@ h2.saltText small,
 /* Heading 3 */
 h3.saltText,
 .saltText-h3.saltText {
+  font-family: var(--salt-text-h3-fontFamily);
   font-size: var(--salt-text-h3-fontSize);
   font-weight: var(--salt-text-h3-fontWeight);
   line-height: var(--salt-text-h3-lineHeight);
@@ -130,6 +137,7 @@ h3.saltText small,
 /* Heading 4 */
 h4.saltText,
 .saltText-h4.saltText {
+  font-family: var(--salt-text-h4-fontFamily);
   font-size: var(--salt-text-h4-fontSize);
   font-weight: var(--salt-text-h4-fontWeight);
   line-height: var(--salt-text-h4-lineHeight);
@@ -150,6 +158,7 @@ h4.saltText small,
 /* Label */
 label.saltText,
 .saltText-label.saltText {
+  font-family: var(--salt-text-label-fontFamily);
   font-size: var(--salt-text-label-fontSize);
   line-height: var(--salt-text-label-lineHeight);
   font-weight: var(--salt-text-fontWeight);

--- a/packages/theme/css/characteristics/text.css
+++ b/packages/theme/css/characteristics/text.css
@@ -13,39 +13,47 @@
   --salt-text-fontWeight-strong: var(--salt-typography-fontWeight-semiBold);
 
   /* H1 */
+  --salt-text-h1-fontFamily: var(--salt-text-fontFamily);
   --salt-text-h1-fontWeight: var(--salt-typography-fontWeight-bold);
   --salt-text-h1-fontWeight-small: var(--salt-typography-fontWeight-medium);
   --salt-text-h1-fontWeight-strong: var(--salt-typography-fontWeight-extraBold);
 
   /* H2 */
+  --salt-text-h2-fontFamily: var(--salt-text-fontFamily);
   --salt-text-h2-fontWeight: var(--salt-typography-fontWeight-semiBold);
   --salt-text-h2-fontWeight-small: var(--salt-typography-fontWeight-regular);
   --salt-text-h2-fontWeight-strong: var(--salt-typography-fontWeight-bold);
 
   /* H3 */
+  --salt-text-h3-fontFamily: var(--salt-text-fontFamily);
   --salt-text-h3-fontWeight: var(--salt-typography-fontWeight-semiBold);
   --salt-text-h3-fontWeight-small: var(--salt-typography-fontWeight-regular);
   --salt-text-h3-fontWeight-strong: var(--salt-typography-fontWeight-bold);
 
   /* H4 */
+  --salt-text-h4-fontFamily: var(--salt-text-fontFamily);
   --salt-text-h4-fontWeight: var(--salt-typography-fontWeight-semiBold);
   --salt-text-h4-fontWeight-small: var(--salt-typography-fontWeight-regular);
   --salt-text-h4-fontWeight-strong: var(--salt-typography-fontWeight-bold);
 
   /* Label */
+  --salt-text-label-fontFamily: var(--salt-text-fontFamily);
   --salt-text-label-fontWeight: var(--salt-typography-fontWeight-regular);
   --salt-text-label-fontWeight-small: var(--salt-typography-fontWeight-light);
   --salt-text-label-fontWeight-strong: var(--salt-typography-fontWeight-semiBold);
 
   /* Display text */
+  --salt-text-display1-fontFamily: var(--salt-text-fontFamily);
   --salt-text-display1-fontWeight: var(--salt-typography-fontWeight-semiBold);
   --salt-text-display1-fontWeight-strong: var(--salt-typography-fontWeight-bold);
   --salt-text-display1-fontWeight-small: var(--salt-typography-fontWeight-regular);
 
+  --salt-text-display2-fontFamily: var(--salt-text-fontFamily);
   --salt-text-display2-fontWeight: var(--salt-typography-fontWeight-semiBold);
   --salt-text-display2-fontWeight-strong: var(--salt-typography-fontWeight-bold);
   --salt-text-display2-fontWeight-small: var(--salt-typography-fontWeight-regular);
 
+  --salt-text-display3-fontFamily: var(--salt-text-fontFamily);
   --salt-text-display3-fontWeight: var(--salt-typography-fontWeight-semiBold);
   --salt-text-display3-fontWeight-strong: var(--salt-typography-fontWeight-bold);
   --salt-text-display3-fontWeight-small: var(--salt-typography-fontWeight-regular);

--- a/packages/theme/css/characteristics/text.css
+++ b/packages/theme/css/characteristics/text.css
@@ -13,47 +13,47 @@
   --salt-text-fontWeight-strong: var(--salt-typography-fontWeight-semiBold);
 
   /* H1 */
-  --salt-text-h1-fontFamily: var(--salt-text-fontFamily);
+  --salt-text-h1-fontFamily: var(--salt-typography-fontFamily);
   --salt-text-h1-fontWeight: var(--salt-typography-fontWeight-bold);
   --salt-text-h1-fontWeight-small: var(--salt-typography-fontWeight-medium);
   --salt-text-h1-fontWeight-strong: var(--salt-typography-fontWeight-extraBold);
 
   /* H2 */
-  --salt-text-h2-fontFamily: var(--salt-text-fontFamily);
+  --salt-text-h2-fontFamily: var(--salt-typography-fontFamily);
   --salt-text-h2-fontWeight: var(--salt-typography-fontWeight-semiBold);
   --salt-text-h2-fontWeight-small: var(--salt-typography-fontWeight-regular);
   --salt-text-h2-fontWeight-strong: var(--salt-typography-fontWeight-bold);
 
   /* H3 */
-  --salt-text-h3-fontFamily: var(--salt-text-fontFamily);
+  --salt-text-h3-fontFamily: var(--salt-typography-fontFamily);
   --salt-text-h3-fontWeight: var(--salt-typography-fontWeight-semiBold);
   --salt-text-h3-fontWeight-small: var(--salt-typography-fontWeight-regular);
   --salt-text-h3-fontWeight-strong: var(--salt-typography-fontWeight-bold);
 
   /* H4 */
-  --salt-text-h4-fontFamily: var(--salt-text-fontFamily);
+  --salt-text-h4-fontFamily: var(--salt-typography-fontFamily);
   --salt-text-h4-fontWeight: var(--salt-typography-fontWeight-semiBold);
   --salt-text-h4-fontWeight-small: var(--salt-typography-fontWeight-regular);
   --salt-text-h4-fontWeight-strong: var(--salt-typography-fontWeight-bold);
 
   /* Label */
-  --salt-text-label-fontFamily: var(--salt-text-fontFamily);
+  --salt-text-label-fontFamily: var(--salt-typography-fontFamily);
   --salt-text-label-fontWeight: var(--salt-typography-fontWeight-regular);
   --salt-text-label-fontWeight-small: var(--salt-typography-fontWeight-light);
   --salt-text-label-fontWeight-strong: var(--salt-typography-fontWeight-semiBold);
 
   /* Display text */
-  --salt-text-display1-fontFamily: var(--salt-text-fontFamily);
+  --salt-text-display1-fontFamily: var(--salt-typography-fontFamily);
   --salt-text-display1-fontWeight: var(--salt-typography-fontWeight-semiBold);
   --salt-text-display1-fontWeight-strong: var(--salt-typography-fontWeight-bold);
   --salt-text-display1-fontWeight-small: var(--salt-typography-fontWeight-regular);
 
-  --salt-text-display2-fontFamily: var(--salt-text-fontFamily);
+  --salt-text-display2-fontFamily: var(--salt-typography-fontFamily);
   --salt-text-display2-fontWeight: var(--salt-typography-fontWeight-semiBold);
   --salt-text-display2-fontWeight-strong: var(--salt-typography-fontWeight-bold);
   --salt-text-display2-fontWeight-small: var(--salt-typography-fontWeight-regular);
 
-  --salt-text-display3-fontFamily: var(--salt-text-fontFamily);
+  --salt-text-display3-fontFamily: var(--salt-typography-fontFamily);
   --salt-text-display3-fontWeight: var(--salt-typography-fontWeight-semiBold);
   --salt-text-display3-fontWeight-strong: var(--salt-typography-fontWeight-bold);
   --salt-text-display3-fontWeight-small: var(--salt-typography-fontWeight-regular);


### PR DESCRIPTION
1. `--salt-text-fontFamily` was not applied on text components at all, so add it to `.saltText` with test
2. Adds new variables like `--salt-text-h1-fontFamily` which bridges to default text one. This is useful for code generator tool which generates CSS automatically from design softwares like Figma, or design tokens typography definitions (e.g. [draft format#typography](https://design-tokens.github.io/community-group/format/#typography)) where font family is defined together with other text properties like font size, font weight, line height.

Open for alternative suggestion on 2nd point