### PR TITLE
Add warning to Checkbox and RadioButton

### DIFF
--- a/.changeset/clever-cobras-crash.md
+++ b/.changeset/clever-cobras-crash.md
@@ -4,3 +4,5 @@
 
 Added `validationStatus` prop to RadioButton and Checkbox allowing for error and warning status
 Deprecated `error` prop in RadioButton and Checkbox: Use `validationStatus="error"` instead
+
+Added `validationStatus` prop to RadioButtonGroupContext and CheckboxGroupContext allowing for error and warning status on the group as a whole

--- a/.changeset/clever-cobras-crash.md
+++ b/.changeset/clever-cobras-crash.md
@@ -1,0 +1,6 @@
+---
+"@salt-ds/core": minor
+---
+
+Added `validationStatus` prop to RadioButton and Checkbox allowing for error and warning status
+Deprecated `error` prop in RadioButton and Checkbox: Use `validationStatus="error"` instead

--- a/packages/core/src/checkbox/Checkbox.tsx
+++ b/packages/core/src/checkbox/Checkbox.tsx
@@ -132,7 +132,9 @@ export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
       state: "checked",
     });
 
-    const validationStatus = !disabled ? checkboxGroup.validationStatus ?? validationStatusProp : undefined;
+    const validationStatus = !disabled
+      ? checkboxGroup.validationStatus ?? validationStatusProp
+      : undefined;
 
     return (
       <label

--- a/packages/core/src/checkbox/Checkbox.tsx
+++ b/packages/core/src/checkbox/Checkbox.tsx
@@ -132,7 +132,7 @@ export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
       state: "checked",
     });
 
-    const validationStatus = !disabled ? validationStatusProp : undefined;
+    const validationStatus = !disabled ? checkboxGroup.validationStatus ?? validationStatusProp : undefined;
 
     return (
       <label

--- a/packages/core/src/checkbox/Checkbox.tsx
+++ b/packages/core/src/checkbox/Checkbox.tsx
@@ -76,7 +76,7 @@ export interface CheckboxProps
   /**
    * Validation status.
    */
-   validationStatus?: "error" | "warning";
+  validationStatus?: "error" | "warning";
 }
 
 export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(

--- a/packages/core/src/checkbox/Checkbox.tsx
+++ b/packages/core/src/checkbox/Checkbox.tsx
@@ -35,6 +35,7 @@ export interface CheckboxProps
    */
   disabled?: boolean;
   /**
+   * **Deprecated**: Use validationStatus instead
    * If `true`, the checkbox will be in the error state.
    */
   error?: boolean;
@@ -72,6 +73,10 @@ export interface CheckboxProps
    * The value of the checkbox.
    */
   value?: string;
+  /**
+   * Validation status.
+   */
+   validationStatus?: "error" | "warning";
 }
 
 export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
@@ -90,6 +95,7 @@ export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
       onChange,
       onFocus,
       value,
+      validationStatus: validationStatusProp,
       ...rest
     },
     ref
@@ -126,7 +132,7 @@ export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
       state: "checked",
     });
 
-    const isError = error && !disabled;
+    const validationStatus = !disabled ? validationStatusProp : undefined;
 
     return (
       <label
@@ -134,7 +140,7 @@ export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
           withBaseName(),
           {
             [withBaseName("disabled")]: disabled,
-            [withBaseName("error")]: isError,
+            [withBaseName(validationStatus || "")]: validationStatus,
           },
           className
         )}
@@ -160,8 +166,8 @@ export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
         <CheckboxIcon
           checked={checked}
           disabled={disabled}
-          error={isError}
           indeterminate={indeterminate}
+          validationStatus={validationStatus}
         />
         {label}
       </label>

--- a/packages/core/src/checkbox/CheckboxGroup.tsx
+++ b/packages/core/src/checkbox/CheckboxGroup.tsx
@@ -106,7 +106,12 @@ export const CheckboxGroup = forwardRef<
       {...other}
     >
       <CheckboxGroupContext.Provider
-        value={{ name, onChange: handleChange, checkedValues, validationStatus }}
+        value={{
+          name,
+          onChange: handleChange,
+          checkedValues,
+          validationStatus,
+        }}
       >
         {children}
       </CheckboxGroupContext.Provider>

