### PR TITLE
Make the Checkbox WithoutLabel example accessible

### DIFF
--- a/packages/lab/stories/checkbox/checkbox.doc.stories.mdx
+++ b/packages/lab/stories/checkbox/checkbox.doc.stories.mdx
@@ -143,4 +143,8 @@ The Checkbox component is similar to the following components:
 
 ## Accessibility
 
+If you are using a Checkbox without a label:
+
+- You should pass an `aria-label` to `Checkbox` that describes its purpose.
+
 <HelpAndSupport />

--- a/packages/lab/stories/checkbox/checkbox.stories.tsx
+++ b/packages/lab/stories/checkbox/checkbox.stories.tsx
@@ -58,7 +58,7 @@ FeatureInput.args = {
 
 export const WithoutLabel = CheckboxTemplate.bind({});
 
-WithoutLabel.args = { defaultChecked: true };
+WithoutLabel.args = { defaultChecked: true, "aria-label": "Select" };
 
 export const Indeterminate: ComponentStory<typeof Checkbox> = () => {
   const [checkboxState, setCheckboxState] = useState({


### PR DESCRIPTION
This fixes an omission of the `aria-label` attribute on the example `WithoutLabel`