### PR TITLE
Tooltip floating platform

### DIFF
--- a/.changeset/brown-stingrays-yell.md
+++ b/.changeset/brown-stingrays-yell.md
@@ -1,0 +1,12 @@
+---
+"@salt-ds/core": minor
+---
+
+## Added desktop support for Tooltips
+
+Advanced Desktop support can now be achieved for `<Tooltip>` by passing a [Floating UI Platform](https://floating-ui.com/docs/platform) via a new `<FloatingPlatformProvider>` component.
+
+This enables advanced use-cases e.g. on multi-window desktop applications where you may want to render a `Tooltip` in an external window, and position it relative to a global coordinate space such as a user's desktop.
+
+To support this use-case you can also pass a component to be used as the root for floating components such as `<Tooltip>`, overriding the default. This is done using the `<FloatingComponentProvider>`. The component used as the FloatingComponent will receive the Floating UI props used for positioning, as well as `open` and `disabled`, so you can hook into the Tooltip
+s lifecycle e.g. to activate external windows.

--- a/packages/core/src/tooltip/Tooltip.tsx
+++ b/packages/core/src/tooltip/Tooltip.tsx
@@ -7,22 +7,19 @@ import {
   ReactNode,
   Ref,
 } from "react";
-import { FloatingArrow, FloatingPortal } from "@floating-ui/react";
-import { useWindow } from "@salt-ds/window";
-import { useComponentCssInjection } from "@salt-ds/styles";
 
-import { StatusIndicator, ValidationStatus } from "../status-indicator";
+import { ValidationStatus } from "../status-indicator";
 import {
   makePrefixer,
   mergeProps,
   UseFloatingUIProps,
   useForkRef,
+  useFloatingComponent,
 } from "../utils";
-import { SaltProvider } from "../salt-provider";
 
 import { useTooltip, UseTooltipProps } from "./useTooltip";
-import tooltipCss from "./Tooltip.css";
 import { useFormFieldProps } from "../form-field-context";
+import { TooltipBase } from "./TooltipBase";
 
 const withBaseName = makePrefixer("saltTooltip");
 
@@ -76,7 +73,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     const {
       children,
       className,
-      disabled: disabledProp,
+      disabled: disabledProp = false,
       hideArrow = false,
       hideIcon = false,
       open: openProp,
@@ -89,7 +86,6 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     } = props;
 
     const {
-      a11yProps,
       disabled: formFieldDisabled,
       validationStatus: formFieldValidationStatus,
     } = useFormFieldProps();
@@ -97,12 +93,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     const disabled = formFieldDisabled ?? disabledProp;
     const status = formFieldValidationStatus ?? statusProp;
 
-    const targetWindow = useWindow();
-    useComponentCssInjection({
-      testId: "salt-tooltip",
-      css: tooltipCss,
-      window: targetWindow,
-    });
+    const { Component } = useFloatingComponent();
 
     const hookProps: UseTooltipProps = {
       open: openProp,
@@ -126,7 +117,6 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       isValidElement(children) ? children.ref : null,
       reference
     );
-
     const floatingRef = useForkRef(floating, ref) as Ref<HTMLDivElement>;
 
     return (
@@ -137,49 +127,21 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
             ref: triggerRef,
           })}
 
-        {open && !disabled && (
-          <FloatingPortal>
-            {/* The provider is needed to support the use case where an app has nested modes. The element that is portalled needs to have the same style as the current scope */}
-            <SaltProvider>
-              <div
-                className={clsx(
-                  withBaseName(),
-                  withBaseName(status),
-                  className
-                )}
-                ref={floatingRef}
-                {...getTooltipProps()}
-              >
-                <div className={withBaseName("container")}>
-                  {!hideIcon && (
-                    <StatusIndicator
-                      status={status}
-                      size={1}
-                      className={withBaseName("icon")}
-                    />
-                  )}
-                  <span
-                    id={a11yProps?.["aria-describedby"]}
-                    className={withBaseName("content")}
-                  >
-                    {content}
-                  </span>
-                </div>
-                {!hideArrow && (
-                  <FloatingArrow
-                    {...arrowProps}
-                    className={withBaseName("arrow")}
-                    strokeWidth={1}
-                    fill="var(--salt-container-primary-background)"
-                    stroke="var(--tooltip-status-borderColor)"
-                    height={5}
-                    width={10}
-                  />
-                )}
-              </div>
-            </SaltProvider>
-          </FloatingPortal>
-        )}
+        <Component
+          className={clsx(withBaseName(), withBaseName(status), className)}
+          open={open}
+          disabled={disabled}
+          ref={floatingRef}
+          {...getTooltipProps()}
+        >
+          <TooltipBase
+            hideIcon={hideIcon}
+            status={status}
+            content={content}
+            hideArrow={hideArrow}
+            arrowProps={arrowProps}
+          />
+        </Component>
       </>
     );
   }

