### PR TITLE
Replace -emphasize background status tokens as default background tokens

### DIFF
--- a/.changeset/lucky-oranges-knock.md
+++ b/.changeset/lucky-oranges-knock.md
@@ -1,0 +1,17 @@
+---
+"@salt-ds/core": minor
+"@salt-ds/lab": minor
+"@salt-ds/theme": minor
+---
+
+Deprecated -emphasize tokens in status and palette; replaced with default tokens
+
+`--salt-status-error-background-emphasize` replaced with `--salt-status-error-background`
+`--salt-status-info-background-emphasize` replaced with `--salt-status-info-background`
+`--salt-status-success-background-emphasize` replaced with `--salt-status-success-background`
+`--salt-status-warning-background-emphasize` replaced with `--salt-status-warning-background`
+
+`--salt-palette-error-background-emphasize` replaced with `--salt-palette-error-background`
+`--salt-palette-info-background-emphasize` replaced with `--salt-palette-info-background`
+`--salt-palette-success-background-emphasize` replaced with `--salt-palette-success-background`
+`--salt-palette-warning-background-emphasize` replaced with `--salt-palette-warning-background`

--- a/packages/core/src/checkbox/CheckboxIcon.css
+++ b/packages/core/src/checkbox/CheckboxIcon.css
@@ -42,7 +42,7 @@
 
 /* Styles applied if `error={true}` on hover */
 .saltCheckbox-error:hover .saltCheckboxIcon {
-  background: var(--salt-status-error-background-emphasize);
+  background: var(--salt-status-error-background);
 }
 
 /* Styles applied if `error={true}` and `disabled={true}` */

--- a/packages/core/src/radio-button/RadioButtonIcon.css
+++ b/packages/core/src/radio-button/RadioButtonIcon.css
@@ -49,7 +49,7 @@
 }
 
 .saltRadioButton:hover .saltRadioButtonIcon-error .saltRadioButtonIcon-circle {
-  fill: var(--saltRadioButton-icon-error-hover-fill, var(--salt-status-error-background-emphasize));
+  fill: var(--saltRadioButton-icon-error-hover-fill, var(--salt-status-error-background));
 }
 
 /* Styles applied to radio button icon with error and disabled */

--- a/packages/lab/src/banner/Banner.css
+++ b/packages/lab/src/banner/Banner.css
@@ -74,17 +74,17 @@
 }
 
 .saltBanner-emphasize.saltBanner-info {
-  --banner-background: var(--salt-status-info-background-emphasize);
+  --banner-background: var(--salt-status-info-background);
 }
 
 .saltBanner-emphasize.saltBanner-error {
-  --banner-background: var(--salt-status-error-background-emphasize);
+  --banner-background: var(--salt-status-error-background);
 }
 
 .saltBanner-emphasize.saltBanner-warning {
-  --banner-background: var(--salt-status-warning-background-emphasize);
+  --banner-background: var(--salt-status-warning-background);
 }
 
 .saltBanner-emphasize.saltBanner-success {
-  --banner-background: var(--salt-status-success-background-emphasize);
+  --banner-background: var(--salt-status-success-background);
 }

--- a/packages/lab/src/file-drop-zone/FileDropZone.css
+++ b/packages/lab/src/file-drop-zone/FileDropZone.css
@@ -52,7 +52,7 @@
 
 /* Styles applied if `isRejected={true}`  */
 .saltFileDropZone-error {
-  --fileDropZone-background: var(--salt-status-error-background-emphasize);
+  --fileDropZone-background: var(--salt-status-error-background);
   --fileDropZone-borderColor: var(--salt-status-error-borderColor);
   --fileDropZone-icon-color: var(--salt-status-error-foreground);
 }

