### PR TITLE
Fix Data Grid Dropdown showing when there are no list items

### DIFF
--- a/.changeset/new-brooms-punch.md
+++ b/.changeset/new-brooms-punch.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/data-grid": minor
+---
+
+Condition dropdown in data-grid to only render if the array of options is not empty

--- a/packages/data-grid/src/DropdownCellEditor.tsx
+++ b/packages/data-grid/src/DropdownCellEditor.tsx
@@ -62,14 +62,16 @@ export function DropdownCellEditor<T>(props: DropdownCellEditorProps<T>) {
   return (
     <Cell separator={column?.separator} className={withBaseName()}>
       <div className={withBaseName("dropdownContainer")}>
-        <Dropdown
-          isOpen={true}
-          source={options}
-          defaultSelected={value}
-          onSelectionChange={onSelectionChange}
-          triggerComponent={triggerComponent}
-          width={column!.info.width! - 5}
-        />
+        {options && options.length > 0
+          ? <Dropdown
+            isOpen={true}
+            source={options}
+            defaultSelected={value}
+            onSelectionChange={onSelectionChange}
+            triggerComponent={triggerComponent}
+            width={column!.info.width! - 5}
+          />
+          : triggerComponent}
       </div>
       <CornerTag />
     </Cell>

--- a/packages/data-grid/src/DropdownCellEditor.tsx
+++ b/packages/data-grid/src/DropdownCellEditor.tsx
@@ -62,8 +62,8 @@ export function DropdownCellEditor<T>(props: DropdownCellEditorProps<T>) {
   return (
     <Cell separator={column?.separator} className={withBaseName()}>
       <div className={withBaseName("dropdownContainer")}>
-        {options && options.length > 0
-          ? <Dropdown
+        {options && options.length > 0 ? (
+          <Dropdown
             isOpen={true}
             source={options}
             defaultSelected={value}
@@ -71,7 +71,9 @@ export function DropdownCellEditor<T>(props: DropdownCellEditorProps<T>) {
             triggerComponent={triggerComponent}
             width={column!.info.width! - 5}
           />
-          : triggerComponent}
+        ) : (
+          triggerComponent
+        )}
       </div>
       <CornerTag />
     </Cell>


### PR DESCRIPTION
this change avoids showing a dropdown in a cell editor when there is no source or the source is empty