### PR TITLE
Update Tooltip props to account for new content attribute

### DIFF
--- a/.changeset/gentle-geese-smile.md
+++ b/.changeset/gentle-geese-smile.md
@@ -2,4 +2,4 @@
 "@salt-ds/core": patch
 ---
 
-Update Tooltip props to account for new content attribute introduced in @types/react 18.2.4
+Update Tooltip props to account for the new content attribute introduced in @types/react@18.2.4

--- a/.changeset/gentle-geese-smile.md
+++ b/.changeset/gentle-geese-smile.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Update Tooltip props to account for new content attribute introduced in @types/react 18.2.4

--- a/packages/core/src/tooltip/Tooltip.tsx
+++ b/packages/core/src/tooltip/Tooltip.tsx
@@ -22,8 +22,8 @@ import { SaltProvider } from "../salt-provider";
 const withBaseName = makePrefixer("saltTooltip");
 
 export interface TooltipProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, "content">,
-    Pick<UseFloatingUIProps, "open" | "onOpenChange" | "placement"> {
+  extends Pick<UseFloatingUIProps, "open" | "onOpenChange" | "placement">,
+    Omit<HTMLAttributes<HTMLDivElement>, "content"> {
   /**
    * The children will be the Tooltip's trigger.
    */

--- a/packages/core/src/tooltip/Tooltip.tsx
+++ b/packages/core/src/tooltip/Tooltip.tsx
@@ -3,16 +3,16 @@ import {
   cloneElement,
   forwardRef,
   HTMLAttributes,
-  ReactNode,
   isValidElement,
+  ReactNode,
   Ref,
 } from "react";
 import { FloatingArrow, FloatingPortal } from "@floating-ui/react";
 import { StatusIndicator, ValidationStatus } from "../status-indicator";
 import {
-  UseFloatingUIProps,
   makePrefixer,
   mergeProps,
+  UseFloatingUIProps,
   useForkRef,
 } from "../utils";
 import { useTooltip, UseTooltipProps } from "./useTooltip";
@@ -22,7 +22,7 @@ import { SaltProvider } from "../salt-provider";
 const withBaseName = makePrefixer("saltTooltip");
 
 export interface TooltipProps
-  extends HTMLAttributes<HTMLDivElement>,
+  extends Omit<HTMLAttributes<HTMLDivElement>, "content">,
     Pick<UseFloatingUIProps, "open" | "onOpenChange" | "placement"> {
   /**
    * The children will be the Tooltip's trigger.


### PR DESCRIPTION
Update Tooltip props to account for new content attribute introduced in new react types version.

https://github.com/DefinitelyTyped/DefinitelyTyped/commit/3f5d20608d31363487694535189ef64569043ff9
