### PR TITLE
Fix button styling in ag grid filter panel

### DIFF
--- a/.changeset/short-shrimps-reflect.md
+++ b/.changeset/short-shrimps-reflect.md
@@ -2,4 +2,4 @@
 "@salt-ds/ag-grid-theme": minor
 ---
 
-Add salt styles to `.ag-standard-button`.
+Fix button styles in ag grid theme currently showing default HTML buttons by adding salt styles to `.ag-standard-button`.

--- a/.changeset/short-shrimps-reflect.md
+++ b/.changeset/short-shrimps-reflect.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/ag-grid-theme": minor
+---
+
+Add salt styles to `.ag-standard-button`.

--- a/packages/ag-grid-theme/css/_salt-ag-theme-mixin.scss
+++ b/packages/ag-grid-theme/css/_salt-ag-theme-mixin.scss
@@ -333,6 +333,28 @@
     width: var(--salt-size-stackable);
   }
 
+  .ag-standard-button {
+    appearance: none;
+    background: var(--salt-actionable-secondary-background);
+    -webkit-appearance: none;
+    border-radius: ag-param(border-radius);
+    border: 1px transparent;
+    cursor: pointer;
+    height: var(--salt-size-base);
+    font-weight: 600;
+    color: var(--salt-actionable-secondary-foreground);
+    text-transform: uppercase;
+    font-size: var(--salt-text-fontSize);
+    padding: 0 var(--salt-size-unit);
+    &:hover {
+      background-color: var(--salt-actionable-secondary-background-hover);
+    }
+    &:active {
+      color: var(--salt-actionable-secondary-foreground-active);
+      background-color: var(--salt-actionable-secondary-background-active);
+    }
+  }
+
   .ag-ltr .ag-side-bar-right .ag-side-button-button {
     border-left: 2px solid transparent;
     &:focus-visible {

--- a/packages/ag-grid-theme/css/_salt-ag-theme-mixin.scss
+++ b/packages/ag-grid-theme/css/_salt-ag-theme-mixin.scss
@@ -346,6 +346,13 @@
     text-transform: uppercase;
     font-size: var(--salt-text-fontSize);
     padding: 0 var(--salt-size-unit);
+    &:focus-visible {
+      outline-style: var(--salt-focused-outlineStyle);
+      outline-width: var(--salt-focused-outlineWidth);
+      outline-color: var(--salt-focused-outlineColor);
+      outline-offset: var(--salt-focused-outlineOffset);
+      background: var(--salt-actionable-secondary-background-hover);
+    }
     &:hover {
       background-color: var(--salt-actionable-secondary-background-hover);
     }


### PR DESCRIPTION
add `ag-standard-button` styles to salt-ag-theme

path to see changes: 
https://31a01c59.saltdesignsystem-storybook.pages.dev/?path=/story/data-grid-ag-grid-theme--basic-grid