### PR TITLE
Prevent AppHeader links from wrapping 

### DIFF
--- a/site/src/components/app-header/AppHeader.module.css
+++ b/site/src/components/app-header/AppHeader.module.css
@@ -8,6 +8,7 @@
 .appHeaderTabs :first-child {
   font-size: var(--salt-text-fontSize);
   gap: var(--salt-size-unit);
+  white-space: nowrap;
 }
 
 .root a[href*="github"] {


### PR DESCRIPTION
Before:
<img width="1124" alt="Screenshot 2023-04-20 at 14 17 08" src="https://user-images.githubusercontent.com/31695437/233378302-e84a0558-ed0c-45a3-9b6a-673e5913980a.png">
After:
<img width="1062" alt="Screenshot 2023-04-20 at 14 17 19" src="https://user-images.githubusercontent.com/31695437/233378365-e4d8c132-1192-41e2-8512-b75f44fdc2ab.png">