--- a/packages/core/src/tooltip/TooltipBase.tsx
+++ b/packages/core/src/tooltip/TooltipBase.tsx
@@ -1,0 +1,62 @@
+import { StatusIndicator, ValidationStatus } from "../status-indicator";
+import { FloatingArrow, FloatingArrowProps } from "@floating-ui/react";
+import { TooltipProps } from "./Tooltip";
+import { makePrefixer } from "../utils";
+import { useFormFieldProps } from "../form-field-context";
+
+import tooltipCss from "./Tooltip.css";
+import { useWindow } from "@salt-ds/window";
+import { useComponentCssInjection } from "@salt-ds/styles";
+
+const withBaseName = makePrefixer("saltTooltip");
+
+interface TooltipBaseProps extends Omit<TooltipProps, "children"> {
+  arrowProps: FloatingArrowProps;
+  /**
+   * A string to determine the status of the Tooltip. Defaults to `info`.
+   */
+  status: ValidationStatus;
+}
+
+export const TooltipBase = (props: TooltipBaseProps) => {
+  const targetWindow = useWindow();
+  useComponentCssInjection({
+    testId: "salt-tooltip",
+    css: tooltipCss,
+    window: targetWindow,
+  });
+
+  const { a11yProps } = useFormFieldProps();
+
+  const { arrowProps, content, hideArrow, hideIcon, status } = props;
+  return (
+    <>
+      <div className={withBaseName("container")}>
+        {!hideIcon && (
+          <StatusIndicator
+            status={status}
+            size={1}
+            className={withBaseName("icon")}
+          />
+        )}
+        <span
+          id={a11yProps?.["aria-describedby"]}
+          className={withBaseName("content")}
+        >
+          {content}
+        </span>
+      </div>
+      {!hideArrow && (
+        <FloatingArrow
+          {...arrowProps}
+          className={withBaseName("arrow")}
+          strokeWidth={1}
+          fill="var(--salt-container-primary-background)"
+          stroke="var(--tooltip-status-borderColor)"
+          height={5}
+          width={10}
+        />
+      )}
+    </>
+  );
+};

