### PR TITLE
Fix breakpoints being ignored if they are out of order

### DIFF
--- a/.changeset/mighty-turkeys-join.md
+++ b/.changeset/mighty-turkeys-join.md
@@ -2,4 +2,5 @@
 "@salt-ds/core": patch
 ---
 
-sort breakpoints in `useResponsiveProps` so it can handle unordered props
+- Sort breakpoints in `useResponsiveProps` so it can handle unordered props.
+- Fix flickering bug on breakpoint change when values passed to `useResponsiveProps` are the same.

--- a/.changeset/mighty-turkeys-join.md
+++ b/.changeset/mighty-turkeys-join.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+sort breakpoints in `useResponsiveProps` so it can handle unordered props

--- a/packages/core/src/stack-layout/StackLayout.tsx
+++ b/packages/core/src/stack-layout/StackLayout.tsx
@@ -68,7 +68,7 @@ export const StackLayout: StackLayoutComponent = forwardRef(
 
     const flexGap = useResponsiveProp(gap, 3);
     const separatorAlignment = separators === true ? "center" : separators;
-    const flexDirection = useResponsiveProp(direction) || "column";
+    const flexDirection = useResponsiveProp(direction, "column");
     const stackLayoutStyles = {
       ...style,
       "--stackLayout-gap-multiplier": flexGap,

--- a/packages/core/src/stack-layout/StackLayout.tsx
+++ b/packages/core/src/stack-layout/StackLayout.tsx
@@ -68,7 +68,7 @@ export const StackLayout: StackLayoutComponent = forwardRef(
 
     const flexGap = useResponsiveProp(gap, 3);
     const separatorAlignment = separators === true ? "center" : separators;
-    const flexDirection = useResponsiveProp(direction, "column");
+    const flexDirection = useResponsiveProp(direction) || "column";
     const stackLayoutStyles = {
       ...style,
       "--stackLayout-gap-multiplier": flexGap,

--- a/packages/core/src/utils/useResponsiveProp.ts
+++ b/packages/core/src/utils/useResponsiveProp.ts
@@ -12,8 +12,7 @@ export const getCurrentBreakpoint = (
   breakpoints: Breakpoints,
   width: number
 ) => {
-  const breakpointList = Object.entries(breakpoints);
-
+  const breakpointList = Object.entries(breakpoints).sort(([, a], [, b]) => a - b);
   const [currentBreakpoint] = (
     breakpointList as [keyof Breakpoints, number][]
   ).reduce((acc, val) => {

--- a/packages/core/src/utils/useResponsiveProp.ts
+++ b/packages/core/src/utils/useResponsiveProp.ts
@@ -95,7 +95,7 @@ export const useResponsiveProp = <T>(
   const breakpoints = useBreakpoints();
   const viewport = useViewport();
   // return early if the values are the same
-  if (value === defaultValue) return value;
+  if (value === defaultValue) return defaultValue;
 
   const currentViewport = getCurrentBreakpoint(breakpoints, viewport);
   if (hasBreakpointValues(value, breakpoints)) {

--- a/packages/core/src/utils/useResponsiveProp.ts
+++ b/packages/core/src/utils/useResponsiveProp.ts
@@ -12,7 +12,9 @@ export const getCurrentBreakpoint = (
   breakpoints: Breakpoints,
   width: number
 ) => {
-  const breakpointList = Object.entries(breakpoints).sort(([, a], [, b]) => a - b);
+  const breakpointList = Object.entries(breakpoints).sort(
+    ([, a], [, b]) => a - b
+  );
   const [currentBreakpoint] = (
     breakpointList as [keyof Breakpoints, number][]
   ).reduce((acc, val) => {

--- a/packages/core/src/utils/useResponsiveProp.ts
+++ b/packages/core/src/utils/useResponsiveProp.ts
@@ -65,9 +65,10 @@ const hasBreakpointValues = <T>(
 const getResponsiveValue = <T>(
   breakpointValues: BreakpointProp<T>,
   breakpoints: Breakpoints,
-  viewport: keyof Breakpoints
+  viewport: keyof Breakpoints,
+  defaultValue: T
 ) => {
-  return Object.entries(breakpointValues).reduce<[number, T | undefined]>(
+  return Object.entries(breakpointValues).reduce<[number, T]>(
     (acc, val) => {
       const [accWidth] = acc;
       const [breakpoint, breakpointValue] = val;
@@ -84,13 +85,13 @@ const getResponsiveValue = <T>(
 
       return acc;
     },
-    [0, undefined]
+    [0, defaultValue]
   )[1];
 };
 
 export const useResponsiveProp = <T>(
   value: ResponsiveProp<T>,
-  defaultValue?: T
+  defaultValue: T
 ) => {
   const breakpoints = useBreakpoints();
   const viewport = useViewport();
@@ -99,8 +100,11 @@ export const useResponsiveProp = <T>(
 
   const currentViewport = getCurrentBreakpoint(breakpoints, viewport);
   if (hasBreakpointValues(value, breakpoints)) {
-    return (
-      getResponsiveValue(value, breakpoints, currentViewport) || defaultValue
+    return getResponsiveValue(
+      value,
+      breakpoints,
+      currentViewport,
+      defaultValue
     );
   }
   return value;

--- a/packages/core/src/utils/useResponsiveProp.ts
+++ b/packages/core/src/utils/useResponsiveProp.ts
@@ -40,11 +40,9 @@ export const useCurrentBreakpoint = () => {
 export const useOrderedBreakpoints = () => {
   const breakpoints = useBreakpoints();
 
-  const orderedBreakpoints = Object.entries(breakpoints)
+  return Object.entries(breakpoints)
     .sort(([, a], [, b]) => a - b)
     .map(([key]) => key);
-
-  return orderedBreakpoints;
 };
 
 const isObject = <T>(
@@ -67,10 +65,9 @@ const hasBreakpointValues = <T>(
 const getResponsiveValue = <T>(
   breakpointValues: BreakpointProp<T>,
   breakpoints: Breakpoints,
-  viewport: keyof Breakpoints,
-  defaultValue: T
+  viewport: keyof Breakpoints
 ) => {
-  const value = Object.entries(breakpointValues).reduce<[number, T]>(
+  return Object.entries(breakpointValues).reduce<[number, T | undefined]>(
     (acc, val) => {
       const [accWidth] = acc;
       const [breakpoint, breakpointValue] = val;
@@ -87,27 +84,23 @@ const getResponsiveValue = <T>(
 
       return acc;
     },
-    [0, defaultValue]
+    [0, undefined]
   )[1];
-
-  return value;
 };
 
 export const useResponsiveProp = <T>(
   value: ResponsiveProp<T>,
-  defaultValue: T
+  defaultValue?: T
 ) => {
   const breakpoints = useBreakpoints();
   const viewport = useViewport();
+  // return early if the values are the same
+  if (value === defaultValue) return value;
 
   const currentViewport = getCurrentBreakpoint(breakpoints, viewport);
-
   if (hasBreakpointValues(value, breakpoints)) {
-    return getResponsiveValue(
-      value,
-      breakpoints,
-      currentViewport,
-      defaultValue
+    return (
+      getResponsiveValue(value, breakpoints, currentViewport) || defaultValue
     );
   }
   return value;


### PR DESCRIPTION
Prevents grid (and probably others that use responsiveProps)from ignoring some breakpoints if they don't come in the right order.