### PR TITLE
Fix Tooltip using default text styles

### DIFF
--- a/.changeset/friendly-impalas-explode.md
+++ b/.changeset/friendly-impalas-explode.md
@@ -2,4 +2,4 @@
 "@salt-ds/core": patch
 ---
 
-Tooltip uses default text styles by default.
+Fix Tooltip having incorrect text styles when being nested in elements with custom text styles.

--- a/.changeset/friendly-impalas-explode.md
+++ b/.changeset/friendly-impalas-explode.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Tooltip uses default text styles by default.

--- a/packages/core/src/__tests__/__e2e__/tooltip/Tooltip.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/tooltip/Tooltip.cy.tsx
@@ -1,6 +1,6 @@
 import * as tooltipStories from "@stories/tooltip/tooltip.stories";
 import { composeStories } from "@storybook/testing-react";
-import { InfoIcon } from "packages/icons/src";
+import { InfoIcon } from "@salt-ds/icons";
 import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
 import { Tooltip } from "@salt-ds/core";
 

--- a/packages/core/src/__tests__/__e2e__/tooltip/Tooltip.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/tooltip/Tooltip.cy.tsx
@@ -1,6 +1,8 @@
 import * as tooltipStories from "@stories/tooltip/tooltip.stories";
 import { composeStories } from "@storybook/testing-react";
+import { InfoIcon } from "packages/icons/src";
 import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import { Tooltip } from "../../../tooltip";
 
 const composedStories = composeStories(tooltipStories);
 
@@ -154,6 +156,23 @@ describe("GIVEN a Tooltip", () => {
       cy.get("div").should("be.visible");
       cy.get("ul").should("be.visible");
       cy.get("li").should("be.visible");
+    });
+  });
+
+  describe("WHEN used in header tag", () => {
+    it("then tooltip displays default font weight and size", () => {
+      cy.mount(
+        <h3>
+          Header{" "}
+          <Tooltip open content="tooltip">
+            <InfoIcon />
+          </Tooltip>
+        </h3>
+      );
+      cy.findByText("tooltip")
+        .should("be.visible")
+        .should("have.css", "font-size", "11px")
+        .should("have.css", "font-weight", "400");
     });
   });
 });

--- a/packages/core/src/__tests__/__e2e__/tooltip/Tooltip.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/tooltip/Tooltip.cy.tsx
@@ -171,7 +171,7 @@ describe("GIVEN a Tooltip", () => {
       );
       cy.findByText("tooltip")
         .should("be.visible")
-        .should("have.css", "font-size", "11px")
+        .should("have.css", "font-size", "12px")
         .should("have.css", "font-weight", "400");
     });
   });

--- a/packages/core/src/__tests__/__e2e__/tooltip/Tooltip.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/tooltip/Tooltip.cy.tsx
@@ -2,7 +2,7 @@ import * as tooltipStories from "@stories/tooltip/tooltip.stories";
 import { composeStories } from "@storybook/testing-react";
 import { InfoIcon } from "packages/icons/src";
 import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
-import { Tooltip } from "../../../tooltip";
+import { Tooltip } from "@salt-ds/core";
 
 const composedStories = composeStories(tooltipStories);
 

--- a/packages/core/src/tooltip/Tooltip.css
+++ b/packages/core/src/tooltip/Tooltip.css
@@ -13,7 +13,7 @@
   border-width: var(--saltTooltip-borderWidth, var(--salt-size-border));
   box-shadow: var(--saltTooltip-shadow, var(--salt-overlayable-shadow-popout));
   color: var(--saltTooltip-text-color, var(--salt-text-primary-foreground));
-  font-size: var(--saltTooltip-fontSize, var(--salt-text-label-fontSize));
+  font-size: var(--saltTooltip-fontSize, var(--salt-text-fontSize));
   font-weight: var(--saltTooltip-fontWeight, var(--salt-text-fontWeight));
   line-height: var(--saltTooltip-lineHeight, var(--salt-text-label-lineHeight));
   max-width: var(--saltTooltip-maxWidth, 230px);

--- a/packages/core/src/tooltip/Tooltip.css
+++ b/packages/core/src/tooltip/Tooltip.css
@@ -9,10 +9,13 @@
 .saltTooltip {
   background: var(--tooltip-background);
   border-color: var(--saltTooltip-borderColor, var(--tooltip-status-borderColor));
-  border-width: var(--saltTooltip-borderWidth, var(--salt-size-border));
   border-style: var(--saltTooltip-borderStyle, var(--salt-container-borderStyle));
+  border-width: var(--saltTooltip-borderWidth, var(--salt-size-border));
   box-shadow: var(--saltTooltip-shadow, var(--salt-overlayable-shadow-popout));
   color: var(--saltTooltip-text-color, var(--salt-text-primary-foreground));
+  font-size: var(--saltTooltip-fontSize, var(--salt-text-label-fontSize));
+  font-weight: var(--saltTooltip-fontWeight, var(--salt-text-fontWeight));
+  line-height: var(--saltTooltip-lineHeight, var(--salt-text-label-lineHeight));
   max-width: var(--saltTooltip-maxWidth, 230px);
   padding: var(--saltTooltip-padding, var(--salt-size-unit));
   position: relative;

--- a/packages/core/src/tooltip/Tooltip.css
+++ b/packages/core/src/tooltip/Tooltip.css
@@ -15,7 +15,7 @@
   color: var(--saltTooltip-text-color, var(--salt-text-primary-foreground));
   font-size: var(--saltTooltip-fontSize, var(--salt-text-fontSize));
   font-weight: var(--saltTooltip-fontWeight, var(--salt-text-fontWeight));
-  line-height: var(--saltTooltip-lineHeight, var(--salt-text-label-lineHeight));
+  line-height: var(--saltTooltip-lineHeight, var(--salt-text-lineHeight));
   max-width: var(--saltTooltip-maxWidth, 230px);
   padding: var(--saltTooltip-padding, var(--salt-size-unit));
   position: relative;


### PR DESCRIPTION
When tooltip is used in heading tags, text is not showing default sizes. 

```
<h3>
  Header{' '}
  <Tooltip open content="Tooltip">
    <InfoIcon />
  </Tooltip>
</h3>
```

Reproduce: https://stackblitz.com/edit/salt-1-2-0-tooltip-in-heading?file=App.tsx

Redo #1238