### PR TITLE
[Tooltip] Add strategy and portal props to Tooltip

### DIFF
--- a/.changeset/grumpy-timers-hammer.md
+++ b/.changeset/grumpy-timers-hammer.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": minor
+---
+
+Add strategy and portal props to Tooltip

--- a/packages/core/src/__tests__/__e2e__/tooltip/Tooltip.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/tooltip/Tooltip.cy.tsx
@@ -156,4 +156,38 @@ describe("GIVEN a Tooltip", () => {
       cy.get("li").should("be.visible");
     });
   });
+
+  describe("WHEN portal prop is true", () => {
+    it("should render the tooltip at the root of the body element", () => {
+      cy.mount(
+        <div id="container">
+          <Open content="tooltip" portal />
+        </div>
+      );
+
+      cy.get("#container .saltTooltip").should("not.exist");
+
+      cy.get("body > [data-floating-ui-portal] > .saltTooltip").should("exist");
+    });
+  });
+
+  describe("By default the strategy prop is 'absolute'", () => {
+    it("should render the tooltip with css position fixed", () => {
+      cy.mount(<Open content="tooltip" />);
+
+      cy.get(".saltTooltip").then(($el) => {
+        expect(getComputedStyle($el[0]).position).to.be.eq("absolute");
+      });
+    });
+  });
+
+  describe("WHEN strategy prop is 'fixed'", () => {
+    it("should render the tooltip with css position fixed", () => {
+      cy.mount(<Open content="tooltip" strategy="fixed" />);
+
+      cy.get(".saltTooltip").then(($el) => {
+        expect(getComputedStyle($el[0]).position).to.be.eq("fixed");
+      });
+    });
+  });
 });

--- a/packages/core/src/tooltip/Tooltip.tsx
+++ b/packages/core/src/tooltip/Tooltip.tsx
@@ -5,17 +5,22 @@ import {
   HTMLAttributes,
   ReactNode,
   isValidElement,
+  Fragment,
 } from "react";
 import { StatusIndicator, ValidationStatus } from "../status-indicator";
 import { UseFloatingUIProps, makePrefixer, useForkRef } from "../utils";
 import { useTooltip, UseTooltipProps } from "./useTooltip";
 import "./Tooltip.css";
+import { FloatingPortal } from "@floating-ui/react";
 
 const withBaseName = makePrefixer("saltTooltip");
 
 export interface TooltipProps
   extends HTMLAttributes<HTMLDivElement>,
-    Pick<UseFloatingUIProps, "open" | "onOpenChange" | "placement"> {
+    Pick<
+      UseFloatingUIProps,
+      "open" | "onOpenChange" | "placement" | "strategy"
+    > {
   /**
    * The children will be the tooltip's trigger.
    */
@@ -56,6 +61,10 @@ export interface TooltipProps
    * Option to remove the focus listener
    */
   disableFocusListener?: boolean;
+  /**
+   * Renders the tooltip using a portal at the root of the html body element
+   */
+  portal?: boolean;
 }
 
 export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
@@ -72,6 +81,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       placement = "right",
       enterDelay = 300,
       leaveDelay = 0,
+      portal = false,
       ...rest
     } = props;
 
@@ -98,28 +108,32 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       reference
     );
 
+    const WrappingComponent = portal ? FloatingPortal : Fragment;
+
     return (
       <>
         {open && !disabled && (
-          <div
-            className={clsx(withBaseName(), withBaseName(status), className)}
-            ref={floating}
-            {...getTooltipProps()}
-          >
-            <div className={withBaseName("container")}>
-              {!hideIcon && (
-                <StatusIndicator
-                  status={status}
-                  size={1}
-                  className={withBaseName("icon")}
-                />
+          <WrappingComponent>
+            <div
+              className={clsx(withBaseName(), withBaseName(status), className)}
+              ref={floating}
+              {...getTooltipProps()}
+            >
+              <div className={withBaseName("container")}>
+                {!hideIcon && (
+                  <StatusIndicator
+                    status={status}
+                    size={1}
+                    className={withBaseName("icon")}
+                  />
+                )}
+                <span className={withBaseName("content")}>{content}</span>
+              </div>
+              {!hideArrow && (
+                <div className={withBaseName("arrow")} {...arrowProps} />
               )}
-              <span className={withBaseName("content")}>{content}</span>
             </div>
-            {!hideArrow && (
-              <div className={withBaseName("arrow")} {...arrowProps} />
-            )}
-          </div>
+          </WrappingComponent>
         )}
 
         {isValidElement(children) &&

--- a/packages/core/src/tooltip/useTooltip.ts
+++ b/packages/core/src/tooltip/useTooltip.ts
@@ -17,7 +17,7 @@ import { useAriaAnnounce } from "./useAriaAnnounce";
 
 export interface UseTooltipProps
   extends Partial<
-    Pick<UseFloatingUIProps, "onOpenChange" | "open" | "placement">
+    Pick<UseFloatingUIProps, "onOpenChange" | "open" | "placement" | "strategy">
   > {
   /**
    * Do not respond to focus events.
@@ -48,6 +48,7 @@ export function useTooltip(props?: UseTooltipProps) {
     placement: placementProp,
     disableHoverListener,
     disableFocusListener,
+    strategy: strategyProp,
   } = props || {};
 
   const arrowRef = useRef<HTMLDivElement | null>(null);
@@ -73,6 +74,7 @@ export function useTooltip(props?: UseTooltipProps) {
     placement,
     context,
   } = useFloatingUI({
+    strategy: strategyProp,
     open,
     onOpenChange: handleOpenChange,
     placement: placementProp,

--- a/packages/core/stories/tooltip/tooltip.doc.stories.mdx
+++ b/packages/core/stories/tooltip/tooltip.doc.stories.mdx
@@ -75,6 +75,14 @@ Use `enterDelay` prop to change the delay before the tooltip is shown. Defaults 
   <Story id="core-tooltip--delay" decorators={[withFlexGap]} />
 </Canvas>
 
+### Strategy
+
+This prop allows you to change the css positioning to fixed.
+
+### Portal
+
+When `strategy="fixed"` is not enough and your Tooltip is still getting clipped by other content, or you are struggling with z-index stacking, you can use the portal prop to render the Tooltip at the root of the `body` element. Be midful if you are customizing the style of the Tooltip with a nested class name, it will no longer work (eg. `.customClass .saltTooltip`).
+
 ## Configuring Tooltip
 
 ### API


### PR DESCRIPTION
### Why
When we are using the Tooltip in a container that is clipped, we need a portal in order to escape the bounding container that is clipping the tooltip and render the tooltip at the root of the html document. While `strategy="fixed"` is useful in most cases because the tooltip is still nested within the dom hierarchy, it doesn't work in the case of css `clip-path` property.

### Changes
- add `portal` prop to Tooltip
- add `strategy` prop to Tooltip