### PR TITLE
Replace size divider tokens with separator

### DIFF
--- a/.changeset/odd-wasps-eat.md
+++ b/.changeset/odd-wasps-eat.md
@@ -4,4 +4,4 @@
 ---
 
 Deprecated `--salt-size-graphic-small`, `--salt-size-graphic-medium`, `--salt-size-graphic-large`
-Simplified `--salt-size-divider-height` calculation from `--salt-size-base - (1.5 * --salt-size-unit) - (0.5 * --salt-size-basis-unit)` to `--salt-size-compact + (1.5 * --salt-size-basis-unit)`
+Deprecated `--salt-size-divider-height`, `--salt-size-divider-strokeWidth`, replaced with `--salt-size-separator-height`, `--salt-size-separator-strokeWidth`

--- a/packages/lab/src/logo/Logo.css
+++ b/packages/lab/src/logo/Logo.css
@@ -14,7 +14,7 @@
 .saltLogo {
   --logo-color: var(--saltLogo-color, var(--salt-palette-neutral-secondary-foreground));
   --logo-divider-color: var(--saltLogo-pipe-color, var(--salt-separable-secondary-borderColor));
-  --logo-divider-height: var(--saltLogo-title-height, var(--salt-size-divider-height));
+  --logo-divider-height: var(--saltLogo-title-height, var(--salt-size-separator-height));
   --logo-divider-margin: 0 calc(var(--salt-size-unit) * 2);
   --logo-fontSize: var(--salt-text-fontSize);
   --logo-lineHeight: var(--salt-text-lineHeight);

--- a/packages/theme/css/foundations/size.css
+++ b/packages/theme/css/foundations/size.css
@@ -6,11 +6,11 @@
   --salt-size-basis-unit: 4px;
 
   --salt-size-border: 1px;
-  --salt-size-divider-strokeWidth: 1px;
   --salt-size-sharktooth-height: 5px;
   --salt-size-sharktooth-width: 10px;
 
-  --salt-size-divider-height: calc(var(--salt-size-compact) + 1.5 * var(--salt-size-basis-unit));
+  --salt-size-separator-strokeWidth: 1px;
+  --salt-size-separator-height: calc(var(--salt-size-compact) + 1.5 * var(--salt-size-basis-unit));
   --salt-size-selectable: calc(var(--salt-size-base) - (1.5 * var(--salt-size-unit)) - (0.5 * var(--salt-size-basis-unit)));
   --salt-size-stackable: calc(var(--salt-size-base) + var(--salt-size-unit));
 
@@ -20,6 +20,8 @@
   --salt-size-graphic-small: 12px;
   --salt-size-graphic-medium: 24px;
   --salt-size-graphic-large: 48px;
+  --salt-size-divider-height: var(--salt-size-separator-height);
+  --salt-size-divider-strokeWidth: var(--salt-size-separator-strokeWidth);
 }
 
 .salt-density-high {

--- a/packages/theme/stories/foundations/size.stories.mdx
+++ b/packages/theme/stories/foundations/size.stories.mdx
@@ -6,7 +6,7 @@ import { DocGrid } from "docs/components/DocGrid";
 
 # Size
 
-All size values are based on 4px, `--salt-size-basis-unit`. If you need to change this, use `--salt-size-unit` (see density aware values below) which will adjust this base value according to density.
+All size values are built on the basis of 4px, `--salt-size-basis-unit`. We encourage you to use the density aware `--salt-size-unit` which will adjust this base value according to density.
 
 ## Tokens
 
@@ -14,14 +14,14 @@ All size values are based on 4px, `--salt-size-basis-unit`. If you need to chang
   <SpacingBlock spacingVar="--salt-size-accent" />
   <SpacingBlock spacingVar="--salt-size-basis-unit" />
   <SpacingBlock spacingVar="--salt-size-border" />
-  <SpacingBlock spacingVar="--salt-size-divider-strokeWidth" />
   <SpacingBlock spacingVar="--salt-size-sharktooth-height" />
   <SpacingBlock spacingVar="--salt-size-sharktooth-width" />
   <SpacingBlock spacingVar="--salt-size-unit" />
   <SpacingBlock spacingVar="--salt-size-compact" />
   <SpacingBlock spacingVar="--salt-size-base" />
-  <SpacingBlock spacingVar="--salt-size-divider-height" />
   <SpacingBlock spacingVar="--salt-size-selectable" />
+  <SpacingBlock spacingVar="--salt-size-separator-height" />
+  <SpacingBlock spacingVar="--salt-size-separator-strokeWidth" />
   <SpacingBlock spacingVar="--salt-size-stackable" />
   <SpacingBlock
     spacingVar="--salt-size-brandBar"
@@ -34,5 +34,13 @@ All size values are based on 4px, `--salt-size-basis-unit`. If you need to chang
   <SpacingBlock
     spacingVar="--salt-size-selection"
     replacementToken="--salt-size-selectable"
+  />
+  <SpacingBlock
+    spacingVar="--salt-size-divider-height"
+    replacementToken="--salt-size-separator-height"
+  />
+  <SpacingBlock
+    spacingVar="--salt-size-divider-strokeWidth"
+    replacementToken="--salt-size-separator-strokeWidth"
   />
 </DocGrid>


### PR DESCRIPTION
Alignment of naming conventions

Deprecated `--salt-size-divider-height`, `--salt-size-divider-strokeWidth`, replaced with `--salt-size-separator-height`, `--salt-size-separator-strokeWidth`