### PR TITLE
Improve Tabs alignment in AppHeader

### DIFF
--- a/.changeset/blue-mangos-ring.md
+++ b/.changeset/blue-mangos-ring.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/lab": patch
+---
+
+Improve Tabs alignment in AppHeader

--- a/packages/lab/src/app-header/AppHeader.css
+++ b/packages/lab/src/app-header/AppHeader.css
@@ -16,8 +16,14 @@
   --appHeader-paddingLeft: 8px;
   --appHeader-paddingRight: var(--appHeader-padding);
 
-  --saltTabs-tabstrip-height: var(--appHeader-height);
   --saltToolbar-width: auto;
+}
+
+.saltAppHeader .saltTabstrip {
+  --saltTabs-tabstrip-height: var(--appHeader-height);
+  /* App header has its own bottom border, so remove tabs line but keeping activation indicator */
+  --saltTabs-activationIndicator-height: 0px;
+  --saltTabs-activationIndicator-thumb-inset: -2px 0 0 0;
 }
 
 .saltAppHeader {

--- a/packages/lab/src/tabs/Tab.css
+++ b/packages/lab/src/tabs/Tab.css
@@ -54,7 +54,7 @@
   font-family: inherit;
   font-size: inherit;
   font-weight: inherit;
-  height: var(--salt-size-stackable);
+  height: var(--saltTabs-tabstrip-height, var(--salt-size-stackable));
   outline: none;
   padding: 0 var(--tabs-tab-spacing);
   position: relative;

--- a/packages/lab/src/tabs/TabActivationIndicator.css
+++ b/packages/lab/src/tabs/TabActivationIndicator.css
@@ -7,7 +7,7 @@
 
   background: var(--saltTabs-activationIndicator-background, var(--tabs-activationIndicator-background));
   bottom: 0;
-  height: var(--tabs-activationIndicator-height, auto);
+  height: var(--saltTabs-activationIndicator-height, auto);
   inset: var(--tabs-activationIndicator-inset);
   position: absolute;
   width: var(--tabs-activationIndicator-width, auto);
@@ -15,7 +15,7 @@
 
 /* the Active Tab indicator, uses navigable styles */
 .saltTabActivationIndicator-thumb {
-  inset: var(--tabs-activationIndicator-thumb-inset);
+  inset: var(--saltTabs-activationIndicator-thumb-inset);
   position: absolute;
   height: var(--tabs-activationIndicator-thumb-height, auto);
   background: var(--salt-navigable-indicator-active);

--- a/packages/lab/src/tabs/Tabstrip.css
+++ b/packages/lab/src/tabs/Tabstrip.css
@@ -18,22 +18,24 @@
 
 /* Tabstrip orientation is horizontal */
 .saltTabstrip-horizontal {
+  --saltTabs-activationIndicator-height: 1px;
+  --saltTabs-activationIndicator-thumb-inset: -1px 0 0 0;
+
   --tabs-activationIndicator-borderStyle: none none solid none;
-  --tabs-activationIndicator-height: 1px;
   --tabs-activationIndicator-inset: auto 0px 0px 0px;
   --tabs-activationIndicator-transitionProperty: left;
   --tabs-activationIndicator-thumb-height: 2px;
-  --tabs-activationIndicator-thumb-inset: -1px 0 0 0;
 }
 
 /* Tabstrip orientation is vertical */
 .saltTabstrip-vertical {
+  --saltTabs-activationIndicator-thumb-inset: 0 0 0 -1px;
+
   --tabs-activationIndicator-transition: top 0.3s ease;
   --tabs-activationIndicator-borderStyle: none solid none none;
   --tabs-activationIndicator-inset: 0px 0px 0px auto;
   --tabs-activationIndicator-transitionProperty: top;
   --tabs-activationIndicator-width: 1px;
-  --tabs-activationIndicator-thumb-inset: 0 0 0 -1px;
   --tabs-activationIndicator-thumb-width: 2px;
 
   align-self: flex-start;

--- a/packages/lab/src/toolbar/Toolbar.css
+++ b/packages/lab/src/toolbar/Toolbar.css
@@ -20,7 +20,6 @@
 } */
 
 .saltToolbar > .Responsive-inner {
-  /* align-items: flex-start; */
   align-items: center;
   flex: 1;
   flex-wrap: wrap;

--- a/packages/lab/src/toolbar/Toolbar.css
+++ b/packages/lab/src/toolbar/Toolbar.css
@@ -20,7 +20,8 @@
 } */
 
 .saltToolbar > .Responsive-inner {
-  align-items: flex-start;
+  /* align-items: flex-start; */
+  align-items: center;
   flex: 1;
   flex-wrap: wrap;
   justify-content: inherit;
@@ -45,8 +46,8 @@
 }
 
 .saltToolbar[aria-orientation="horizontal"] > .Responsive-inner > :not(.saltTooltray) {
-  margin-top: var(--salt-size-unit);
   margin-right: var(--salt-size-unit);
+  align-self: center;
 }
 
 .saltToolbar[aria-orientation="horizontal"] > .Responsive-inner > .saltTooltray > .Responsive-inner > * {


### PR DESCRIPTION
Currently Tab is very misaligned within App Header. Try to do some *minimal* change to make it usable

- Center align toolbar items vertically instead of using margin top
- Adjust tab activation indicator css api to support app header hiding the line but not the thumb

- [x] check visual regression in Chromatic