### PR TITLE
Add readonly variant to RadioButton

### DIFF
--- a/.changeset/yellow-waves-visit.md
+++ b/.changeset/yellow-waves-visit.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Added readonly variant to RadioButton, that can be toggled by setting the `readOnly` prop.

--- a/packages/core/src/radio-button/RadioButton.css
+++ b/packages/core/src/radio-button/RadioButton.css
@@ -14,6 +14,13 @@
   pointer-events: visible;
 }
 
+/* Styles applied when RadioButton is readonly */
+.saltRadioButton-readonly {
+  color: var(--salt-text-primary-foreground-disabled); /* TODO check tokens */
+  cursor: var(--salt-selectable-cursor-disabled);
+  pointer-events: visible;
+}
+
 /* Styles applied to input component */
 .saltRadioButton-input {
   cursor: inherit;

--- a/packages/core/src/radio-button/RadioButton.css
+++ b/packages/core/src/radio-button/RadioButton.css
@@ -17,7 +17,7 @@
 /* Styles applied when RadioButton is readonly */
 .saltRadioButton-readonly {
   color: var(--salt-text-primary-foreground-disabled); /* TODO check tokens */
-  cursor: var(--salt-selectable-cursor-disabled);
+  cursor: var(--salt-selectable-cursor-readonly);
   pointer-events: visible;
 }
 

--- a/packages/core/src/radio-button/RadioButton.tsx
+++ b/packages/core/src/radio-button/RadioButton.tsx
@@ -160,7 +160,8 @@ export const RadioButton = forwardRef<HTMLLabelElement, RadioButtonProps>(
           className={withBaseName("input")}
           {...restInputProps}
           checked={checked}
-          disabled={disabled || readOnly}
+          disabled={disabled || readOnly}          
+          readOnly={readOnly}
           name={name}
           value={value}
           onBlur={onBlur}

--- a/packages/core/src/radio-button/RadioButton.tsx
+++ b/packages/core/src/radio-button/RadioButton.tsx
@@ -60,6 +60,10 @@ export interface RadioButtonProps
    */
   onFocus?: FocusEventHandler<HTMLInputElement>;
   /**
+   * Set the readonly state
+   */
+  readOnly?: boolean
+  /**
    * Value of radio button
    */
   value?: string;
@@ -82,6 +86,7 @@ export const RadioButton = forwardRef<HTMLLabelElement, RadioButtonProps>(
       onFocus,
       onBlur,
       onChange,
+      readOnly,
       value,
       validationStatus: validationStatusProp,
       ...rest
@@ -136,6 +141,7 @@ export const RadioButton = forwardRef<HTMLLabelElement, RadioButtonProps>(
             [withBaseName("disabled")]: disabled,
             [withBaseName(validationStatus || "")]: validationStatus,
             [withBaseName("error")]: error,
+            [withBaseName("readonly")]: readOnly,
           },
           className
         )}
@@ -154,7 +160,7 @@ export const RadioButton = forwardRef<HTMLLabelElement, RadioButtonProps>(
           className={withBaseName("input")}
           {...restInputProps}
           checked={checked}
-          disabled={disabled}
+          disabled={disabled || readOnly}
           name={name}
           value={value}
           onBlur={onBlur}
@@ -166,7 +172,8 @@ export const RadioButton = forwardRef<HTMLLabelElement, RadioButtonProps>(
           checked={checked}
           disabled={disabled}
           validationStatus={validationStatus}
-          error={error}
+          readOnly={readOnly} 
+          error={error} /* **Deprecated** */
         />
         {label}
       </label>

--- a/packages/core/src/radio-button/RadioButton.tsx
+++ b/packages/core/src/radio-button/RadioButton.tsx
@@ -86,7 +86,7 @@ export const RadioButton = forwardRef<HTMLLabelElement, RadioButtonProps>(
       onFocus,
       onBlur,
       onChange,
-      readOnly,
+      readOnly: readOnlyProp,
       value,
       validationStatus: validationStatusProp,
       ...rest
@@ -108,7 +108,8 @@ export const RadioButton = forwardRef<HTMLLabelElement, RadioButtonProps>(
     } = inputProps;
 
     const disabled = radioGroup.disabled ?? disabledProp;
-    const validationStatus = !disabled
+    const readOnly = radioGroup.readOnly ?? readOnlyProp;
+    const validationStatus = !disabled && !readOnly
       ? radioGroup.validationStatus ?? validationStatusProp
       : undefined;
 

--- a/packages/core/src/radio-button/RadioButtonGroup.css
+++ b/packages/core/src/radio-button/RadioButtonGroup.css
@@ -26,11 +26,3 @@
 .saltRadioButtonGroup-noWrap .saltRadioButton {
   white-space: break-spaces;
 }
-
-/* Styles applied to radio group's legend */
-.saltRadioButtonGroup-legend {
-  display: inline-block;
-  font-size: var(--formFieldLegacy-label-fontSize); /* TODO: V2 Form Field work */
-  color: var(--salt-text-primary-foreground);
-  margin-bottom: var(--salt-spacing-200);
-}

--- a/packages/core/src/radio-button/RadioButtonGroup.tsx
+++ b/packages/core/src/radio-button/RadioButtonGroup.tsx
@@ -41,6 +41,10 @@ export interface RadioButtonGroupProps
    */
   onChange?: ChangeEventHandler<HTMLInputElement>;
   /**
+   * Set the readonly state
+   */
+  readOnly?: boolean
+  /**
    * The value of the radio group, required for a controlled component.
    */
   value?: string;
@@ -63,6 +67,7 @@ export const RadioButtonGroup = forwardRef<
     wrap = true,
     name: nameProp,
     onChange,
+    readOnly: readOnlyProp,
     value: valueProp,
     validationStatus: validationStatusProp,
     ...rest
@@ -78,9 +83,11 @@ export const RadioButtonGroup = forwardRef<
   const {
     a11yProps,
     disabled: formFieldDisabled,
+    readOnly: formFieldReadOnly,
     validationStatus: formFieldValidationStatus,
   } = useFormFieldProps();
 
+  const readOnly = formFieldReadOnly ?? readOnlyProp;
   const disabled = formFieldDisabled ?? disabledProp;
   const validationStatus = formFieldValidationStatus
     ? formFieldValidationStatus !== "success"
@@ -122,6 +129,7 @@ export const RadioButtonGroup = forwardRef<
           disabled,
           name,
           onChange: handleChange,
+          readOnly,
           validationStatus,
           value,
         }}

--- a/packages/core/src/radio-button/RadioButtonIcon.css
+++ b/packages/core/src/radio-button/RadioButtonIcon.css
@@ -42,6 +42,21 @@
   stroke-width: calc(var(--salt-size-border) * 6.5);
 }
 
+/* Styles applied to radio button icon if readonly */
+.saltRadioButtonIcon-readonly .saltRadioButtonIcon-circle,
+.saltRadioButton:hover .saltRadioButtonIcon-readonly .saltRadioButtonIcon-circle {
+  fill: var(--saltRadioButton-icon-readonly-fill, var(--salt-selectable-background));
+  stroke: var(--saltRadioButton-icon-readonly-stroke, var(--salt-selectable-foreground));
+}
+
+/* Styles applied to radio button icon if checked and readonly */
+.saltRadioButtonIcon-readonly.saltRadioButtonIcon-checked .saltRadioButtonIcon-circle,
+.saltRadioButton:hover .saltRadioButtonIcon-readonly.saltRadioButtonIcon-checked .saltRadioButtonIcon-circle {
+  fill: var(--saltRadioButton-icon-checked-readonly-fill, var(--salt-container-primary-background));
+  stroke: var(--saltRadioButton-icon-checked-readonly-stroke, var(--salt-selectable-foreground));
+  stroke-width: calc(var(--salt-size-border) * 6.5);
+}
+
 /* Styles applied to radio button icon with `validationStatus="error"` */
 .saltRadioButtonIcon-error .saltRadioButtonIcon-circle,
 .saltRadioButton:hover .saltRadioButtonIcon-error .saltRadioButtonIcon-circle {
@@ -84,4 +99,9 @@
 /* Styles applied to checked inner circle when disabled */
 .saltRadioButtonIcon-disabled .saltRadioButtonIcon-checked-circle {
   fill: var(--saltRadioButton-icon-inner-disabled-fill, var(--salt-container-primary-background-disabled));
+}
+
+/* Styles applied to checked inner circle when readonly */
+.saltRadioButtonIcon-readonly .saltRadioButtonIcon-checked-circle {
+  fill: var(--saltRadioButton-icon-inner-readonly-fill, var(--salt-container-primary-background));
 }

--- a/packages/core/src/radio-button/RadioButtonIcon.tsx
+++ b/packages/core/src/radio-button/RadioButtonIcon.tsx
@@ -11,6 +11,7 @@ export interface RadioButtonIconProps {
   error?: boolean;
   disabled?: boolean;
   validationStatus?: "error" | "warning";
+  readOnly?: boolean;
 }
 
 /**
@@ -20,6 +21,7 @@ export const RadioButtonIcon = ({
   checked,
   error,
   disabled,
+  readOnly,
   validationStatus,
 }: RadioButtonIconProps) => {
   const targetWindow = useWindow();
@@ -35,6 +37,7 @@ export const RadioButtonIcon = ({
         [withBaseName("error")]: error,
         [withBaseName("disabled")]: disabled,
         [withBaseName(validationStatus || "")]: validationStatus,
+        [withBaseName("readonly")]: readOnly,
       })}
       height="14"
       viewBox="0 0 14 14"

--- a/packages/core/src/radio-button/internal/RadioGroupContext.tsx
+++ b/packages/core/src/radio-button/internal/RadioGroupContext.tsx
@@ -8,6 +8,7 @@ export interface RadioGroupContextValue {
   name?: string;
   value?: string;
   onChange?: ChangeEventHandler<HTMLElement>;
+  readOnly?: boolean;
   validationStatus?: "error" | "warning";
 }
 

--- a/packages/core/stories/radio-button/radio-button.doc.stories.mdx
+++ b/packages/core/stories/radio-button/radio-button.doc.stories.mdx
@@ -44,6 +44,14 @@ A Radio Button can be disabled by setting the `disabled` prop to true. This will
   <Story id="core-radio-button--disabled" />
 </Canvas>
 
+### Readonly
+
+A Radio Button with the prop `readOnly="true"` will suppress all functionality along with displaying readonly styling.
+
+<Canvas>
+  <Story id="core-radio-button--readonly" />
+</Canvas>
+
 ### Validation state
 
 Error state can be indicated stylistically by setting the `validationStatus` prop to "error".

--- a/packages/core/stories/radio-button/radio-button.doc.stories.mdx
+++ b/packages/core/stories/radio-button/radio-button.doc.stories.mdx
@@ -48,6 +48,8 @@ A Radio Button can be disabled by setting the `disabled` prop to true. This will
 
 Error state can be indicated stylistically by setting the `validationStatus` prop to "error".
 
+Error state can be indicated stylistically by setting the `error` prop to true.
+
 <Canvas>
   <Story id="core-radio-button--error" />
 </Canvas>

--- a/packages/core/stories/radio-button/radio-button.stories.tsx
+++ b/packages/core/stories/radio-button/radio-button.stories.tsx
@@ -17,29 +17,28 @@ export const Checked = () => {
 
 export const Disabled = () => {
   return (
-    <>
-      <RadioButton disabled label="Disabled" value="Disabled" />
+    <RadioButtonGroup disabled>
+      <RadioButton label="Disabled" value="Disabled" />
       <RadioButton
-        disabled
         label="Checked Disabled"
         value="Disabled-checked"
         checked
       />
-    </>
+    </RadioButtonGroup>
   );
 };
 
 export const Readonly = () => {
   return (
-    <>
-      <RadioButton readOnly label="Readonly" value="Readonly" />
+    <RadioButtonGroup readOnly>
+      <RadioButton label="Readonly" value="Readonly" />
       <RadioButton
         readOnly
         label="Checked Readonly"
         value="Readonly-checked"
         checked
       />
-    </>
+    </RadioButtonGroup>
   );
 };
 

--- a/packages/core/stories/radio-button/radio-button.stories.tsx
+++ b/packages/core/stories/radio-button/radio-button.stories.tsx
@@ -29,6 +29,20 @@ export const Disabled = () => {
   );
 };
 
+export const Readonly = () => {
+  return (
+    <>
+      <RadioButton readOnly label="Readonly" value="Readonly" />
+      <RadioButton
+        readOnly
+        label="Checked Readonly"
+        value="Readonly-checked"
+        checked
+      />
+    </>
+  );
+};
+
 export const Error = () => {
   return (
     <RadioButtonGroup validationStatus="error">

--- a/packages/core/stories/radio-button/radio-button.stories.tsx
+++ b/packages/core/stories/radio-button/radio-button.stories.tsx
@@ -47,6 +47,7 @@ export const Warning = () => {
   );
 };
 
+
 export const VerticalGroup = () => (
   <RadioButtonGroup>
     <RadioButton key="option1" label="Radio Option 1" value="option1" />


### PR DESCRIPTION
Added readonly variant, that can be toggled by setting the `readOnly` prop.