--- a/packages/lab/src/form-field/FormField.css
+++ b/packages/lab/src/form-field/FormField.css
@@ -134,12 +134,12 @@
 
 /* Error state styling when `variant="secondary"` */
 .saltFormField-secondary.saltFormField-error {
-  --formField-background: var(--salt-status-error-background-emphasize);
+  --formField-background: var(--salt-status-error-background);
 }
 
 /* Warning state styling when `variant="secondary"` */
 .saltFormField-secondary.saltFormField-warning {
-  --formField-background: var(--salt-status-warning-background-emphasize);
+  --formField-background: var(--salt-status-warning-background);
 }
 
 /* Class applied to the root element if `labelPlacement="left"` */

--- a/packages/theme/css/characteristics/status.css
+++ b/packages/theme/css/characteristics/status.css
@@ -25,12 +25,18 @@
   --salt-status-warning-borderColor-disabled: var(--salt-palette-warning-border-disabled);
   --salt-status-error-borderColor-disabled: var(--salt-palette-error-border-disabled);
 
-  --salt-status-info-background-emphasize: var(--salt-palette-info-background-emphasize);
-  --salt-status-success-background-emphasize: var(--salt-palette-success-background-emphasize);
-  --salt-status-warning-background-emphasize: var(--salt-palette-warning-background-emphasize);
-  --salt-status-error-background-emphasize: var(--salt-palette-error-background-emphasize);
+  --salt-status-info-background: var(--salt-palette-info-background);
+  --salt-status-success-background: var(--salt-palette-success-background);
+  --salt-status-warning-background: var(--salt-palette-warning-background);
+  --salt-status-error-background: var(--salt-palette-error-background);
 
   --salt-status-success-background-selected: var(--salt-palette-success-background-selected);
   --salt-status-warning-background-selected: var(--salt-palette-warning-background-selected);
   --salt-status-error-background-selected: var(--salt-palette-error-background-selected);
+
+  /* Deprecated */
+  --salt-status-info-background-emphasize: var(--salt-status-info-background);
+  --salt-status-success-background-emphasize: var(--salt-status-success-background);
+  --salt-status-warning-background-emphasize: var(--salt-status-warning-background);
+  --salt-status-error-background-emphasize: var(--salt-status-error-background);
 }

--- a/packages/theme/css/foundations/palette.css
+++ b/packages/theme/css/foundations/palette.css
@@ -11,6 +11,12 @@
   --salt-palette-opacity-primary-border: var(--salt-opacity-3);
   --salt-palette-opacity-secondary-border: var(--salt-opacity-2);
   --salt-palette-opacity-tertiary-border: var(--salt-opacity-1);
