### PR TITLE
Add `basis` to FlexItem

### DIFF
--- a/.changeset/poor-lions-hear.md
+++ b/.changeset/poor-lions-hear.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": minor
+---
+
+Added new `basis` prop to FlexItem to control flex-basis

--- a/packages/core/src/__tests__/__e2e__/flex-item/FlexItem.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/flex-item/FlexItem.cy.tsx
@@ -1,0 +1,31 @@
+import * as flexStories from "@stories/flex-item/flex-item.stories";
+import { composeStories } from "@storybook/testing-react";
+
+const composedStories = composeStories(flexStories);
+const { FlexItemWrapper } = composedStories;
+
+describe("GIVEN a FlexItem in FlexLayout", () => {
+  describe("WHEN no props are provided", () => {
+    it("THEN it should render default flex properties", () => {
+      cy.mount(<FlexItemWrapper />);
+
+      cy.get(".saltFlexLayout > .saltFlexItem")
+        .first()
+        .should("have.css", "flex-grow", "0")
+        .should("have.css", "flex-shrink", "1")
+        .should("have.css", "flex-basis", "auto");
+    });
+  });
+
+  describe("WHEN flex props are provided", () => {
+    it("THEN it should render properties with overridden value", () => {
+      cy.mount(<FlexItemWrapper grow={2} shrink={2} basis="100px" />);
+
+      cy.get(".saltFlexLayout > .saltFlexItem")
+        .first()
+        .should("have.css", "flex-grow", "2")
+        .should("have.css", "flex-shrink", "2")
+        .should("have.css", "flex-basis", "100px");
+    });
+  });
+});

--- a/packages/core/src/__tests__/__e2e__/flex-layout/FlexLayout.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/flex-layout/FlexLayout.cy.tsx
@@ -6,7 +6,7 @@ import { SaltProvider } from "@salt-ds/core";
 const composedStories = composeStories(flexStories);
 const { Default, Nested } = composedStories;
 
-describe("GIVEN a Flex", () => {
+describe("GIVEN a FlexLayout", () => {
   checkAccessibility(composedStories);
 
   describe("WHEN no props are provided", () => {

--- a/packages/core/src/flex-item/FlexItem.css
+++ b/packages/core/src/flex-item/FlexItem.css
@@ -3,6 +3,7 @@
   --saltFlexItem-alignment: auto;
   --saltFlexItem-shrink: 1;
   --saltFlexItem-grow: 0;
+  --saltFlexItem-basis: auto;
 }
 
 /* Style applied to the root element */
@@ -11,6 +12,7 @@
   align-self: var(--saltFlexItem-alignment);
   flex-grow: var(--saltFlexItem-grow);
   flex-shrink: var(--saltFlexItem-shrink);
+  flex-basis: var(--saltFlexItem-basis);
 }
 
 .saltFlexItem-stacked {

--- a/packages/core/src/flex-item/FlexItem.tsx
+++ b/packages/core/src/flex-item/FlexItem.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ElementType, ReactElement } from "react";
+import { forwardRef, ElementType, ReactElement, CSSProperties } from "react";
 import {
   makePrefixer,
   ResponsiveProp,
@@ -28,14 +28,17 @@ export type FlexItemProps<T extends ElementType> =
        */
       align?: flexItemAlignment;
       /**
-   * Defines the ability for an item to shrink x times more compared to it's siblings, default is 1.
-
-   */
+       * Defines the ability for an item to shrink x times more compared to it's siblings, default is 1.
+       */
       shrink?: ResponsiveProp<number>;
       /**
        * Defines the ability for an item to grow x times more compared to it's siblings, default is 0.
        */
       grow?: ResponsiveProp<number>;
+      /**
+       * Sets the initial main size of a flex item, default is "auto".
+       */
+      basis?: ResponsiveProp<CSSProperties["flexBasis"]>;
     }
   >;
 
@@ -52,6 +55,7 @@ export const FlexItem: FlexItemComponent = forwardRef(
       className,
       shrink,
       grow,
+      basis,
       style,
       ...rest
     }: FlexItemProps<T>,
@@ -60,11 +64,13 @@ export const FlexItem: FlexItemComponent = forwardRef(
     const Component = as || "div";
     const flexItemShrink = useResponsiveProp(shrink, 1);
     const flexItemGrow = useResponsiveProp(grow, 0);
+    const flexItemBasis = useResponsiveProp(basis, "auto");
 
     const itemStyle = {
       "--saltFlexItem-alignment": align,
       "--saltFlexItem-shrink": flexItemShrink,
       "--saltFlexItem-grow": flexItemGrow,
+      "--saltFlexItem-basis": flexItemBasis,
       ...style,
     };
     return (


### PR DESCRIPTION
Without the basis, need to use `style` to give flex basis for simple 2 column layout like below

<img width="259" alt="image" src="https://user-images.githubusercontent.com/5257855/226866474-5c2fe4fd-c561-4e52-9ce0-22339ca84248.png">

For the 2nd row, i'm can't get input / form field to be exactly half of the space

```
<FlexLayout gap={1}>
  {/* without flexBasis input will be bigger than the empty space */}
  <FlexItem grow={1} shrink={1} style={{ flexBasis: 1 }}>
    <FormField label="Decimal">
      <Input />
    </FormField>
  </FlexItem>
  <FlexItem grow={1} shrink={1}></FlexItem>
</FlexLayout>
```