### PR TITLE
Fix homepage card styling regressions on website

### DIFF
--- a/site/src/_index/accordion/Accordion.module.css
+++ b/site/src/_index/accordion/Accordion.module.css
@@ -14,7 +14,7 @@
 }
 
 .accordionWrapper {
-  background-color: var(--card-background);
+  background-color: #10212b;
   width: min(55vw, var(--max-container-width));
   padding: calc(var(--salt-size-unit) * 10);
   grid-area: 2 / 1 / 3 / 3;

--- a/site/src/_index/accordion/Accordion.module.css
+++ b/site/src/_index/accordion/Accordion.module.css
@@ -14,7 +14,7 @@
 }
 
 .accordionWrapper {
-  background-color: #10212b;
+  background-color: var(--salt-site-dark-accent);
   width: min(55vw, var(--max-container-width));
   padding: calc(var(--salt-size-unit) * 10);
   grid-area: 2 / 1 / 3 / 3;

--- a/site/src/components/card/Card.module.css
+++ b/site/src/components/card/Card.module.css
@@ -1,18 +1,9 @@
 .card,
 .inlineCard {
-  --ifm-link-hover-color: none;
-  --ifm-link-decoration: none;
-  --ifm-link-hover-decoration: none;
-  --card-color: var(--salt-color-white);
-  --card-icon-background: #0e1b23;
-  --saltIcon-color: var(--salt-color-gray-900);
-}
-
-.card.lightTheme,
-.inlineCard.lightTheme {
-  --card-background: var(--salt-color-white);
-  --card-color: var(--salt-color-gray-900);
-  --card-icon-background: var(--salt-color-gray-10);
+  --card-background: var(--salt-container-primary-background);
+  --card-color: var(--salt-text-primary-foreground);
+  --card-icon-background: var(--salt-container-secondary-background);
+  --saltIcon-color: var(---salt-text-primary-foreground);
 }
 
 .cardTitle h2 {

--- a/site/src/components/card/Card.tsx
+++ b/site/src/components/card/Card.tsx
@@ -8,7 +8,7 @@ import {
 import clsx from "clsx";
 import { Link } from "@jpmorganchase/mosaic-site-components";
 
-import { useTheme, useViewport } from "@salt-ds/core";
+import { useViewport } from "@salt-ds/core";
 
 import useOnScreen from "../../utils/useOnScreen";
 
@@ -34,20 +34,14 @@ export const Card = ({
   footerText,
   keylineColor,
   keyLineAnimation = true,
+  className,
 }: CardProps): JSX.Element => {
   const ref = useRef<HTMLDivElement>(null);
 
   const onScreen: boolean = useOnScreen<HTMLDivElement>(ref, "-100px");
 
-  const { mode } = useTheme();
-
-  const useLightTheme = mode !== "dark";
-
   return (
-    <Link
-      className={clsx(styles.card, { [styles.lightTheme]: useLightTheme })}
-      href={url}
-    >
+    <Link className={clsx(styles.card, className)} href={url}>
       {icon && (
         <div className={styles.iconContainer}>
           {cloneElement(icon, { ...icon.props, className: styles.icon })}
@@ -82,15 +76,12 @@ export const InlineCard = ({
   url,
   footerText,
   keylineColor,
+  className,
 }: CardProps): JSX.Element => {
   const ref = useRef<HTMLDivElement>(null);
 
-  const { mode } = useTheme();
-
   const viewport = useViewport();
   const isTabletView = viewport <= 1070;
-
-  const useLightTheme = mode !== "dark";
 
   if (isTabletView) {
     return (
@@ -106,12 +97,7 @@ export const InlineCard = ({
   }
 
   return (
-    <Link
-      className={clsx(styles.inlineCard, {
-        [styles.lightTheme]: useLightTheme,
-      })}
-      href={url}
-    >
+    <Link className={clsx(styles.inlineCard, className)} href={url}>
       <div className={styles.inlineCardContent}>
         {icon && (
           <div className={styles.iconContainer}>

--- a/site/src/css/base/base.css
+++ b/site/src/css/base/base.css
@@ -1,7 +1,6 @@
 :root {
   --max-container-width: 1920px;
   --max-content-width: min(var(--max-container-width), 120ch);
-  --card-background: #10212b;
   --navbar-height: 44px;
 }
 

--- a/site/src/css/base/base.css
+++ b/site/src/css/base/base.css
@@ -2,6 +2,10 @@
   --max-container-width: 1920px;
   --max-content-width: min(var(--max-container-width), 120ch);
   --navbar-height: 44px;
+
+  /* "Special" colors used mainly on homepage */
+  --salt-site-dark-accent: #10212b;
+  --salt-site-dark-accent-secondary: #0e1b23;
 }
 
 :root {

--- a/site/src/pages/index.module.css
+++ b/site/src/pages/index.module.css
@@ -90,6 +90,11 @@
   padding: calc(var(--salt-size-unit) * 5) calc(var(--salt-size-unit) * 4);
 }
 
+.card {
+  --card-background: #10212b;
+  --card-icon-background: #0e1b23;
+}
+
 @media screen and (max-width: 1280px) {
   .heroTitle {
     --heading-line-height: var(--salt-text-h1-lineHeight);

--- a/site/src/pages/index.module.css
+++ b/site/src/pages/index.module.css
@@ -91,8 +91,8 @@
 }
 
 .card {
-  --card-background: #10212b;
-  --card-icon-background: #0e1b23;
+  --card-background: var(--salt-site-dark-accent);
+  --card-icon-background: var(--salt-site-dark-accent-secondary);
 }
 
 @media screen and (max-width: 1280px) {

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -185,6 +185,7 @@ const Homepage = (): JSX.Element => {
                 url={url}
                 footerText={footerText}
                 keylineColor={keylineColor}
+                className={styles.card}
               />
             );
           })}


### PR DESCRIPTION
The cards on our site's homepage have turned white. This fixes that.

The root cause is as follows:

* The website's `Card` component (which is _not_ the Salt core `Card` at the moment), was using `useTheme()` to determine light/dark mode and then adding extra CSS classes to change the colors
* For some weird reason, that call to `useTheme()` on the homepage was incorrectly reporting `light`, when it was actually meant to be `dark`, so the wrong card styles were applied. (Weirdly, the elements rendered to the DOM _do_ actually set a `data-mode="dark"` attribute, so as far as CSS is concerned, dark mode is in effect)

My fix removes that JS code and instead leans on our CSS custom properties to apply the correct light/dark styling. Our homepage actually uses some bespoke colors, so I'm doing that via the Hompage's CSS.

While this does fix the card styling, there should be further investigation into _why_ the `<SaltProvider>` doesn't seem to be working as expected.
