### PR TITLE
Fixed error in run local server instructions

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -22,7 +22,7 @@ SNAPSHOT_MODE=active
 
 ## Run the local server
 
-Run the following command and navigate to `http://localhost:3000/local/index`.
+Run the following command and navigate to `http://localhost:3000/salt/index`.
 
 ```
 yarn serve


### PR DESCRIPTION
The current instructions direct to a local "page not found", as the url should read http://localhost:3000/salt/index