### PR TITLE
Sort component status table with version number

### DIFF
--- a/site/docs/components/_index/ComponentsList.tsx
+++ b/site/docs/components/_index/ComponentsList.tsx
@@ -50,12 +50,29 @@ const componentsListSorting = (
     return componentsListSortedByName(ascendingOrder);
   }
 
-  return componentsListSortedByName().sort(
-    (a, b) =>
+  return componentsListSortedByName().sort((a, b) => {
+    const orderMultiplier = ascendingOrder ? 1 : -1;
+    const statusDiff =
       (statusSortList.indexOf(a[componentDetail]) -
         statusSortList.indexOf(b[componentDetail])) *
-      (ascendingOrder ? 1 : -1)
-  );
+      orderMultiplier;
+    if (statusDiff === 0 && componentDetail === "devStatus") {
+      if (a.availableInCoreSince && b.availableInCoreSince) {
+        return (
+          a.availableInCoreSince.localeCompare(b.availableInCoreSince) *
+          orderMultiplier
+        );
+      } else if (a.availableInCoreSince) {
+        return orderMultiplier;
+      } else if (b.availableInCoreSince) {
+        return -1 * orderMultiplier;
+      } else {
+        return 0;
+      }
+    } else {
+      return statusDiff;
+    }
+  });
 };
 
 const ComponentNameData = ({ component }: { component: ComponentDetails }) => {


### PR DESCRIPTION
On [component status page](https://www.saltdesignsystem.com/components/), when sorting by "React", it's quite confusing to see "Released in v1.1.0" is mixed with "Released in v1.0.0".

Redo #1187