### PR TITLE
Fixes WindowProvider props so that they don't extend from Window

### DIFF
--- a/packages/window/src/WindowProvider.tsx
+++ b/packages/window/src/WindowProvider.tsx
@@ -10,8 +10,9 @@ if (process.env.NODE_ENV !== "production") {
   WindowContext.displayName = "WindowContext";
 }
 
-export interface WindowProviderProps extends WindowContextType {
+export interface WindowProviderProps {
   children: ReactNode;
+  window: WindowContextType;
 }
 
 export function WindowProvider(props: WindowProviderProps) {


### PR DESCRIPTION
I spotted a bug (I think) in the `WindowProviderProps` interface while trying to resolve some Salt site build issues. It extends `WindowContextType` (which is currently just an alias for `Window`) and therefore includes all the Window properties. Presumably that was not the intent, and what's actually needed is just a `window` prop, whose type is `WindowContextType`. (Note, this has gone unnoticed so far because the `Window` interface happens to have a `.window` property whose type is `Window & typeof globalThis` and therefore compatible with `Window`)

This PR corrects that.

However, I think this will once again break the Salt site builds. Since a static HTML representation of each page is generated at build time, there is no `Window` object, since the React components are being rendered by Node rather than in the browser. Our workaround so far has been to do this:

```tsx
<WindowProvider window={globalThis}>
  ...
</WindowProvider>
```

But, with the correction done in this PR, I suspect that'll no longer work, since `typeof globalThis` won't match `Window`. Is there a way we can make this compatible with SSR environments like Next.js? Perhaps `useWindow()` could return a window _or `null`_ when not in a browser env? I guess your style injection code would then need to be updated to gracefully handle that `null` case though.