### PR TITLE
Remove default as in storybook controls

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -90,7 +90,7 @@ export const globalTypes: GlobalTypes = {
 };
 
 export const argTypes: ArgTypes = {
-  as: { type: "string" },
+  as: { type: "string", if:{ arg :"as", exists: true }},
   ref: { control: { type: null } },
 };
 

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -90,7 +90,6 @@ export const globalTypes: GlobalTypes = {
 };
 
 export const argTypes: ArgTypes = {
-  as: { type: "string", if:{ arg :"as", exists: true }},
   ref: { control: { type: null } },
 };
 

--- a/packages/core/stories/border-item/border-item.stories.tsx
+++ b/packages/core/stories/border-item/border-item.stories.tsx
@@ -5,6 +5,7 @@ export default {
   title: "Core/Layout/Border Layout/Border Item",
   component: BorderItem,
   argTypes: {
+    as: { type: "string" },
     position: {
       control: { type: "select" },
     },

--- a/packages/core/stories/border-layout/border-layout.stories.tsx
+++ b/packages/core/stories/border-layout/border-layout.stories.tsx
@@ -7,6 +7,7 @@ export default {
   component: BorderLayout,
   subcomponents: { BorderItem },
   argTypes: {
+    as: { type: "string" },
     gap: {
       type: "number",
     },

--- a/packages/core/stories/flex-item/flex-item.stories.tsx
+++ b/packages/core/stories/flex-item/flex-item.stories.tsx
@@ -6,6 +6,7 @@ export default {
   title: "Core/Layout/Flex Layout/Flex Item",
   component: FlexItem,
   argTypes: {
+    as: { type: "string" },
     align: {
       options: ["start", "end", "center", "stretch"],
       control: { type: "select" },

--- a/packages/core/stories/flex-layout/flex-layout.stories.tsx
+++ b/packages/core/stories/flex-layout/flex-layout.stories.tsx
@@ -8,6 +8,7 @@ export default {
   component: FlexLayout,
   subcomponents: { FlexItem },
   argTypes: {
+    as: { type: "string" },
     align: {
       options: ["start", "end", "center", "stretch", "baseline"],
       control: { type: "select" },

--- a/packages/core/stories/flow-layout/flow-layout.stories.tsx
+++ b/packages/core/stories/flow-layout/flow-layout.stories.tsx
@@ -7,6 +7,7 @@ export default {
   title: "Core/Layout/Flow Layout",
   component: FlowLayout,
   argTypes: {
+    as: { type: "string" },
     align: {
       options: [...FLEX_ALIGNMENT_BASE, "stretch", "baseline"],
       control: { type: "select" },

--- a/packages/core/stories/grid-item/grid-item.stories.tsx
+++ b/packages/core/stories/grid-item/grid-item.stories.tsx
@@ -5,6 +5,7 @@ export default {
   title: "Core/Layout/Grid Layout/Grid Item",
   component: GridItem,
   argTypes: {
+    as: { type: "string" },
     colSpan: { control: { type: "number" } },
     rowSpan: { control: { type: "number" } },
     horizontalAlignment: { control: { type: "select" } },

--- a/packages/core/stories/grid-layout/grid-layout.stories.tsx
+++ b/packages/core/stories/grid-layout/grid-layout.stories.tsx
@@ -14,6 +14,7 @@ export default {
   component: GridLayout,
   subcomponents: { GridItem },
   argTypes: {
+    as: { type: "string" },
     columnGap: { type: "number" },
     columns: { type: "number" },
     gap: {

--- a/packages/core/stories/split-layout/split-layout.stories.tsx
+++ b/packages/core/stories/split-layout/split-layout.stories.tsx
@@ -19,6 +19,7 @@ export default {
   title: "Core/Layout/Split Layout",
   component: SplitLayout,
   argTypes: {
+    as: { type: "string" },
     align: {
       options: [...FLEX_ALIGNMENT_BASE, "stretch", "baseline"],
       control: { type: "select" },

--- a/packages/core/stories/stack-layout/stack-layout.stories.tsx
+++ b/packages/core/stories/stack-layout/stack-layout.stories.tsx
@@ -6,6 +6,7 @@ export default {
   title: "Core/Layout/Stack Layout",
   component: StackLayout,
   argTypes: {
+    as: { type: "string" },
     align: {
       options: [...FLEX_ALIGNMENT_BASE, "stretch", "baseline"],
       control: { type: "select" },


### PR DESCRIPTION
Remove default `as` from the storybook preview controls and add the type in the ones that have the prop.