--- a/packages/core/src/tooltip/useTooltip.ts
+++ b/packages/core/src/tooltip/useTooltip.ts
@@ -68,6 +68,7 @@ export function useTooltip(props?: UseTooltipProps) {
     reference,
     x,
     y,
+
     strategy,
     middlewareData: { arrow: { x: arrowX, y: arrowY } = {} },
     placement,

--- a/packages/core/src/utils/useFloatingUI.tsx
+++ b/packages/core/src/utils/useFloatingUI.tsx
@@ -1,11 +1,80 @@
-import type { Middleware, Placement, Strategy } from "@floating-ui/react";
+import type {
+  Middleware,
+  Placement,
+  Platform,
+  Strategy,
+} from "@floating-ui/react";
 import {
   autoUpdate,
   flip,
   limitShift,
+  platform,
   shift,
   useFloating,
 } from "@floating-ui/react";
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useMemo,
+  ForwardedRef,
+  forwardRef,
+  PropsWithChildren,
+  ComponentType,
+} from "react";
+
+import { FloatingPortal } from "@floating-ui/react";
+import { SaltProvider } from "../salt-provider";
+
+export interface FloatingComponentProps extends UseFloatingUIProps {
+  /**
+   * Option to not render the popper.
+   */
+  disabled: boolean;
+}
+
+export interface FloatingComponentContextType {
+  Component: ComponentType<PropsWithChildren<FloatingComponentProps>>;
+}
+
+const FloatingComponentContext = createContext<FloatingComponentContextType>({
+  Component: forwardRef((props, ref: ForwardedRef<HTMLDivElement>) => {
+    const { open, disabled, ...rest } = props;
+    return open && !disabled ? (
+      <FloatingPortal>
+        <SaltProvider>
+          <div {...rest} ref={ref} />
+        </SaltProvider>
+      </FloatingPortal>
+    ) : null;
+  }),
+});
+
+if (process.env.NODE_ENV !== "production") {
+  FloatingComponentContext.displayName = "FloatingComponentContext";
+}
+
+export interface FloatingComponentProviderProps
+  extends FloatingComponentContextType {
+  children: ReactNode;
+}
+
+export function FloatingComponentProvider(
+  props: FloatingComponentProviderProps
+) {
+  const { Component, children } = props;
+  const value = useMemo(() => ({ Component }), [Component]);
+
+  return (
+    <FloatingComponentContext.Provider value={value}>
+      {children}
+    </FloatingComponentContext.Provider>
+  );
+}
+
+export function useFloatingComponent() {
+  return useContext(FloatingComponentContext);
+}
 
 export type UseFloatingUIProps = {
   /**
@@ -24,6 +93,27 @@ export type UseFloatingUIProps = {
   onOpenChange?: (open: boolean) => void;
 };
 
+const PlatformContext = createContext<Platform>(platform);
+
+export interface FloatingPlatformProviderProps {
+  platform: Platform;
+  children: ReactNode;
+}
+
+export function FloatingPlatformProvider(props: FloatingPlatformProviderProps) {
+  const { platform: platformProp, children } = props;
+
+  return (
+    <PlatformContext.Provider value={platformProp}>
+      {children}
+    </PlatformContext.Provider>
+  );
+}
+
+export function usePlatform() {
+  return useContext(PlatformContext);
+}
+
 export const DEFAULT_FLOATING_UI_MIDDLEWARE = [
   flip(),
   shift({ limiter: limitShift() }),
@@ -40,6 +130,8 @@ export function useFloatingUI(
     onOpenChange,
   } = props;
 
+  const platform = usePlatform();
+
   const { reference, floating, refs, update, ...rest } = useFloating({
     placement,
     strategy,
@@ -47,6 +139,7 @@ export function useFloatingUI(
     open,
     onOpenChange,
     whileElementsMounted: autoUpdate,
+    platform,
   });
 
   return {

--- a/packages/core/stories/tooltip/NewWindow.tsx
+++ b/packages/core/stories/tooltip/NewWindow.tsx
@@ -1,0 +1,200 @@
+import {
+  ComponentPropsWithoutRef,
+  forwardRef,
+  useState,
+  createContext,
+  useContext,
+  ForwardedRef,
+  useLayoutEffect,
+  useMemo,
+} from "react";
+import { WindowProvider, useWindow } from "@salt-ds/window";
+import { useComponentCssInjection } from "@salt-ds/styles";
+import { SaltProvider, useForkRef } from "@salt-ds/core";
+import { createPortal } from "react-dom";
+
+import themeCss from "@salt-ds/theme/index.css";
+import font300Css from "@fontsource/open-sans/300.css";
+import font300iCss from "@fontsource/open-sans/300-italic.css";
+import font400Css from "@fontsource/open-sans/400.css";
+import font400iCss from "@fontsource/open-sans/400-italic.css";
+import font500Css from "@fontsource/open-sans/500.css";
+import font500iCss from "@fontsource/open-sans/500-italic.css";
+import font600Css from "@fontsource/open-sans/600.css";
+import font600iCss from "@fontsource/open-sans/600-italic.css";
+import font700Css from "@fontsource/open-sans/700.css";
+import font700iCss from "@fontsource/open-sans/700-italic.css";
+import font800Css from "@fontsource/open-sans/800.css";
+import font800iCss from "@fontsource/open-sans/800-italic.css";
+
+const IframeContext = createContext<HTMLIFrameElement | null>(null);
+export const useIframe = () => useContext(IframeContext);
+const IframeProvider = IframeContext.Provider;
+
+const globalCss = `
+    html,body {
+        margin: 0;
+        overflow: hidden;
+    }
+
+    html,body * {
+        box-shadow: none;
+    }
+`;
+
+type Props = ComponentPropsWithoutRef<"iframe"> & {
+  title?: string;
+};
+
+const StyleInjection = () => {
+  const targetWindow = useWindow();
+
+  useComponentCssInjection({ css: themeCss, window: targetWindow });
+  useComponentCssInjection({ css: font300Css, window: targetWindow });
+  useComponentCssInjection({ css: font300iCss, window: targetWindow });
+  useComponentCssInjection({ css: font400Css, window: targetWindow });
+  useComponentCssInjection({ css: font400iCss, window: targetWindow });
+  useComponentCssInjection({ css: font500Css, window: targetWindow });
+  useComponentCssInjection({ css: font500iCss, window: targetWindow });
+  useComponentCssInjection({ css: font600Css, window: targetWindow });
+  useComponentCssInjection({ css: font600iCss, window: targetWindow });
+  useComponentCssInjection({ css: font700Css, window: targetWindow });
+  useComponentCssInjection({ css: font700iCss, window: targetWindow });
+  useComponentCssInjection({ css: font800Css, window: targetWindow });
+  useComponentCssInjection({ css: font800iCss, window: targetWindow });
+  useComponentCssInjection({ css: globalCss, window: targetWindow });
+
+  return null;
+};
+
+type Size = {
+  width: number;
+  height: number;
+};
+
+const useElementSize = (element?: HTMLElement) => {
+  const [size, setSize] = useState<Size | null>(null);
+
+  const [observer] = useState(() => {
+    return new ResizeObserver((entries) => {
+      const observedSize = entries[0].target.getBoundingClientRect();
+
+      if (
+        !size ||
+        observedSize.width !== size.width ||
+        observedSize.height !== size.height
+      ) {
+        setSize({
+          width: observedSize.width,
+          height: observedSize.height,
+        });
+      }
+    });
+  });
+
+  useLayoutEffect(() => {
+    if (element) {
+      observer.observe(element);
+    }
+
+    return () => {
+      if (element) {
+        observer.unobserve(element);
+      }
+    };
+  }, [element, observer]);
+
+  return size;
+};
+
+export const TooltipWindow = forwardRef(
+  (
+    { children, title, style, ...rest }: Props,
+    ref: ForwardedRef<HTMLIFrameElement>
+  ) => {
+    const [contentRef, setContentRef] = useState<HTMLIFrameElement | null>(
+      null
+    );
+
+    const mountNode = contentRef?.contentWindow?.document?.body;
+
+    const wrappedChildren = useMemo(
+      () => <SaltProvider>{children}</SaltProvider>,
+      [children]
+    );
+
+    const size = useElementSize(
+      mountNode?.querySelector(".saltTooltip") || undefined
+    );
+
+    const iframeRef = useForkRef(ref, setContentRef);
+
+    const opacity = !size || !contentRef ? 0 : undefined;
+
+    const iframeStyle = size
+      ? {
+          ...size,
+          opacity,
+          ...style,
+        }
+      : { opacity, ...style };
+
+    console.log(iframeStyle, opacity);
+
+    return (
+      <iframe
+        {...rest}
+        style={iframeStyle}
+        title={title}
+        ref={iframeRef as ForwardedRef<HTMLIFrameElement>}
+      >
+        {mountNode && (
+          <IframeProvider value={contentRef}>
+            <WindowProvider window={contentRef?.contentWindow}>
+              <StyleInjection />
+              {createPortal(wrappedChildren, mountNode)}
+            </WindowProvider>
+          </IframeProvider>
+        )}
+      </iframe>
+    );
+  }
+);
+
+export const NewWindow = forwardRef(
+  (
+    { children, title, style, ...rest }: Props,
+    ref: ForwardedRef<HTMLIFrameElement>
+  ) => {
+    const [contentRef, setContentRef] = useState<HTMLIFrameElement | null>(
+      null
+    );
+
+    const mountNode = contentRef?.contentWindow?.document?.body;
+
+    const iframeRef = useForkRef(ref, setContentRef);
+
+    const wrappedChildren = useMemo(
+      () => <SaltProvider>{children}</SaltProvider>,
+      [children]
+    );
+
+    return (
+      <iframe
+        {...rest}
+        style={style}
+        title={title}
+        ref={iframeRef as ForwardedRef<HTMLIFrameElement>}
+      >
+        {mountNode && (
+          <IframeProvider value={contentRef}>
+            <WindowProvider window={contentRef?.contentWindow}>
+              <StyleInjection />
+              {createPortal(wrappedChildren, mountNode)}
+            </WindowProvider>
+          </IframeProvider>
+        )}
+      </iframe>
+    );
+  }
+);

--- a/packages/core/stories/tooltip/custom-floating-ui-platform.stories.tsx
+++ b/packages/core/stories/tooltip/custom-floating-ui-platform.stories.tsx
@@ -1,0 +1,155 @@
+import { ComponentMeta, Story } from "@storybook/react";
+import React, {
+  ForwardedRef,
+  forwardRef,
+  useMemo,
+  ComponentPropsWithoutRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import { platform } from "@floating-ui/dom";
+import { Platform } from "@floating-ui/react";
+
+import {
+  Button,
+  FloatingPlatformProvider,
+  Tooltip,
+  TooltipProps,
+  StackLayout,
+  Text,
+  H3,
+  FloatingComponentProvider,
+  FloatingComponentProps,
+} from "@salt-ds/core";
+import { useWindow } from "@salt-ds/window";
+
+import { NewWindow, TooltipWindow } from "./NewWindow";
+
+export default {
+  title: "Core/Tooltip",
+  component: Tooltip,
+} as ComponentMeta<typeof Tooltip>;
+
+const defaultArgs: Omit<TooltipProps, "children"> = {
+  content:
+    "I am a tooltip, rendered into my own iframe within the global coordinate space",
+  hideArrow: true,
+};
+
+type RootComponentProps = FloatingComponentProps &
+  ComponentPropsWithoutRef<"div">;
+
+type NewWindowTestProps = Pick<TooltipProps, "placement" | "content">;
+
+const offscreenStyles: React.CSSProperties = {
+  top: -9999,
+  left: -9999,
+  position: "fixed",
+  opacity: 0,
+};
+
+const NewWindowTest = (props: NewWindowTestProps) => {
+  /*
+   * This ref is a little awkward in that the platform needs the iframe element for correct positioning
+   * but the iframe element isn't rendered until the tooltip is open which requires the Platform
+   */
+  const [iframe, setIframe] = useState<HTMLIFrameElement | null>(null);
+
+  const customPlatform: Platform = useMemo(
+    () => ({
+      ...platform,
+      async getElementRects({ ...data }) {
+        const result = await platform.getElementRects({
+          ...data,
+        });
+
+        const referenceRect = data.reference.getBoundingClientRect();
+        const iframeRect = iframe?.getBoundingClientRect();
+
+        const reference = iframeRect
+          ? {
+              ...result.reference,
+              x: referenceRect.x + iframeRect.x,
+              y: referenceRect.y + iframeRect.y,
+            }
+          : result.reference;
+
+        return {
+          ...result,
+          reference: reference,
+        };
+      },
+    }),
+    [iframe]
+  );
+
+  const rootBody = useWindow()?.document.body;
+
+  const FloatingUIComponent = useMemo(
+    () =>
+      forwardRef(
+        (
+          { style, open, ...rest }: RootComponentProps,
+          ref: ForwardedRef<HTMLIFrameElement>
+        ) => {
+          const FloatingRoot = (
+            /* In thise case to avoid Flash of Unstyled Text (FOUT) in the tooltip, due to being in an iframe, we are always rendering the tooltip.
+             * We are visually hiding it until it is open to 'eagerly load' the font
+             * In a more realistic example e.g. desktop you would take a different approach e.g. re-using an existing window which could have fonts loaded in advance
+             * Alternatively you could use the Font Loader API to check fonts have been loaded before showing the tooltip, or use a better fallback system font which would cause less layout shift
+             */
+            <TooltipWindow
+              style={{
+                ...style,
+                border: "none",
+                padding: 0,
+                position: "fixed",
+                ...(!open ? offscreenStyles : undefined),
+              }}
+              ref={ref}
+            >
+              {/* max-content allows tooltip to size itself, the TooltipWindow will resize to fit this */}
+              <div style={{ width: "max-content" }} {...rest} />
+            </TooltipWindow>
+          );
+
+          // In this case tooltip is portalled back to the root document this may not be the case if tooltips were opened as new windows
+          return rootBody ? createPortal(FloatingRoot, rootBody) : null;
+        }
+      ),
+    [rootBody]
+  );
+
+  return (
+    <NewWindow ref={setIframe} style={{ height: 200 }}>
+      <div style={{ padding: 10 }}>
+        <StackLayout gap={3}>
+          <H3>This is an iframe with a button</H3>
+          <Text>It represents a portalled window within an application</Text>
+          <FloatingPlatformProvider platform={customPlatform}>
+            <FloatingComponentProvider Component={FloatingUIComponent}>
+              <Tooltip {...props}>
+                <Button>Hover Me</Button>
+              </Tooltip>
+            </FloatingComponentProvider>
+          </FloatingPlatformProvider>
+        </StackLayout>
+      </div>
+    </NewWindow>
+  );
+};
+
+export const CustomFloatingUiPlatform: Story<TooltipProps> = (
+  props: TooltipProps
+) => {
+  return (
+    <StackLayout gap={2}>
+      <H3>This is the root of the application</H3>
+      <Text>It represents a global coordinate space (e.g. a users screen)</Text>
+      <StackLayout gap={10} direction="row">
+        <NewWindowTest {...props} />
+      </StackLayout>
+    </StackLayout>
+  );
+};
+CustomFloatingUiPlatform.args = defaultArgs;

