### PR TITLE
Icon size token changes

### DIFF
--- a/.changeset/polite-windows-tap.md
+++ b/.changeset/polite-windows-tap.md
@@ -1,0 +1,8 @@
+---
+"@salt-ds/core": minor
+"@salt-ds/icons": minor
+"@salt-ds/theme": minor
+---
+
+Deprecated `--salt-size-icon-base`, replaced with `--salt-icon-size-base`
+Added `--salt-icon-size-status-adornment`

--- a/packages/core/src/avatar/Avatar.css
+++ b/packages/core/src/avatar/Avatar.css
@@ -8,7 +8,7 @@
   --avatar-fontSize: calc(var(--avatar-base-fontSize) * var(--avatar-size-multiplier));
   /* Icon styling */
   --saltIcon-color: var(--avatar-foreground);
-  --salt-size-icon-base: calc(var(--avatar-container-size) / 2);
+  --salt-icon-size-base: calc(var(--avatar-container-size) / 2);
 }
 
 /* Style applied to the root element */

--- a/packages/icons/src/icon/Icon.css
+++ b/packages/icons/src/icon/Icon.css
@@ -2,7 +2,7 @@
 .saltIcon {
   --icon-color: var(--saltIcon-color, var(--salt-text-secondary-foreground));
   --icon-size-multiplier: var(--saltIcon-size-multiplier, 1);
-  --icon-base-size: var(--salt-size-icon-base, 12px);
+  --icon-base-size: var(--salt-icon-size-base, 12px);
   /**
    * Icon size will be the multiplier (an integer from the size prop) * the base size (set by the theme per density)
    * Icons should never be smaller than 12px for readability so we've added a max() to enforce this

--- a/packages/theme/css/foundations/icon.css
+++ b/packages/theme/css/foundations/icon.css
@@ -1,13 +1,24 @@
 .salt-density-touch {
-  --salt-size-icon-base: 16px;
+  --salt-icon-size-base: 16px;
+  --salt-icon-size-status-adornment: 12px;
 }
 
 .salt-density-low {
-  --salt-size-icon-base: 14px;
+  --salt-icon-size-base: 14px;
+  --salt-icon-size-status-adornment: 10px;
 }
+
 .salt-density-medium {
-  --salt-size-icon-base: 12px;
+  --salt-icon-size-base: 12px;
+  --salt-icon-size-status-adornment: 8px;
 }
+
 .salt-density-high {
-  --salt-size-icon-base: 10px;
+  --salt-icon-size-base: 10px;
+  --salt-icon-size-status-adornment: 6px;
+}
+
+.salt-theme {
+  /* **Deprecated:** Replacement tokens should be used as noted */
+  --salt-size-icon-base: var(--salt-icon-size-base); 
 }

--- a/packages/theme/css/foundations/icon.css
+++ b/packages/theme/css/foundations/icon.css
@@ -20,5 +20,5 @@
 
 .salt-theme {
   /* **Deprecated:** Replacement tokens should be used as noted */
-  --salt-size-icon-base: var(--salt-icon-size-base); 
+  --salt-size-icon-base: var(--salt-icon-size-base);
 }

--- a/packages/theme/stories/foundations/icon.stories.mdx
+++ b/packages/theme/stories/foundations/icon.stories.mdx
@@ -10,7 +10,7 @@ The defined set of foundational values for the Salt theme.
 
 ## Tokens
 
-<DocGrid style={{ paddingBottom: "20px" }}>
+<DocGrid>
   <SpacingBlock spacingVar="--salt-icon-size-base" />
   <SpacingBlock spacingVar="--salt-icon-size-status-adornment" />
 </DocGrid>

--- a/packages/theme/stories/foundations/icon.stories.mdx
+++ b/packages/theme/stories/foundations/icon.stories.mdx
@@ -1,0 +1,25 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
+import { DocGrid } from "docs/components/DocGrid";
+import { SpacingBlock } from "docs/components/SpacingBlock";
+
+<Meta title="Theme/Foundations/Icon" />
+
+# Icon
+
+The defined set of foundational values for the Salt theme.
+
+## Tokens
+
+<DocGrid style={{ paddingBottom: "20px" }}>
+  <SpacingBlock spacingVar="--salt-icon-size-base" />
+  <SpacingBlock spacingVar="--salt-icon-size-status-adornment" />
+</DocGrid>
+
+### **Deprecated:** The following should be replaced as noted
+
+<DocGrid withNotes>
+  <SpacingBlock
+    spacingVar="--salt-icon-size-base"
+    replacementToken="--salt-size-icon-base"
+  />
+</DocGrid>

--- a/site/src/components/accordion/Accordion.module.css
+++ b/site/src/components/accordion/Accordion.module.css
@@ -41,7 +41,7 @@
 }
 
 .summary :global(.saltIcon) {
-  --salt-size-icon-base: calc(var(--salt-size-unit) * 2);
+  --salt-icon-size-base: calc(var(--salt-size-unit) * 2);
 }
 
 .accordion :global(.saltAccordionDetails .saltAccordionDetails-content) {
@@ -52,6 +52,6 @@
 
 @media screen and (max-width: 768px) {
   .summary :global(.saltIcon) {
-    --salt-size-icon-base: var(--salt-size-unit);
+    --salt-icon-size-base: var(--salt-size-unit);
   }
 }

--- a/site/src/components/getting-started/develop-fonts-accordion/DevelopFontsAccordion.module.css
+++ b/site/src/components/getting-started/develop-fonts-accordion/DevelopFontsAccordion.module.css
@@ -3,7 +3,7 @@
 }
 
 .accordionWrapper :global(.saltIcon) {
-  --salt-size-icon-base: var(--salt-size-unit);
+  --salt-icon-size-base: var(--salt-size-unit);
 }
 
 .accordionWrapper :global(.saltAccordionSection) {

--- a/tooling/stylelint/custom-property-no-foundations/index.js
+++ b/tooling/stylelint/custom-property-no-foundations/index.js
@@ -83,9 +83,11 @@ const allAllowedKeys = [
   "delay", // TODO: **deprecated:** delete here
   "duration", // TODO: to be merged with animation
   "size",
+  // icon size
+  "icon-size",
   "zIndex",
   // palette opacity
-  "palette-opacity",
+  "palette-opacity"
 ];
 
 const regexpPattern = new RegExp(

--- a/tooling/stylelint/custom-property-no-foundations/index.js
+++ b/tooling/stylelint/custom-property-no-foundations/index.js
@@ -87,7 +87,7 @@ const allAllowedKeys = [
   "icon-size",
   "zIndex",
   // palette opacity
-  "palette-opacity"
+  "palette-opacity",
 ];
 
 const regexpPattern = new RegExp(


### PR DESCRIPTION
Deprecated `--salt-size-icon-base`, replaced with `--salt-icon-size-base` (aligns with design, and follows pattern of starting with foundation name)
Added `--salt-icon-size-status-adornment`