+
+  /* Deprecated */
+  --salt-palette-error-background-emphasize: var(--salt-palette-error-background);
+  --salt-palette-warning-background-emphasize: var(--salt-palette-warning-background);
+  --salt-palette-success-background-emphasize: var(--salt-palette-success-background);
+  --salt-palette-info-background-emphasize: var(--salt-palette-info-background);
 }
 
 .salt-theme[data-mode="light"] {
@@ -73,24 +79,24 @@
   --salt-palette-interact-secondary-foreground-hover: var(--salt-color-gray-900);
 
   /* States - error, info, success, warning */
-  --salt-palette-error-background-emphasize: var(--salt-color-red-10);
+  --salt-palette-error-background: var(--salt-color-red-10);
   --salt-palette-error-background-selected: var(--salt-color-red-20);
   --salt-palette-error-border: var(--salt-color-red-500);
   --salt-palette-error-border-disabled: var(--salt-color-red-500-fade-border);
   --salt-palette-error-foreground: var(--salt-color-red-500);
   --salt-palette-error-foreground-disabled: var(--salt-color-red-500-fade-foreground);
-  --salt-palette-info-background-emphasize: var(--salt-color-blue-10);
+  --salt-palette-info-background: var(--salt-color-blue-10);
   --salt-palette-info-border: var(--salt-color-blue-500);
   --salt-palette-info-border-disabled: var(--salt-color-blue-500-fade-border);
   --salt-palette-info-foreground: var(--salt-color-blue-500);
   --salt-palette-info-foreground-disabled: var(--salt-color-blue-500-fade-foreground);
-  --salt-palette-success-background-emphasize: var(--salt-color-green-10);
+  --salt-palette-success-background: var(--salt-color-green-10);
   --salt-palette-success-background-selected: var(--salt-color-green-20);
   --salt-palette-success-border: var(--salt-color-green-500);
   --salt-palette-success-border-disabled: var(--salt-color-green-500-fade-border);
   --salt-palette-success-foreground: var(--salt-color-green-500);
   --salt-palette-success-foreground-disabled: var(--salt-color-green-500-fade-foreground);
-  --salt-palette-warning-background-emphasize: var(--salt-color-orange-10);
+  --salt-palette-warning-background: var(--salt-color-orange-10);
   --salt-palette-warning-background-selected: var(--salt-color-orange-20);
   --salt-palette-warning-border: var(--salt-color-orange-700);
   --salt-palette-warning-border-disabled: var(--salt-color-orange-700-fade-border);
@@ -213,24 +219,24 @@
   --salt-palette-interact-secondary-foreground-hover: var(--salt-color-white);
 
   /* States - error, info, success, warning */
-  --salt-palette-error-background-emphasize: var(--salt-color-red-900);
+  --salt-palette-error-background: var(--salt-color-red-900);
   --salt-palette-error-background-selected: var(--salt-color-red-900);
   --salt-palette-error-border: var(--salt-color-red-500);
   --salt-palette-error-border-disabled: var(--salt-color-red-500-fade-border);
   --salt-palette-error-foreground: var(--salt-color-red-500);
   --salt-palette-error-foreground-disabled: var(--salt-color-red-500-fade-foreground);
-  --salt-palette-info-background-emphasize: var(--salt-color-blue-900);
+  --salt-palette-info-background: var(--salt-color-blue-900);
   --salt-palette-info-border: var(--salt-color-blue-500);
   --salt-palette-info-border-disabled: var(--salt-color-blue-500-fade-border);
   --salt-palette-info-foreground: var(--salt-color-blue-500);
   --salt-palette-info-foreground-disabled: var(--salt-color-blue-500-fade-foreground);
-  --salt-palette-success-background-emphasize: var(--salt-color-green-900);
+  --salt-palette-success-background: var(--salt-color-green-900);
   --salt-palette-success-background-selected: var(--salt-color-green-900);
   --salt-palette-success-border: var(--salt-color-green-400);
   --salt-palette-success-border-disabled: var(--salt-color-green-400-fade-border);
   --salt-palette-success-foreground: var(--salt-color-green-400);
   --salt-palette-success-foreground-disabled: var(--salt-color-green-400-fade-foreground);
-  --salt-palette-warning-background-emphasize: var(--salt-color-orange-900);
+  --salt-palette-warning-background: var(--salt-color-orange-900);
   --salt-palette-warning-background-selected: var(--salt-color-orange-900);
   --salt-palette-warning-border: var(--salt-color-orange-500);
   --salt-palette-warning-border-disabled: var(--salt-color-orange-500-fade-border);

--- a/packages/theme/stories/characteristics/status.stories.mdx
+++ b/packages/theme/stories/characteristics/status.stories.mdx
@@ -40,6 +40,10 @@ Components which have attributes that denote status and the severity of that sta
       <ColorBlock colorVar="--salt-status-error-borderColor-disabled" />
       <ColorBlock colorVar="--salt-status-warning-borderColor-disabled" />
       <ColorBlock colorVar="--salt-status-success-borderColor-disabled" />
+      <ColorBlock colorVar="--salt-status-error-background" />
+      <ColorBlock colorVar="--salt-status-warning-background" />
+      <ColorBlock colorVar="--salt-status-success-background" />
+      <ColorBlock colorVar="--salt-status-info-background" />
       <ColorBlock colorVar="--salt-status-error-background-selected" />
       <ColorBlock colorVar="--salt-status-warning-background-selected" />
       <ColorBlock colorVar="--salt-status-success-background-selected" />
@@ -47,15 +51,27 @@ Components which have attributes that denote status and the severity of that sta
   </Story>
 </Canvas>
 
-### Emphasized styling
+### Deprecated
 
 <Canvas>
   <Story name="Emphasized">
-    <DocGrid>
-      <ColorBlock colorVar="--salt-status-info-background-emphasize" />
-      <ColorBlock colorVar="--salt-status-error-background-emphasize" />
-      <ColorBlock colorVar="--salt-status-warning-background-emphasize" />
-      <ColorBlock colorVar="--salt-status-success-background-emphasize" />
+    <DocGrid withNotes>
+      <ColorBlock
+        colorVar="--salt-status-info-background-emphasize"
+        replacementToken="--salt-status-info-background"
+      />
+      <ColorBlock
+        colorVar="--salt-status-error-background-emphasize"
+        replacementToken="--salt-status-error-background"
+      />
+      <ColorBlock
+        colorVar="--salt-status-warning-background-emphasize"
+        replacementToken="--salt-status-warning-background"
+      />
+      <ColorBlock
+        colorVar="--salt-status-success-background-emphasize"
+        replacementToken="--salt-status-success-background"
+      />
     </DocGrid>
   </Story>
 </Canvas>

--- a/packages/theme/stories/palettes/error.stories.mdx
+++ b/packages/theme/stories/palettes/error.stories.mdx
@@ -5,6 +5,7 @@ import {
   ColorPalette,
   ColorItem,
 } from "@storybook/addon-docs";
+import { ColorBlock } from "docs/components/ColorBlock";
 import { ColorContainer } from "docs/components/ColorContainer";
 import { DocGrid } from "docs/components/DocGrid";
 
@@ -34,11 +35,11 @@ Colors used to symbolise an error state.
       }}
     />
     <ColorItem
