### PR TITLE
Fix ids in label and helper text of FF Next

### DIFF
--- a/.changeset/forty-toes-type.md
+++ b/.changeset/forty-toes-type.md
@@ -2,5 +2,5 @@
 "@salt-ds/lab": minor
 ---
 
-Fixed ids in `FormFieldLabel` and `FormFieldHelperText` from useFormFieldPropsNext
+Fixed id in `FormFieldNext`, and ids in `FormFieldLabel` and `FormFieldHelperText` from useFormFieldPropsNext
 Deleted `a11yValueAriaProps`, replaced `a11yProps` type with `A11yValueProps` in `FormFieldContextNext`

--- a/.changeset/forty-toes-type.md
+++ b/.changeset/forty-toes-type.md
@@ -1,0 +1,6 @@
+---
+"@salt-ds/lab": minor
+---
+
+Fixed ids in `FormFieldLabel` and `FormFieldHelperText` from useFormFieldPropsNext
+Deleted `a11yValueAriaProps`, replaced `a11yProps` type with `A11yValueProps` in `FormFieldContextNext`

--- a/packages/lab/src/form-field-context-next/FormFieldContextNext.ts
+++ b/packages/lab/src/form-field-context-next/FormFieldContextNext.ts
@@ -1,5 +1,4 @@
 import { createContext } from "@salt-ds/core";
-
 export interface A11yValueProps {
   /**
    * id for FormFieldHelperText
@@ -10,12 +9,8 @@ export interface A11yValueProps {
    */
   labelId?: string;
 }