--- a/packages/core/stories/tooltip/tooltip.doc.stories.mdx
+++ b/packages/core/stories/tooltip/tooltip.doc.stories.mdx
@@ -87,6 +87,36 @@ By default, the Tooltip displays after 300 milliseconds (ms). To change the dela
   <Story id="core-tooltip--delay" />
 </Canvas>
 
+## Custom Floating UI Platform
+
+### Custom Platforms
+
+Tooltip also provides support for advanced usage where the Tooltip or anchor may not be rendered in the root document of the application. This is based on [Floating UI's Platform feature](https://floating-ui.com/docs/platform)
+
+You can provide a custom Floating UI platform to be used in Tooltip by importing `<FloatingPlatformProvider>` and passing a custom floating-ui [Floating UI Platform](https://floating-ui.com/docs/platform) this will then be used within Tooltip.
+
+```
+import { FloatingPlatformProvider } from "@salt-ds/core";
+```
+
+You may also need to pass a custom component to be used as the root of the tooltip (e.g. to spawn an external window). This can be achieved by importing `<FloatingComponentProvider>` and providing a component.
+
+```
+import { FloatingComponentProvider } from "@salt-ds/window";
+```
+
+The following example shows these in action. The application is rendered in an iframe, representing a windowed applicationinside a global coordinate space (e.g. a users desktop).
+
+When the Button is hovered the Tooltip is rendered in it's own iframe (representing a popout window) which has been portalled to the global coordinate space.
+
+The example uses the `FloatingComponentProvider` to trigger creating the new window when the Tooltip is opened.
+
+It also uses the `FloatingPlatformProvider` to customise the positioning of the Tooltip based on the global coordinates of the anchor, rather than the position within it's own window.
+
+<Canvas>
+  <Story id="core-tooltip--custom-floating-ui-platform" />
+</Canvas>
+
 ## Configuring Tooltip
 
 ### API


### PR DESCRIPTION
This PR is for adding advanced desktop support to floating ui elements, initially Tooltip. For example in cases where users are working in multi-window applications, and want the Tooltip to be spawned in a new window, rather than in the root document.

It does this by adding a couple of contexts which can be provided to modify tooltip behaviour. The first is a <FloatingPlatformProvider>. This can be used to pass a [Floating UI Platform](https://floating-ui.com/docs/platform) for modifying the way the Tooltip is positioned e.g. by passing a differerent [getElementRects](https://floating-ui.com/docs/platform#getelementrects) function.

The second is a <FloatingComponentProvider> which can be used to pass a component to be used as the root element for the floating component (Tooltip). This can be used for things like spawning a new window when the Tooltip is opened and rendering the Tooltip content within in. This component is passed all the floating UI positioning information, in addition to the props `open` and `disabled` (this was from consumer feedback who wanted more control over when to hide the Tooltip).

An example has been added to try as best as possible to replicate this scenario in the following story: https://b4da726c.saltdesignsystem-storybook.pages.dev/?path=/story/core-tooltip--custom-floating-ui-platform

In this example the application is rendered into an iframe to represent a window within a global coordinate space. The tooltip itself is then rendered into it's own iframe and positioned appropriately.
