### PR TITLE
Add community label to new bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,6 +3,7 @@ description: Report bugs in our code.
 labels:
   - "type: bug 🪲"
   - "status: awaiting triage"
+  - "community"
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Updates the bug reporting issue template to automatically add a "community" label. This label will let us differentiate between community-raised issues (which are potentially subject to our 2 week resolution SLA) and internal defects.

The assumption is that incoming defects via that form will be raised by our community.

Where someone in our team uses the form, they can just remove the community label afterwards.