### PR TITLE
Remove changesets action from snapshot workflow

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -24,7 +24,6 @@ jobs:
           COMMENT_ID: ${{ github.event.comment.id }}
         with:
           script: |
-            const { COMMENT_ID } = process.env
             const username = context.actor;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -41,7 +40,7 @@ jobs:
               await github.rest.reactions.createForIssueComment({
                 owner,
                 repo,
-                comment_id: COMMENT_ID,
+                comment_id: process.env.COMMENT_ID,
                 content: "eyes",
               })
             } else {
@@ -87,26 +86,34 @@ jobs:
         run: yarn install
       - name: Build
         run: yarn build
-      - name: Create Release Pull Request or Publish packages
-        id: changesets
-        uses: changesets/action@v1
-        with:
-          version: yarn changeset version --snapshot snapshot
-          publish: yarn changeset publish --no-git-tag --snapshot --tag snapshot
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Comment on PR
+      - name: Create and publish snapshot release
         uses: actions/github-script@v6
         env:
-          PACKAGES: ${{ steps.changesets.outputs.published }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_ID: ${{ github.event.comment.id }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           script: |
-            const { PACKAGES, COMMENT_ID } = process.env
-            const newTags = JSON.parse(PACKAGES).map(pkg => `${pkg.name}@${pkg.version}`)
+
+            exec.exec('yarn changeset version --snapshot snapshot');
+
+            let output = ''
+
+            const options = {
+              listeners = {
+                stdout: (data) => {
+                  output += data.toString();
+                },
+              }
+            };
+
+            exec.exec('yarn changeset publish --no-git-tag --snapshot --tag snapshot', [], options);
+
+            const { COMMENT_ID } = process.env
+            const newTags = Array
+              .from(stdout.matchAll(/New tag:\s+([^\s\n]+)/g))
+              .map(([_, tag]) => tag)
             if (newTags.length) {
               const multiple = newTags.length > 1
               const body = (


### PR DESCRIPTION
This PR removes the changesets action from the snapshot workflow.

The changesets action does too much here and tries to create a PR and do the normal release workflow. This isn't needed in a snapshot workflow.