### PR TITLE
Simplify Spinner

### DIFF
--- a/packages/core/src/spinner/Spinner.tsx
+++ b/packages/core/src/spinner/Spinner.tsx
@@ -1,51 +1,21 @@
 import { clsx } from "clsx";
-import { forwardRef, HTMLAttributes, useEffect } from "react";
-import { useAriaAnnouncer } from "../aria-announcer";
+import { ComponentPropsWithoutRef, forwardRef } from "react";
 import { makePrefixer, useId } from "../utils";
 import { SpinnerSVG } from "./svgSpinners/SpinnerSVG";
 
 import "./Spinner.css";
 
-/**
- * Spinner component, provides an indeterminate loading indicator
- *
- * @example
- * <Spinner size="default | large" />
- */
-
-export const SpinnerSizeValues = ["default", "large"] as const;
-export type SpinnerSize = typeof SpinnerSizeValues[number];
 const withBaseName = makePrefixer("saltSpinner");
 
-export interface SpinnerProps extends HTMLAttributes<HTMLDivElement> {
+export interface SpinnerProps extends ComponentPropsWithoutRef<"div"> {
   /**
-   * Determines the interval on which the component will continue to announce the aria-label. Defaults to 5000ms (5s)
+   * A label for accessibility
    */
-  announcerInterval?: number;
-  /**
-   *  * Determines the interval after which the component will stop announcing the aria-label. Defaults to 20000ms (20s)
-   */
-  announcerTimeout?: number;
-  /**
-   * The className(s) of the component
-   */
-  className?: string;
-  /**
-   * Determines the message to be announced by the component when it unmounts. Set to null if not needed.
-   */
-  completionAnnouncement?: string | null;
-  /**
-   * If true, built in aria announcer will be inactive
-   */
-  disableAnnouncer?: boolean;
-  /**
-   * The prop for the role attribute of the component
-   */
-  role?: string;
+  "aria-label"?: string;
   /**
    * Determines the size of the spinner. Must be one of: 'default', 'large'.
    */
-  size?: SpinnerSize;
+  size?: "default" | "large";
   /**
    * The ids of the SvgSpinner components
    */
@@ -53,69 +23,16 @@ export interface SpinnerProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 export const Spinner = forwardRef<HTMLDivElement, SpinnerProps>(
-  function Spinner(
-    {
-      "aria-label": ariaLabel = "loading",
-      announcerInterval = 5000,
-      announcerTimeout = 20000,
-      completionAnnouncement = `finished ${ariaLabel}`,
-      disableAnnouncer,
-      role = "img",
-      className,
-      size = "default",
-      id: idProp,
-      ...rest
-    },
-    ref
-  ) {
+  function Spinner({ className, size = "default", id: idProp, ...rest }, ref) {
     const id = useId(idProp);
-
-    const { announce } = useAriaAnnouncer();
-
-    useEffect(() => {
-      if (disableAnnouncer) return;
-
-      announce(ariaLabel);
-
-      const startTime = new Date().getTime();
-
-      const interval =
-        announcerInterval > 0 &&
-        setInterval(() => {
-          if (new Date().getTime() - startTime > announcerTimeout) {
-            // The announcer will stop after `announcerTimeout` time
-            announce(
-              `${ariaLabel} is still in progress, but will no longer announce.`
-            );
-            interval && clearInterval(interval);
-            return;
-          }
-          announce(ariaLabel);
-        }, announcerInterval);
-
-      return () => {
-        if (disableAnnouncer) return;
-
-        interval && clearInterval(interval);
-        if (completionAnnouncement) {
-          announce(completionAnnouncement);
-        }
-      };
-    }, [
-      announce,
-      announcerInterval,
-      announcerTimeout,
-      ariaLabel,
-      completionAnnouncement,
-      disableAnnouncer,
-    ]);
 
     return (
       <div
-        aria-label={ariaLabel}
         className={clsx(withBaseName(), withBaseName(size), className)}
         ref={ref}
-        role={role}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
         {...rest}
       >
         <SpinnerSVG id={id} />


### PR DESCRIPTION
Simplifies Spinner to remove the useAnnouncer call. 

Currently, Spinner is very complex and does too many things. This makes Spinner act in a more standard way and, more importantly, means we can release it without including features we won't be able to remove until a v2 release.