--- a/packages/core/src/checkbox/CheckboxGroup.tsx
+++ b/packages/core/src/checkbox/CheckboxGroup.tsx
@@ -39,6 +39,10 @@ export interface CheckboxGroupProps
    * Only for horizontal direction. When `true` the text in radio button label will wrap to fit within the container. Otherwise, the checkboxes will wrap onto the next line.
    */
   wrap?: boolean;
+  /**
+   * Validation status.
+   */
+  validationStatus?: "error" | "warning";
 }
 
 const withBaseName = makePrefixer("saltCheckboxGroup");
@@ -56,6 +60,7 @@ export const CheckboxGroup = forwardRef<
     name,
     onChange,
     wrap,
+    validationStatus,
     ...other
   },
   ref
@@ -101,7 +106,7 @@ export const CheckboxGroup = forwardRef<
       {...other}
     >
       <CheckboxGroupContext.Provider
-        value={{ name, onChange: handleChange, checkedValues }}
+        value={{ name, onChange: handleChange, checkedValues, validationStatus }}
       >
         {children}
       </CheckboxGroupContext.Provider>

--- a/packages/core/src/checkbox/CheckboxIcon.css
+++ b/packages/core/src/checkbox/CheckboxIcon.css
@@ -34,15 +34,26 @@
   background: var(--salt-selectable-background);
 }
 
-/* Styles applied if `error={true}` */
+/* Styles applied if validationStatus="error"` */
 .saltCheckbox-error .saltCheckboxIcon,
 .saltCheckbox-error:hover .saltCheckboxIcon {
   stroke: var(--saltCheckbox-icon-stroke-error, var(--salt-status-error-foreground));
 }
 
-/* Styles applied if `error={true}` on hover */
+/* Styles applied if validationStatus="error"` on hover */
 .saltCheckbox-error:hover .saltCheckboxIcon {
   background: var(--salt-status-error-background);
+}
+
+/* Styles applied if `validationStatus="warning"` */
+.saltCheckbox-warning .saltCheckboxIcon,
+.saltCheckbox-warning:hover .saltCheckboxIcon {
+  stroke: var(--saltCheckbox-icon-stroke-warning, var(--salt-status-warning-foreground));
+}
+
+/* Styles applied if validationStatus="warning"` on hover */
+.saltCheckbox-warning:hover .saltCheckboxIcon {
+  background: var(--salt-status-warning-background);
 }
 
 /* Styles applied if `checked={true}` */
@@ -56,9 +67,14 @@
   fill: var(--saltCheckbox-icon-fill-disabled, var(--salt-selectable-foreground-selectedDisabled));
 }
 
-/* Styles applied if `checked={true}` and `error={true}` */
+/* Styles applied if `checked={true}` and `validationStatus="error"` */
 .saltCheckboxIcon-checked.saltCheckboxIcon-error {
   fill: var(--saltCheckbox-icon-stroke-error, var(--salt-status-error-foreground));
+}
+
+/* Styles applied if `checked={true}` and `validationStatus="warning"` */
+.saltCheckboxIcon-checked.saltCheckboxIcon-warning {
+  fill: var(--saltCheckbox-icon-stroke-warning, var(--salt-status-warning-foreground));
 }
 
 /* Styles applied to box */
@@ -88,10 +104,16 @@
   --checkbox-icon-tick-fill: var(--saltCheckbox-icon-indeterminate-bar-color-disabled, var(--salt-selectable-foreground-selectedDisabled));
 }
 
-/* Styles applied if `indeterminate={true}` and `error={true}` */
+/* Styles applied if `indeterminate={true}` and `validationStatus="error"` */
 .saltCheckboxIcon-error.saltCheckboxIcon-indeterminate,
 .saltCheckbox:hover .saltCheckboxIcon-error.saltCheckboxIcon-indeterminate {
   --checkbox-icon-tick-fill: var(--saltCheckbox-icon-stroke-error, var(--salt-status-error-foreground));
+}
+
+/* Styles applied if `indeterminate={true}` and `validationStatus="warning"` */
+.saltCheckboxIcon-warning.saltCheckboxIcon-indeterminate,
+.saltCheckbox:hover .saltCheckboxIcon-warning.saltCheckboxIcon-indeterminate {
+  --checkbox-icon-tick-fill: var(--saltCheckbox-icon-stroke-erwarningror, var(--salt-status-warning-foreground));
 }
 
 /* Styles applied to tick */