-      title="Background (emphasized)"
-      subtitle="--salt-palette-error-background-emphasize"
+      title="Background"
+      subtitle="--salt-palette-error-background"
       colors={{
-        "--salt-palette-error-background-emphasize":
-          "var(--salt-palette-error-background-emphasize)",
+        "--salt-palette-error-background":
+          "var(--salt-palette-error-background)",
       }}
     />
     <ColorItem
@@ -51,3 +52,16 @@ Colors used to symbolise an error state.
     />
   </ColorPalette>
 </ColorContainer>
+
+### **Deprecated:** The following should be replaced as noted
+
+<Canvas>
+  <Story name="Emphasized">
+    <DocGrid withNotes>
+      <ColorBlock
+        colorVar="--salt-palette-error-background-emphasize"
+        replacementToken="--salt-palette-error-background"
+      />
+    </DocGrid>
+  </Story>
+</Canvas>

--- a/packages/theme/stories/palettes/info.stories.mdx
+++ b/packages/theme/stories/palettes/info.stories.mdx
@@ -5,6 +5,7 @@ import {
   ColorPalette,
   ColorItem,
 } from "@storybook/addon-docs";
+import { ColorBlock } from "docs/components/ColorBlock";
 import { ColorContainer } from "docs/components/ColorContainer";
 import { DocGrid } from "docs/components/DocGrid";
 
@@ -33,12 +34,24 @@ Colors used to represent informational content or messaging.
       }}
     />
     <ColorItem
-      title="Background (emphasized)"
-      subtitle="--salt-palette-info-background-emphasize"
+      title="Background"
+      subtitle="--salt-palette-info-background"
       colors={{
-        "--salt-palette-info-background-emphasize":
-          "var(--salt-palette-info-background-emphasize)",
+        "--salt-palette-info-background": "var(--salt-palette-info-background)",
       }}
     />
   </ColorPalette>
 </ColorContainer>
+
+### **Deprecated:** The following should be replaced as noted
+
+<Canvas>
+  <Story name="Emphasized">
+    <DocGrid withNotes>
+      <ColorBlock
+        colorVar="--salt-palette-info-background-emphasize"
+        replacementToken="--salt-palette-info-background"
+      />
+    </DocGrid>
+  </Story>
+</Canvas>

--- a/packages/theme/stories/palettes/measured.stories.mdx
+++ b/packages/theme/stories/palettes/measured.stories.mdx
@@ -6,6 +6,7 @@ import {
   ColorItem,
 } from "@storybook/addon-docs";
 import { Banner } from "@salt-ds/lab";