-export interface a11yValueAriaProps {
-  "aria-labelledby": A11yValueProps["labelId"];
-  "aria-describedby": A11yValueProps["helperTextId"] | undefined;
-}
 export interface FormFieldContextNextValue {
-  a11yProps: a11yValueAriaProps;
+  a11yProps: A11yValueProps;
   disabled: boolean;
   readOnly: boolean;
   validationStatus: "error" | "warning" | "success" | undefined;

--- a/packages/lab/src/form-field-next/FormFieldHelperText.tsx
+++ b/packages/lab/src/form-field-next/FormFieldHelperText.tsx
@@ -11,7 +11,7 @@ export const FormFieldHelperText = ({
   children,
   ...restProps
 }: Omit<TextProps<"label">, "variant" | "styleAs">) => {
-  const { disabled, readOnly, validationStatus } = useFormFieldPropsNext();
+  const { a11yProps, disabled, readOnly, validationStatus } = useFormFieldPropsNext();
 
   return (
     <div
@@ -20,6 +20,7 @@ export const FormFieldHelperText = ({
         { [withBaseName("withValidation")]: validationStatus },
         className
       )}
+      id={a11yProps?.["aria-describedby"]}
     >
       {!disabled && !readOnly && validationStatus && (
         <StatusIndicator status={validationStatus} />

--- a/packages/lab/src/form-field-next/FormFieldHelperText.tsx
+++ b/packages/lab/src/form-field-next/FormFieldHelperText.tsx
@@ -20,7 +20,7 @@ export const FormFieldHelperText = ({
         { [withBaseName("withValidation")]: validationStatus },
         className
       )}
-      id={a11yProps?.["aria-describedby"]}
+      id={a11yProps?.helperTextId}
     >
       {!disabled && !readOnly && validationStatus && (
         <StatusIndicator status={validationStatus} />

--- a/packages/lab/src/form-field-next/FormFieldHelperText.tsx
+++ b/packages/lab/src/form-field-next/FormFieldHelperText.tsx
@@ -11,7 +11,8 @@ export const FormFieldHelperText = ({
   children,
   ...restProps
 }: Omit<TextProps<"label">, "variant" | "styleAs">) => {
-  const { a11yProps, disabled, readOnly, validationStatus } = useFormFieldPropsNext();
+  const { a11yProps, disabled, readOnly, validationStatus } =
+    useFormFieldPropsNext();
 
   return (
     <div

--- a/packages/lab/src/form-field-next/FormFieldLabel.tsx
+++ b/packages/lab/src/form-field-next/FormFieldLabel.tsx
@@ -20,7 +20,7 @@ export const FormFieldLabel = ({
       className={clsx(withBaseName(), className)}
       disabled={disabled}
       variant="secondary"
-      id={a11yProps?.["aria-labelledby"]}
+      id={a11yProps?.labelId}
     >
       {children}
     </Label>

--- a/packages/lab/src/form-field-next/FormFieldLabel.tsx
+++ b/packages/lab/src/form-field-next/FormFieldLabel.tsx
@@ -11,15 +11,16 @@ export const FormFieldLabel = ({
   children,
   ...restProps
 }: Omit<TextProps<"label">, "variant" | "styleAs">) => {
-  const { disabled } = useFormFieldPropsNext();
+  const { a11yProps, disabled } = useFormFieldPropsNext();
 
   return (
     <Label
       as="label"
+      {...restProps}
       className={clsx(withBaseName(), className)}
       disabled={disabled}
       variant="secondary"
-      {...restProps}
+      id={a11yProps?.["aria-labelledby"]}
     >
       {children}
     </Label>

--- a/packages/lab/src/form-field-next/FormFieldNext.tsx
+++ b/packages/lab/src/form-field-next/FormFieldNext.tsx
@@ -27,6 +27,9 @@ export interface FormFieldProps
   readOnly?: boolean;
   /**
    * Optional id prop
+   * 
+   * Used as suffix of FormFieldLabel id: `label-{id}`
+   * Used as suffix of FormFieldHelperText id: `helperText-{id}`
    */
   id?: string;
   /**

--- a/packages/lab/src/form-field-next/FormFieldNext.tsx
+++ b/packages/lab/src/form-field-next/FormFieldNext.tsx
@@ -75,7 +75,12 @@ export const FormField = forwardRef(
         {...restProps}
       >
         <FormFieldContextNext.Provider
-          value={{ a11yProps: { labelId, helperTextId }, disabled, readOnly, validationStatus }}
+          value={{
+            a11yProps: { labelId, helperTextId },
+            disabled,
+            readOnly,
+            validationStatus,
+          }}
         >
           {children}
         </FormFieldContextNext.Provider>

--- a/packages/lab/src/form-field-next/FormFieldNext.tsx
+++ b/packages/lab/src/form-field-next/FormFieldNext.tsx
@@ -51,7 +51,6 @@ export const FormField = forwardRef(
       onBlur,
       onFocus,
       readOnly = false,
-      id: idProp,
       validationStatus,
       ...restProps
     }: FormFieldProps,

--- a/packages/lab/src/form-field-next/FormFieldNext.tsx
+++ b/packages/lab/src/form-field-next/FormFieldNext.tsx
@@ -43,6 +43,7 @@ export const FormField = forwardRef(
       children,
       className,
       disabled = false,
+      id: idProp,
       labelPlacement = "top",
       onBlur,
       onFocus,
@@ -53,16 +54,10 @@ export const FormField = forwardRef(
     }: FormFieldProps,
     ref: ForwardedRef<HTMLDivElement>
   ) => {
-    const labelId = useId();
-    const helperTextId = useId();
+    const formId = useId(idProp);
 
-    const a11yProps = useMemo(
-      () => ({
-        "aria-labelledby": labelId,
-        "aria-describedby": helperTextId,
-      }),
-      [labelId, helperTextId]
-    );
+    const labelId = formId ? `label-${formId}` : undefined;
+    const helperTextId = formId ? `helperText-${formId}` : undefined;
 
     return (
       <div
@@ -80,7 +75,7 @@ export const FormField = forwardRef(
         {...restProps}
       >
         <FormFieldContextNext.Provider
-          value={{ a11yProps, disabled, readOnly, validationStatus }}
+          value={{ a11yProps: { labelId, helperTextId }, disabled, readOnly, validationStatus }}
         >
           {children}
         </FormFieldContextNext.Provider>

--- a/packages/lab/src/form-field-next/FormFieldNext.tsx
+++ b/packages/lab/src/form-field-next/FormFieldNext.tsx
@@ -1,5 +1,5 @@
 import { clsx } from "clsx";
-import { ForwardedRef, forwardRef, HTMLAttributes, useMemo } from "react";
+import { ForwardedRef, forwardRef, HTMLAttributes } from "react";
 import { makePrefixer, useId, capitalize } from "@salt-ds/core";
 import {
   A11yValueProps,

--- a/packages/lab/src/form-field-next/FormFieldNext.tsx
+++ b/packages/lab/src/form-field-next/FormFieldNext.tsx
@@ -27,7 +27,7 @@ export interface FormFieldProps
   readOnly?: boolean;
   /**
    * Optional id prop
-   * 
+   *
    * Used as suffix of FormFieldLabel id: `label-{id}`
    * Used as suffix of FormFieldHelperText id: `helperText-{id}`
    */

--- a/packages/lab/src/index.ts
+++ b/packages/lab/src/index.ts
@@ -45,7 +45,6 @@ export {
 export * from "./form-field-context";
 export {
   type A11yValueProps as A11yValuePropsNext,
-  type a11yValueAriaProps as a11yValueAriaPropsNext,
   type FormFieldContextNextValue,
   FormFieldContextNext,
 } from "./form-field-context-next";

--- a/packages/lab/src/input-next/InputNext.tsx
+++ b/packages/lab/src/input-next/InputNext.tsx
@@ -76,7 +76,7 @@ function mergeA11yProps(
   misplacedAriaProps: AriaAttributes
 ) {
   const ariaLabelledBy = clsx(
-    a11yProps["aria-labelledby"],
+    a11yProps.labelId,
     inputProps["aria-labelledby"]
   );
 

--- a/packages/lab/src/input-next/InputNext.tsx
+++ b/packages/lab/src/input-next/InputNext.tsx
@@ -75,10 +75,7 @@ function mergeA11yProps(
   inputProps: InputProps["inputProps"] = {},
   misplacedAriaProps: AriaAttributes
 ) {
-  const ariaLabelledBy = clsx(
-    a11yProps.labelId,
-    inputProps["aria-labelledby"]
-  );
+  const ariaLabelledBy = clsx(a11yProps.labelId, inputProps["aria-labelledby"]);
 
   return {
     ...misplacedAriaProps,


### PR DESCRIPTION

Fixed ids in `FormFieldLabel` and `FormFieldHelperText` from useFormFieldPropsNext
Deleted `a11yValueAriaProps`, replaced `a11yProps` type with `A11yValueProps` in `FormFieldContextNext`
