### PR TITLE
Add check for targetWindow to UseComponentCssInjection

### DIFF
--- a/packages/styles/src/use-style-injection/useStyleInjection.ts
+++ b/packages/styles/src/use-style-injection/useStyleInjection.ts
@@ -25,7 +25,10 @@ export function useComponentCssInjection({
   window: targetWindow,
 }: UseComponentCssInjection): void {
   const insertionPoint = useInsertionPoint();
-
+  // Don't inject if we don't have a provided window or if it is the main window.
+  if (!targetWindow || targetWindow === window) {
+    return;
+  }
   maybeUseInsertionEffect(() => {
     let sheetsMap = windowSheetsMap.get(targetWindow) ?? new Map();
     let styleMap = sheetsMap.get(id) ?? { styleElement: null, count: 0 };


### PR DESCRIPTION
This adds a check to  UseComponentCssInjection if the targetWindow is null or if it is equal to the main window.

We do this because of the use of style-inject, which already handles style injection into the main window.