+import { ColorBlock } from "docs/components/ColorBlock";
 import { ColorContainer } from "docs/components/ColorContainer";
 import { DocGrid } from "docs/components/DocGrid";
 

--- a/packages/theme/stories/palettes/success.stories.mdx
+++ b/packages/theme/stories/palettes/success.stories.mdx
@@ -5,6 +5,7 @@ import {
   ColorPalette,
   ColorItem,
 } from "@storybook/addon-docs";
+import { ColorBlock } from "docs/components/ColorBlock";
 import { ColorContainer } from "docs/components/ColorContainer";
 import { DocGrid } from "docs/components/DocGrid";
 
@@ -34,11 +35,11 @@ Colors symbolising a success state or indication of process completion.
       }}
     />
     <ColorItem
-      title="Background (emphasized)"
-      subtitle="--salt-palette-success-background-emphasize"
+      title="Background"
+      subtitle="--salt-palette-success-background"
       colors={{
-        "--salt-palette-success-background-emphasize":
-          "var(--salt-palette-success-background-emphasize)",
+        "--salt-palette-success-background":
+          "var(--salt-palette-success-background)",
       }}
     />
     <ColorItem
@@ -51,3 +52,16 @@ Colors symbolising a success state or indication of process completion.
     />
   </ColorPalette>
 </ColorContainer>
+
+### **Deprecated:** The following should be replaced as noted
+
+<Canvas>
+  <Story name="Emphasized">
+    <DocGrid withNotes>
+      <ColorBlock
+        colorVar="--salt-palette-success-background-emphasize"
+        replacementToken="--salt-palette-success-background"
+      />
+    </DocGrid>
+  </Story>
+</Canvas>

--- a/packages/theme/stories/palettes/warning.stories.mdx
+++ b/packages/theme/stories/palettes/warning.stories.mdx
@@ -5,6 +5,7 @@ import {
   ColorPalette,
   ColorItem,
 } from "@storybook/addon-docs";
+import { ColorBlock } from "docs/components/ColorBlock";
 import { ColorContainer } from "docs/components/ColorContainer";
 import { DocGrid } from "docs/components/DocGrid";
 
@@ -34,11 +35,11 @@ Colors symbolising a warning state.
       }}
     />
     <ColorItem
-      title="Background (emphasized)"
-      subtitle="--salt-palette-warning-background-emphasize"
+      title="Background"
+      subtitle="--salt-palette-warning-background"
       colors={{
-        "--salt-palette-warning-background-emphasize":
-          "var(--salt-palette-warning-background-emphasize)",
+        "--salt-palette-warning-background":
+          "var(--salt-palette-warning-background)",
       }}
     />
     <ColorItem
@@ -51,3 +52,16 @@ Colors symbolising a warning state.
     />
   </ColorPalette>
 </ColorContainer>
+
+### **Deprecated:** The following should be replaced as noted
+
+<Canvas>
+  <Story name="Deprecated">
+    <DocGrid withNotes>
+      <ColorBlock
+        colorVar="--salt-palette-warning-background-emphasize"
+        replacementToken="--salt-palette-warning-background"
+      />
+    </DocGrid>
+  </Story>
+</Canvas>


### PR DESCRIPTION

Deprecated -emphasize tokens in status and palette; replaced with default tokens

`--salt-status-error-background-emphasize` replaced with `--salt-status-error-background`
`--salt-status-info-background-emphasize` replaced with `--salt-status-info-background`
`--salt-status-success-background-emphasize` replaced with `--salt-status-success-background`
`--salt-status-warning-background-emphasize` replaced with `--salt-status-warning-background`

`--salt-palette-error-background-emphasize` replaced with `--salt-palette-error-background`
`--salt-palette-info-background-emphasize` replaced with `--salt-palette-info-background`
`--salt-palette-success-background-emphasize` replaced with `--salt-palette-success-background`
`--salt-palette-warning-background-emphasize` replaced with `--salt-palette-warning-background`
