### PR TITLE
Fix icons table on the site

### DIFF
--- a/site/src/components/getting-started/icons-table/IconsTable.module.css
+++ b/site/src/components/getting-started/icons-table/IconsTable.module.css
@@ -2,15 +2,12 @@
   color: var(--site-tertiary-accent-purple);
 }
 
-.iconsTableContainer {
-  overflow-x: auto;
-}
-
 .iconsTableContainer table thead {
   top: 0;
 }
 
 .iconsTableContainer table {
+  table-layout: fixed;
   caption-side: bottom;
 }
 


### PR DESCRIPTION
Closes #1441

A minor fix to the table, previously a scroll pane was added to scroll the table on small screens but this created more issues around accessibility. 

This PR changes the table to a fixed layout so it scales with screen size 