### PR TITLE
Fix Combo Box filtering bug

### DIFF
--- a/packages/lab/src/common-hooks/useCollectionItems.ts
+++ b/packages/lab/src/common-hooks/useCollectionItems.ts
@@ -223,11 +223,11 @@ export const useCollectionItems = <Item>({
     (pattern = "") => {
       if (typeof pattern === "string") {
         filterPattern.current = pattern;
-        dataRef.current = collectVisibleItems(collectionItemsRef.current);
+        dataRef.current = collectVisibleItems(collectionItems);
         forceUpdate({});
       }
     },
-    [collectVisibleItems]
+    [collectionItems, collectVisibleItems]
   );
 
   const itemById = useCallback(

--- a/packages/lab/stories/combobox/combobox.stories.tsx
+++ b/packages/lab/stories/combobox/combobox.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, memo } from "react";
+import { ComponentProps, memo, useEffect, useState } from "react";
 import {
   ComboBox,
   ComboBoxProps,
@@ -230,4 +230,17 @@ export const WithInitialSelection = FormFieldComboBoxTemplate.bind({});
 WithInitialSelection.args = {
   ...WithFormField.args,
   defaultValue: shortColorData[3],
+};
+
+export const TestSourceDelay = () => {
+  const [source, setSource] = useState<string[]>([]);
+  useEffect(() => {
+    const timeout = setTimeout(() => setSource(["a", "bb", "cc", "abc"]), 5000);
+    return () => void clearTimeout(timeout);
+  }, []);
+  return (
+    <FormField label="Select something" style={{ maxWidth: 292 }}>
+      <ComboBox source={source} />
+    </FormField>
+  );
 };


### PR DESCRIPTION
Closes #1404

setFilterPattern in useCollectionItems was referencing collection data via a ref. That ref is not updated when change to source triggers rebuild of collection.
No reason not to reference the collection directly, with the appropriate entry in dependency array.