--- a/packages/core/src/checkbox/CheckboxIcon.tsx
+++ b/packages/core/src/checkbox/CheckboxIcon.tsx
@@ -16,8 +16,9 @@ export interface CheckboxIconProps {
   checked?: boolean;
   className?: string;
   disabled?: boolean;
-  error?: boolean;
+  error?: boolean; /* **Deprecated**: replaced with validationStatus */
   indeterminate?: boolean;
+  validationStatus?: "error" | "warning";
 }
 
 const withBaseName = makePrefixer("saltCheckboxIcon");
@@ -28,6 +29,7 @@ export const CheckboxIcon = ({
   disabled,
   error,
   indeterminate,
+  validationStatus
 }: CheckboxIconProps): JSX.Element => {
   const targetWindow = useWindow();
   useComponentCssInjection({
@@ -40,6 +42,7 @@ export const CheckboxIcon = ({
     {
       [withBaseName("disabled")]: disabled,
       [withBaseName("error")]: error,
+      [withBaseName(validationStatus || "")]: validationStatus,
     },
     classNameProp
   );

--- a/packages/core/src/checkbox/CheckboxIcon.tsx
+++ b/packages/core/src/checkbox/CheckboxIcon.tsx
@@ -16,7 +16,7 @@ export interface CheckboxIconProps {
   checked?: boolean;
   className?: string;
   disabled?: boolean;
-  error?: boolean; /* **Deprecated**: replaced with validationStatus */
+  error?: boolean /* **Deprecated**: replaced with validationStatus */;
   indeterminate?: boolean;
   validationStatus?: "error" | "warning";
 }
@@ -29,7 +29,7 @@ export const CheckboxIcon = ({
   disabled,
   error,
   indeterminate,
-  validationStatus
+  validationStatus,
 }: CheckboxIconProps): JSX.Element => {
   const targetWindow = useWindow();
   useComponentCssInjection({

--- a/packages/core/src/checkbox/internal/CheckboxGroupContext.ts
+++ b/packages/core/src/checkbox/internal/CheckboxGroupContext.ts
@@ -5,6 +5,7 @@ export interface CheckboxGroupState {
   name?: CheckboxGroupProps["name"];
   onChange?: CheckboxGroupProps["onChange"];
   checkedValues?: CheckboxGroupProps["checkedValues"];
+  validationStatus?: "error" | "warning";
 }
 
 const CheckboxGroupContext = createContext<CheckboxGroupState>({});

--- a/packages/core/src/radio-button/RadioButton.tsx
+++ b/packages/core/src/radio-button/RadioButton.tsx
@@ -94,7 +94,6 @@ export const RadioButton = forwardRef<HTMLLabelElement, RadioButtonProps>(
       window: targetWindow,
     });
 
-    const validationStatus = !disabled ? validationStatusProp : undefined;
 
     const radioGroup = useRadioGroup();
 
@@ -118,6 +117,8 @@ export const RadioButton = forwardRef<HTMLLabelElement, RadioButtonProps>(
       onChange?.(event);
       radioGroup.onChange?.(event);
     };
+
+    const validationStatus = !disabled ? radioGroup.validationStatus ?? validationStatusProp : undefined;
 
     return (
       <label

--- a/packages/core/src/radio-button/RadioButton.tsx
+++ b/packages/core/src/radio-button/RadioButton.tsx
@@ -66,7 +66,7 @@ export interface RadioButtonProps
   /**
    * Validation status.
    */
-   validationStatus?: "error" | "warning";
+  validationStatus?: "error" | "warning";
 }
 
 export const RadioButton = forwardRef<HTMLLabelElement, RadioButtonProps>(

--- a/packages/core/src/radio-button/RadioButton.tsx
+++ b/packages/core/src/radio-button/RadioButton.tsx
@@ -94,7 +94,6 @@ export const RadioButton = forwardRef<HTMLLabelElement, RadioButtonProps>(
       window: targetWindow,
     });
 
-
     const radioGroup = useRadioGroup();
 
     const radioGroupChecked =
@@ -118,7 +117,9 @@ export const RadioButton = forwardRef<HTMLLabelElement, RadioButtonProps>(
       radioGroup.onChange?.(event);
     };
 
-    const validationStatus = !disabled ? radioGroup.validationStatus ?? validationStatusProp : undefined;
+    const validationStatus = !disabled
+      ? radioGroup.validationStatus ?? validationStatusProp
+      : undefined;
 
     return (
       <label

--- a/packages/core/src/radio-button/RadioButton.tsx
+++ b/packages/core/src/radio-button/RadioButton.tsx
@@ -31,6 +31,7 @@ export interface RadioButtonProps
    */
   disabled?: boolean;
   /**
+   * **Deprecated**: Use validationStatus instead
    * Set the error state
    */
   error?: boolean;
@@ -62,6 +63,10 @@ export interface RadioButtonProps
    * Value of radio button
    */
   value?: string;
+  /**
+   * Validation status.
+   */
+   validationStatus?: "error" | "warning";
 }
 
 export const RadioButton = forwardRef<HTMLLabelElement, RadioButtonProps>(
@@ -78,6 +83,7 @@ export const RadioButton = forwardRef<HTMLLabelElement, RadioButtonProps>(
       onBlur,
       onChange,
       value,
+      validationStatus: validationStatusProp,
       ...rest
     } = props;
 
@@ -87,6 +93,8 @@ export const RadioButton = forwardRef<HTMLLabelElement, RadioButtonProps>(
       css: radioButtonCss,
       window: targetWindow,
     });
+
+    const validationStatus = !disabled ? validationStatusProp : undefined;
 
     const radioGroup = useRadioGroup();
 
@@ -117,6 +125,7 @@ export const RadioButton = forwardRef<HTMLLabelElement, RadioButtonProps>(
           withBaseName(),
           {
             [withBaseName("disabled")]: disabled,
+            [withBaseName(validationStatus || "")]: validationStatus,
           },
           className
         )}
@@ -137,8 +146,8 @@ export const RadioButton = forwardRef<HTMLLabelElement, RadioButtonProps>(
         />
         <RadioButtonIcon
           checked={checked}
-          error={error && !disabled}
           disabled={disabled}
+          validationStatus={validationStatus}
         />
         {label}
       </label>

--- a/packages/core/src/radio-button/RadioButtonGroup.tsx
+++ b/packages/core/src/radio-button/RadioButtonGroup.tsx
@@ -39,6 +39,10 @@ export interface RadioButtonGroupProps
    * The value of the radio group, required for a controlled component.
    */
   value?: string;
+  /**
+   * Validation status.
+   */
+  validationStatus?: "error" | "warning";
 }
 
 export const RadioButtonGroup = forwardRef<
@@ -54,6 +58,7 @@ export const RadioButtonGroup = forwardRef<
     name: nameProp,
     onChange,
     value: valueProp,
+    validationStatus,
     ...rest
   } = props;
 
@@ -93,7 +98,7 @@ export const RadioButtonGroup = forwardRef<
       {...rest}
     >
       <RadioGroupContext.Provider
-        value={{ name, onChange: handleChange, value }}
+        value={{ name, onChange: handleChange, validationStatus, value }}
       >
         {children}
       </RadioGroupContext.Provider>

--- a/packages/core/src/radio-button/RadioButtonIcon.css
+++ b/packages/core/src/radio-button/RadioButtonIcon.css
@@ -42,7 +42,7 @@
   stroke-width: calc(var(--salt-size-border) * 6.5);
 }
 
-/* Styles applied to radio button icon with error */
+/* Styles applied to radio button icon with `validationStatus="error"` */
 .saltRadioButtonIcon-error .saltRadioButtonIcon-circle,
 .saltRadioButton:hover .saltRadioButtonIcon-error .saltRadioButtonIcon-circle {
   stroke: var(--saltRadioButton-icon-error-stroke, var(--salt-status-error-foreground));
@@ -52,11 +52,28 @@
   fill: var(--saltRadioButton-icon-error-hover-fill, var(--salt-status-error-background));
 }
 
-/* Styles applied to radio button icon when checked and with error */
+/* Styles applied to radio button icon when checked and with `validationStatus="error"` */
 .saltRadioButtonIcon-checked.saltRadioButtonIcon-error .saltRadioButtonIcon-circle,
 .saltRadioButton:hover .saltRadioButtonIcon-checked.saltRadioButtonIcon-error .saltRadioButtonIcon-circle {
   fill: var(--saltRadioButton-icon-error-fill, var(--salt-status-error-foreground));
   stroke: var(--saltRadioButton-icon-error-stroke, var(--salt-status-error-foreground));
+}
+
+/* Styles applied to radio button icon with `validationStatus="warning"` */
+.saltRadioButtonIcon-warning .saltRadioButtonIcon-circle,
+.saltRadioButton:hover .saltRadioButtonIcon-warning .saltRadioButtonIcon-circle {
+  stroke: var(--saltRadioButton-icon-warning-stroke, var(--salt-status-warning-foreground));
+}
+
+.saltRadioButton:hover .saltRadioButtonIcon-warning .saltRadioButtonIcon-circle {
+  fill: var(--saltRadioButton-icon-warning-hover-fill, var(--salt-status-warning-background));
+}
+
+/* Styles applied to radio button icon when checked and with `validationStatus="warning"` */
+.saltRadioButtonIcon-checked.saltRadioButtonIcon-warning .saltRadioButtonIcon-circle,
+.saltRadioButton:hover .saltRadioButtonIcon-checked.saltRadioButtonIcon-warning .saltRadioButtonIcon-circle {
+  fill: var(--saltRadioButton-icon-warning-fill, var(--salt-status-warning-foreground));
+  stroke: var(--saltRadioButton-icon-warning-stroke, var(--salt-status-warning-foreground));
 }
 
 /* Styles applied to checked inner circle */

--- a/packages/core/src/radio-button/RadioButtonIcon.tsx
+++ b/packages/core/src/radio-button/RadioButtonIcon.tsx
@@ -10,6 +10,7 @@ export interface RadioButtonIconProps {
   checked?: boolean;
   error?: boolean;
   disabled?: boolean;
+  validationStatus?: "error" | "warning";
 }
 
 /**
@@ -19,6 +20,7 @@ export const RadioButtonIcon = ({
   checked,
   error,
   disabled,
+  validationStatus
 }: RadioButtonIconProps) => {
   const targetWindow = useWindow();
   useComponentCssInjection({
@@ -32,6 +34,7 @@ export const RadioButtonIcon = ({
         [withBaseName("checked")]: checked,
         [withBaseName("error")]: error,
         [withBaseName("disabled")]: disabled,
+        [withBaseName(validationStatus || "")]: validationStatus,
       })}
       height="14"
       viewBox="0 0 14 14"

--- a/packages/core/src/radio-button/RadioButtonIcon.tsx
+++ b/packages/core/src/radio-button/RadioButtonIcon.tsx
@@ -20,7 +20,7 @@ export const RadioButtonIcon = ({
   checked,
   error,
   disabled,
-  validationStatus
+  validationStatus,
 }: RadioButtonIconProps) => {
   const targetWindow = useWindow();
   useComponentCssInjection({

--- a/packages/core/src/radio-button/internal/RadioGroupContext.tsx
+++ b/packages/core/src/radio-button/internal/RadioGroupContext.tsx
@@ -5,6 +5,7 @@ export interface RadioGroupContextValue {
   name?: string;
   value?: string;
   onChange?: ChangeEventHandler<HTMLElement>;
+  validationStatus?: "error" | "warning";
 }
 
 export const RadioGroupContext = createContext<RadioGroupContextValue>(

--- a/packages/core/stories/checkbox/checkbox.doc.stories.mdx
+++ b/packages/core/stories/checkbox/checkbox.doc.stories.mdx
@@ -56,7 +56,7 @@ Use this state when you want to alert the user of a critical issue that is relat
   <Story id="core-checkbox--error" />
 </Canvas>
 
-A Checkbox with the prop `validationStatus="warning"` will cause the checkbox to be shown with the error status colors.
+A Checkbox with the prop `validationStatus="warning"` will cause the checkbox to be shown with the warning status colors.
 
 <Canvas>
   <Story id="core-checkbox--warning" />

--- a/packages/core/stories/checkbox/checkbox.doc.stories.mdx
+++ b/packages/core/stories/checkbox/checkbox.doc.stories.mdx
@@ -62,6 +62,7 @@ A Checkbox with the prop `validationStatus="warning"` will cause the checkbox to
   <Story id="core-checkbox--warning" />
 </Canvas>
 
+- When used in a group, use `validationStatus` on the group rather than the individual controls. Any status provided to the group will take precedence over the statuses applied directly to the nested controls.
 - Avoid using `validationStatus` when a Checkbox is `disabled`. If provided, `disabled` functionality and styling will take precedence over any validation status styling.
 
 ### Disabled

--- a/packages/core/stories/checkbox/checkbox.doc.stories.mdx
+++ b/packages/core/stories/checkbox/checkbox.doc.stories.mdx
@@ -47,14 +47,22 @@ children, the parent will show an indeterminate state.
   <Story id="core-checkbox--indeterminate" />
 </Canvas>
 
-### Error
+### Validation state
 
-A Checkbox with the prop `error="true"` will cause the checkbox to be shown with the error status colors.
+A Checkbox with the prop `validationStatus="error"` will cause the checkbox to be shown with the error status colors.
 Use this state when you want to alert the user of a critical issue that is related to the checkbox.
 
 <Canvas>
   <Story id="core-checkbox--error" />
 </Canvas>
+
+A Checkbox with the prop `validationStatus="warning"` will cause the checkbox to be shown with the error status colors.
+
+<Canvas>
+  <Story id="core-checkbox--warning" />
+</Canvas>
+
+- Avoid using `validationStatus` when a Checkbox is `disabled`. If provided, `disabled` functionality and styling will take precedence over any validation status styling.
 
 ### Disabled
 
@@ -63,8 +71,6 @@ A Checkbox with the prop `disabled="true"` will suppress all functionality along
 <Canvas>
   <Story id="core-checkbox--disabled" />
 </Canvas>
-
-- Avoid using `error` when a Checkbox is `disabled`. If provided, `disabled` functionality and styling will take precedence over `error`.
 
 ## Checkbox Group
 

--- a/packages/core/stories/checkbox/checkbox.stories.tsx
+++ b/packages/core/stories/checkbox/checkbox.stories.tsx
@@ -67,10 +67,7 @@ export const Error: ComponentStory<typeof Checkbox> = () => {
   return (
     <StackLayout>
       <CheckboxGroup validationStatus={errorState ? "error" : undefined}>
-        <Checkbox
-          onChange={() => setErrorState(false)}
-          label="Option 1"
-        />
+        <Checkbox onChange={() => setErrorState(false)} label="Option 1" />
         <Checkbox
           onChange={() => setErrorState(false)}
           defaultChecked
@@ -109,10 +106,7 @@ export const Warning: ComponentStory<typeof Checkbox> = () => {
   return (
     <StackLayout>
       <CheckboxGroup validationStatus={warningState ? "warning" : undefined}>
-        <Checkbox
-          onChange={() => setWarningState(false)}
-          label="Option 1"
-        />
+        <Checkbox onChange={() => setWarningState(false)} label="Option 1" />
         <Checkbox
           onChange={() => setWarningState(false)}
           defaultChecked

--- a/packages/core/stories/checkbox/checkbox.stories.tsx
+++ b/packages/core/stories/checkbox/checkbox.stories.tsx
@@ -66,20 +66,17 @@ export const Error: ComponentStory<typeof Checkbox> = () => {
 
   return (
     <StackLayout>
-      <CheckboxGroup>
+      <CheckboxGroup validationStatus={errorState ? "error" : undefined}>
         <Checkbox
-          validationStatus={errorState ? "error" : undefined}
           onChange={() => setErrorState(false)}
           label="Option 1"
         />
         <Checkbox
-          validationStatus={errorState ? "error" : undefined}
           onChange={() => setErrorState(false)}
           defaultChecked
           label="Option 2"
         />
         <Checkbox
-          validationStatus={errorState ? "error" : undefined}
           checked={checkboxState.checked}
           indeterminate={checkboxState.indeterminate}
           onChange={handleChange}
@@ -111,20 +108,17 @@ export const Warning: ComponentStory<typeof Checkbox> = () => {
 
   return (
     <StackLayout>
-      <CheckboxGroup>
+      <CheckboxGroup validationStatus={warningState ? "warning" : undefined}>
         <Checkbox
-          validationStatus={warningState ? "warning" : undefined}
           onChange={() => setWarningState(false)}
           label="Option 1"
         />
         <Checkbox
-          validationStatus={warningState ? "warning" : undefined}
           onChange={() => setWarningState(false)}
           defaultChecked
           label="Option 2"
         />
         <Checkbox
-          validationStatus={warningState ? "warning" : undefined}
           checked={checkboxState.checked}
           indeterminate={checkboxState.indeterminate}
           onChange={handleChange}

--- a/packages/core/stories/checkbox/checkbox.stories.tsx
+++ b/packages/core/stories/checkbox/checkbox.stories.tsx
@@ -68,18 +68,18 @@ export const Error: ComponentStory<typeof Checkbox> = () => {
     <StackLayout>
       <CheckboxGroup>
         <Checkbox
-          error={errorState}
+          validationStatus={errorState ? "error" : undefined}
           onChange={() => setErrorState(false)}
           label="Option 1"
         />
         <Checkbox
-          error={errorState}
+          validationStatus={errorState ? "error" : undefined}
           onChange={() => setErrorState(false)}
           defaultChecked
           label="Option 2"
         />
         <Checkbox
-          error={errorState}
+          validationStatus={errorState ? "error" : undefined}
           checked={checkboxState.checked}
           indeterminate={checkboxState.indeterminate}
           onChange={handleChange}
@@ -87,6 +87,51 @@ export const Error: ComponentStory<typeof Checkbox> = () => {
         />
       </CheckboxGroup>
       <Button onClick={() => setErrorState(true)}>Reset</Button>
+    </StackLayout>
+  );
+};
+
+export const Warning: ComponentStory<typeof Checkbox> = () => {
+  const [warningState, setWarningState] = useState(true);
+
+  const [checkboxState, setCheckboxState] = useState({
+    checked: false,
+    indeterminate: true,
+  });
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const updatedChecked = event.target.checked;
+    setWarningState(false);
+    setCheckboxState({
+      indeterminate: !updatedChecked && checkboxState.checked,
+      checked:
+        checkboxState.indeterminate && updatedChecked ? false : updatedChecked,
+    });
+  };
+
+  return (
+    <StackLayout>
+      <CheckboxGroup>
+        <Checkbox
+          validationStatus={warningState ? "warning" : undefined}
+          onChange={() => setWarningState(false)}
+          label="Option 1"
+        />
+        <Checkbox
+          validationStatus={warningState ? "warning" : undefined}
+          onChange={() => setWarningState(false)}
+          defaultChecked
+          label="Option 2"
+        />
+        <Checkbox
+          validationStatus={warningState ? "warning" : undefined}
+          checked={checkboxState.checked}
+          indeterminate={checkboxState.indeterminate}
+          onChange={handleChange}
+          label="Option 3"
+        />
+      </CheckboxGroup>
+      <Button onClick={() => setWarningState(true)}>Reset</Button>
     </StackLayout>
   );
 };

--- a/packages/core/stories/radio-button/radio-button.doc.stories.mdx
+++ b/packages/core/stories/radio-button/radio-button.doc.stories.mdx
@@ -44,15 +44,21 @@ A Radio Button can be disabled by setting the `disabled` prop to true. This will
   <Story id="core-radio-button--disabled" />
 </Canvas>
 
-### Error
+### Validation state
 
-Error state can be indicated stylistically by setting the `error` prop to true.
+Error state can be indicated stylistically by setting the `validationStatus` prop to "error".
 
 <Canvas>
   <Story id="core-radio-button--error" />
 </Canvas>
 
-- Avoid using `error` when a Radio Button is `disabled`. If provided, `disabled` functionality and styling will take precedence over `error`.
+Warning state can be indicated stylistically by setting the `validationStatus` prop to "warning".
+
+<Canvas>
+  <Story id="core-radio-button--warning" />
+</Canvas>
+
+- Avoid using `validationStatus` when a Radio Button is `disabled`. If provided, `disabled` functionality and styling will take precedence over any validation status styling.
 
 ## Radio Button Group
 

--- a/packages/core/stories/radio-button/radio-button.doc.stories.mdx
+++ b/packages/core/stories/radio-button/radio-button.doc.stories.mdx
@@ -58,6 +58,7 @@ Warning state can be indicated stylistically by setting the `validationStatus` p
   <Story id="core-radio-button--warning" />
 </Canvas>
 
+- When used in a group, use `validationStatus` on the group rather than the individual controls. Any status provided to the group will take precedence over the statuses applied directly to the nested controls.
 - Avoid using `validationStatus` when a Radio Button is `disabled`. If provided, `disabled` functionality and styling will take precedence over any validation status styling.
 
 ## Radio Button Group

--- a/packages/core/stories/radio-button/radio-button.stories.tsx
+++ b/packages/core/stories/radio-button/radio-button.stories.tsx
@@ -32,15 +32,8 @@ export const Disabled = () => {
 export const Error = () => {
   return (
     <RadioButtonGroup validationStatus="error">
-      <RadioButton
-        label="Error"
-        value="Error-unchecked"
-      />
-      <RadioButton
-        label="Error"
-        value="Error-checked"
-        checked
-      />
+      <RadioButton label="Error" value="Error-unchecked" />
+      <RadioButton label="Error" value="Error-checked" checked />
     </RadioButtonGroup>
   );
 };
@@ -48,15 +41,8 @@ export const Error = () => {
 export const Warning = () => {
   return (
     <RadioButtonGroup validationStatus="warning">
-      <RadioButton
-        label="Error"
-        value="Error-unchecked"
-      />
-      <RadioButton
-        label="Error"
-        value="Error-checked"
-        checked
-      />
+      <RadioButton label="Error" value="Error-unchecked" />
+      <RadioButton label="Error" value="Error-checked" checked />
     </RadioButtonGroup>
   );
 };

--- a/packages/core/stories/radio-button/radio-button.stories.tsx
+++ b/packages/core/stories/radio-button/radio-button.stories.tsx
@@ -32,8 +32,17 @@ export const Disabled = () => {
 export const Error = () => {
   return (
     <>
-      <RadioButton label="Error" value="Error-unchecked" error />
-      <RadioButton label="Error" value="Error-checked" error checked />
+      <RadioButton label="Error" value="Error-unchecked" validationStatus="error" />
+      <RadioButton label="Error" value="Error-checked" checked validationStatus="error" />
+    </>
+  );
+};
+
+export const Warning = () => {
+  return (
+    <>
+      <RadioButton label="Error" value="Error-unchecked" validationStatus="warning" />
+      <RadioButton label="Error" value="Error-checked" checked validationStatus="warning" />
     </>
   );
 };

--- a/packages/core/stories/radio-button/radio-button.stories.tsx
+++ b/packages/core/stories/radio-button/radio-button.stories.tsx
@@ -32,8 +32,17 @@ export const Disabled = () => {
 export const Error = () => {
   return (
     <>
-      <RadioButton label="Error" value="Error-unchecked" validationStatus="error" />
-      <RadioButton label="Error" value="Error-checked" checked validationStatus="error" />
+      <RadioButton
+        label="Error"
+        value="Error-unchecked"
+        validationStatus="error"
+      />
+      <RadioButton
+        label="Error"
+        value="Error-checked"
+        checked
+        validationStatus="error"
+      />
     </>
   );
 };
@@ -41,8 +50,17 @@ export const Error = () => {
 export const Warning = () => {
   return (
     <>
-      <RadioButton label="Error" value="Error-unchecked" validationStatus="warning" />
-      <RadioButton label="Error" value="Error-checked" checked validationStatus="warning" />
+      <RadioButton
+        label="Error"
+        value="Error-unchecked"
+        validationStatus="warning"
+      />
+      <RadioButton
+        label="Error"
+        value="Error-checked"
+        checked
+        validationStatus="warning"
+      />
     </>
   );
 };

--- a/packages/core/stories/radio-button/radio-button.stories.tsx
+++ b/packages/core/stories/radio-button/radio-button.stories.tsx
@@ -31,37 +31,33 @@ export const Disabled = () => {
 
 export const Error = () => {
   return (
-    <>
+    <RadioButtonGroup validationStatus="error">
       <RadioButton
         label="Error"
         value="Error-unchecked"
-        validationStatus="error"
       />
       <RadioButton
         label="Error"
         value="Error-checked"
         checked
-        validationStatus="error"
       />
-    </>
+    </RadioButtonGroup>
   );
 };
 
 export const Warning = () => {
   return (
-    <>
+    <RadioButtonGroup validationStatus="warning">
       <RadioButton
         label="Error"
         value="Error-unchecked"
-        validationStatus="warning"
       />
       <RadioButton
         label="Error"
         value="Error-checked"
         checked
-        validationStatus="warning"
       />
-    </>
+    </RadioButtonGroup>
   );
 };
 


### PR DESCRIPTION
Added `validationStatus` prop to RadioButton and Checkbox allowing for error and warning status, added `validationStatus` to group context
Deprecated `error` prop in RadioButton and Checkbox