### PR TITLE
Fix Tabstrip crashes when setting `activeTabIndex` to null

### DIFF
--- a/.changeset/eleven-gifts-agree.md
+++ b/.changeset/eleven-gifts-agree.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/lab": patch
+---
+
+Fix Tabstrip crashes when setting `activeTabIndex` to null

--- a/packages/lab/src/tabs/Tabstrip.tsx
+++ b/packages/lab/src/tabs/Tabstrip.tsx
@@ -463,7 +463,9 @@ export const Tabstrip = forwardRef(function Tabstrip(
     }
   );
 
-  const { id: selectedTabId } = collectionHook.data[activeTabIndex];
+  // We don't want the component to crash when `activeTabIndex` is set up null
+  const selectedTabId =
+    activeTabIndex !== null ? collectionHook.data[activeTabIndex].id : null;
 
   return (
     <div
@@ -479,9 +481,13 @@ export const Tabstrip = forwardRef(function Tabstrip(
       </div>
       {showActivationIndicator ? (
         <TabActivationIndicator
-          hideThumb={selectedTabOverflowed || tabstripHook.isDragging}
+          hideThumb={
+            selectedTabOverflowed ||
+            tabstripHook.isDragging ||
+            selectedTabId === null
+          }
           orientation={orientation}
-          tabId={selectedTabId}
+          tabId={selectedTabId || collectionHook.data[0].id}
         />
       ) : null}
       {tabstripHook.draggable}

--- a/packages/lab/stories/tabstrip/tabstrip.stories.tsx
+++ b/packages/lab/stories/tabstrip/tabstrip.stories.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from "react";
-import { Link, SaltProvider, Text } from "@salt-ds/core";
+import { Button, FlexLayout, Link, SaltProvider, Text } from "@salt-ds/core";
 import {
   EditableLabel,
   Tab,
@@ -1037,5 +1037,30 @@ export const DraggableTabsWithOverflow = () => {
         activeTabIndex={activeTabIndex}
       />
     </div>
+  );
+};
+
+export const NullTabIndex = () => {
+  const [activeTabIndex, setActiveTabIndex] = useState<null | number>(1);
+  return (
+    <SaltProvider>
+      <FlexLayout align="center">
+        <Text>Set active index to</Text>
+        <Button onClick={() => setActiveTabIndex(null)}>Null</Button>
+        <Button onClick={() => setActiveTabIndex(0)}>0</Button>
+        <Button onClick={() => setActiveTabIndex(1)}>1</Button>
+      </FlexLayout>
+      <Tabstrip
+        // @ts-expect-error We don't officially support `null` for activeTabIndex, but we want to test `null` won't crash the app
+        activeTabIndex={activeTabIndex}
+        style={{ width: 600 }}
+        id="ts"
+        onActiveChange={setActiveTabIndex}
+      >
+        {_colours.map((label) => (
+          <Tab key={`tab-${label}`} label={label} />
+        ))}
+      </Tabstrip>
+    </SaltProvider>
   );
 };


### PR DESCRIPTION
Try a different approach on #1677

Fixes #1676