### PR TITLE
Allow site component examples title to be customised

### DIFF
--- a/site/docs/components/button/examples.mdx
+++ b/site/docs/components/button/examples.mdx
@@ -25,15 +25,11 @@ data:
 <LivePreviewControls>
 <LivePreview componentName="button" exampleName="CTA" >
 
-### CTA (call to action)
-
 Use the CTA button for high priority actions.
 
 </LivePreview>
 
 <LivePreview componentName="button" exampleName="Primary" >
-
-### Primary
 
 Use the primary button for routine, non-urgent actions.
 
@@ -41,15 +37,11 @@ Use the primary button for routine, non-urgent actions.
 
 <LivePreview componentName="button" exampleName="Secondary" >
 
-### Secondary
-
 Use the secondary button for non-critical actions that support the user but do not impact a flow.
 
 </LivePreview>
 
 <LivePreview componentName="button" exampleName="IconAndLabel" >
-
-### Icon and label
 
 Add an icon before the text to reinforce the button label, or add an icon after the button label to suggest movement or a direction.
 
@@ -57,15 +49,11 @@ Add an icon before the text to reinforce the button label, or add an icon after 
 
 <LivePreview componentName="button" exampleName="IconOnly" >
 
-### Icon only
-
 Display an icon-only button with no label when you have limited on-screen space and the icon is globally understood.
 
 </LivePreview>
 
 <LivePreview componentName="button" exampleName="Disabled" >
-
-### Disabled
 
 Indicates a button that the user can’t interact with.
 

--- a/site/src/components/components/ExamplesListView.tsx
+++ b/site/src/components/components/ExamplesListView.tsx
@@ -6,17 +6,16 @@ import {
   Dropdown,
 } from "@salt-ds/lab";
 import useIsMobileView from "../../utils/useIsMobileView";
+import { Heading3 } from "../mdx/h3";
+import { exampleNameRegex } from "./LivePreview";
 
 import styles from "./ExamplesListView.module.css";
-
-const exampleNameRegex = /[A-Z]?[a-z]+|[0-9]+|[A-Z]+(?![a-z])/g;
 
 type ExamplesListViewProps = { examples: ReactElement[] };
 
 const ExamplesListView: FC<ExamplesListViewProps> = ({ examples }) => {
-  const examplesList: string[] = Children.map(
-    examples,
-    ({ props }) => props.exampleName
+  const examplesList: string[] = Children.map(examples, ({ props }) =>
+    props.title ? props.title : props.exampleName
   );
 
   const [selectedItem, setSelectedItem] = useState<string | null>(
@@ -36,7 +35,7 @@ const ExamplesListView: FC<ExamplesListViewProps> = ({ examples }) => {
     examplesArray[0];
 
   const {
-    props: { children: exampleCopy, ...restProps },
+    props: { children: exampleCopy, title, exampleName, ...restProps },
     ...rest
   } = selectedExample;
 
@@ -67,11 +66,17 @@ const ExamplesListView: FC<ExamplesListViewProps> = ({ examples }) => {
     </div>
   );
 
-  const componentExample = { props: { list, ...restProps }, ...rest };
+  const componentExample = {
+    props: { list, exampleName, ...restProps },
+    ...rest,
+  };
 
   return (
     <>
       {componentExample}
+      <Heading3>
+        {title ? title : exampleName.match(exampleNameRegex)?.join(" ")}
+      </Heading3>
       {exampleCopy}
     </>
   );

--- a/site/src/components/components/ExamplesListView.tsx
+++ b/site/src/components/components/ExamplesListView.tsx
@@ -7,7 +7,7 @@ import {
 } from "@salt-ds/lab";
 import useIsMobileView from "../../utils/useIsMobileView";
 import { Heading3 } from "../mdx/h3";
-import { exampleNameRegex } from "./LivePreview";
+import { formatComponentExampleName } from "./formatComponentExampleName";
 
 import styles from "./ExamplesListView.module.css";
 
@@ -46,7 +46,7 @@ const ExamplesListView: FC<ExamplesListViewProps> = ({ examples }) => {
         source={examplesList}
         selected={selectedItem}
         onSelectionChange={handleSelect}
-        itemToString={(item) => item.match(exampleNameRegex)?.join(" ") || item}
+        itemToString={(item) => formatComponentExampleName(item)}
       />
     </FormField>
   ) : (
@@ -61,7 +61,7 @@ const ExamplesListView: FC<ExamplesListViewProps> = ({ examples }) => {
         onSelect={handleSelect}
         selected={selectedItem}
         defaultSelected={examplesList[0]}
-        itemToString={(item) => item.match(exampleNameRegex)?.join(" ") || item}
+        itemToString={(item) => formatComponentExampleName(item)}
       />
     </div>
   );
@@ -75,7 +75,7 @@ const ExamplesListView: FC<ExamplesListViewProps> = ({ examples }) => {
     <>
       {componentExample}
       <Heading3>
-        {title ? title : exampleName.match(exampleNameRegex)?.join(" ")}
+        {title ? title : formatComponentExampleName(exampleName)}
       </Heading3>
       {exampleCopy}
     </>

--- a/site/src/components/components/LivePreview.tsx
+++ b/site/src/components/components/LivePreview.tsx
@@ -4,6 +4,7 @@ import clsx from "clsx";
 import { Switch } from "@salt-ds/lab";
 import { SaltProvider } from "@salt-ds/core";
 import { Pre } from "../mdx/pre";
+import { Heading3 } from "../mdx/h3";
 import { useLivePreviewControls } from "./useLivePreviewControls";
 import useIsMobileView from "../../utils/useIsMobileView";
 import styles from "./LivePreview.module.css";
@@ -11,13 +12,17 @@ import styles from "./LivePreview.module.css";
 type LivePreviewProps = {
   componentName: string;
   exampleName: string;
+  title?: string;
   list?: ReactElement;
   children?: ReactNode;
 };
 
+export const exampleNameRegex = /[A-Z]?[a-z]+|[0-9]+|[A-Z]+(?![a-z])/g;
+
 export const LivePreview: FC<LivePreviewProps> = ({
   componentName,
   exampleName,
+  title,
   list,
   children,
 }) => {
@@ -41,6 +46,12 @@ export const LivePreview: FC<LivePreviewProps> = ({
 
   return (
     <>
+      {!list && (
+        <Heading3>
+          {title ? title : exampleName.match(exampleNameRegex)?.join(" ")}
+        </Heading3>
+      )}
+
       {children}
       <div className={styles.container}>
         <div

--- a/site/src/components/components/LivePreview.tsx
+++ b/site/src/components/components/LivePreview.tsx
@@ -6,7 +6,9 @@ import { SaltProvider } from "@salt-ds/core";
 import { Pre } from "../mdx/pre";
 import { Heading3 } from "../mdx/h3";
 import { useLivePreviewControls } from "./useLivePreviewControls";
+import { formatComponentExampleName } from "./formatComponentExampleName";
 import useIsMobileView from "../../utils/useIsMobileView";
+
 import styles from "./LivePreview.module.css";
 
 type LivePreviewProps = {
@@ -16,8 +18,6 @@ type LivePreviewProps = {
   list?: ReactElement;
   children?: ReactNode;
 };
-
-export const exampleNameRegex = /[A-Z]?[a-z]+|[0-9]+|[A-Z]+(?![a-z])/g;
 
 export const LivePreview: FC<LivePreviewProps> = ({
   componentName,
@@ -48,7 +48,7 @@ export const LivePreview: FC<LivePreviewProps> = ({
     <>
       {!list && (
         <Heading3>
-          {title ? title : exampleName.match(exampleNameRegex)?.join(" ")}
+          {title ? title : formatComponentExampleName(exampleName)}
         </Heading3>
       )}
 

--- a/site/src/components/components/LivePreviewControls.tsx
+++ b/site/src/components/components/LivePreviewControls.tsx
@@ -27,7 +27,6 @@ const modes: Mode[] = ["light", "dark"];
 const defaultDensity = densities[1];
 
 const defaultMode = modes[0];
-console.log("defaultMode", defaultMode);
 
 export type LivePreviewContextType = {
   density?: Density;
@@ -42,7 +41,6 @@ export const LivePreviewControls: FC<LivePreviewControlsProps> = ({
   const [density, setDensity] = useState<Density>(defaultDensity);
 
   const [mode, setMode] = useState<Mode>(defaultMode);
-  console.log("mode", mode);
 
   const { allExamplesView, setAllExamplesView } = useAllExamplesView();
 

--- a/site/src/components/components/LivePreviewControls.tsx
+++ b/site/src/components/components/LivePreviewControls.tsx
@@ -27,6 +27,7 @@ const modes: Mode[] = ["light", "dark"];
 const defaultDensity = densities[1];
 
 const defaultMode = modes[0];
+console.log("defaultMode", defaultMode);
 
 export type LivePreviewContextType = {
   density?: Density;
@@ -41,6 +42,7 @@ export const LivePreviewControls: FC<LivePreviewControlsProps> = ({
   const [density, setDensity] = useState<Density>(defaultDensity);
 
   const [mode, setMode] = useState<Mode>(defaultMode);
+  console.log("mode", mode);
 
   const { allExamplesView, setAllExamplesView } = useAllExamplesView();
 
@@ -108,6 +110,7 @@ export const LivePreviewControls: FC<LivePreviewControlsProps> = ({
               <ToggleButtonGroup
                 aria-label="Select mode"
                 onChange={handleModeChange}
+                value={mode}
               >
                 <ToggleButton aria-label="light mode" value="light">
                   <LightIcon /> {!isMobileView && " Light"}

--- a/site/src/components/components/formatComponentExampleName.ts
+++ b/site/src/components/components/formatComponentExampleName.ts
@@ -1,0 +1,7 @@
+const exampleNameRegex = /[A-Z]?[a-z]+|[0-9]+|[A-Z]+(?![a-z])/g;
+
+export const formatComponentExampleName = (name: string) => {
+  const formattedName = name.match(exampleNameRegex);
+
+  return formattedName ? formattedName.join(" ") : name;
+};

--- a/site/src/layouts/DetailComponent/MobileDrawer.module.css
+++ b/site/src/layouts/DetailComponent/MobileDrawer.module.css
@@ -7,7 +7,7 @@
   margin-top: calc(-1 * calc(var(--salt-size-unit) * 2));
   box-shadow: var(--salt-overlayable-shadow-modal);
   padding-left: calc(var(--salt-size-unit) * 2);
-  transition: max-height 0.6s ease-in-out;
+  transition: max-height var(--salt-duration-perceptible) ease-in-out;
   overflow: hidden;
   max-height: 0;
 }

--- a/site/src/layouts/DetailComponent/MobileDrawer.module.css
+++ b/site/src/layouts/DetailComponent/MobileDrawer.module.css
@@ -7,7 +7,7 @@
   margin-top: calc(-1 * calc(var(--salt-size-unit) * 2));
   box-shadow: var(--salt-overlayable-shadow-modal);
   padding-left: calc(var(--salt-size-unit) * 2);
-  transition: max-height 1s ease-in-out;
+  transition: max-height 0.6s ease-in-out;
   overflow: hidden;
   max-height: 0;
 }


### PR DESCRIPTION
- Add optional `title` prop to `LivePreview` component to allow users to customise the title that is displayed for each example. This will default to the example file name if not provided and will also allow for a cleaner `examples.mdx`
- Add missing `value` to mode toggle button
- Amend mobile drawer transition speed
- Preview at https://saltdesignsystem-git-live-preview-tweaks-joshwooding.vercel.app/salt/components/button/examples

<img width="1073" alt="Screenshot 2023-06-27 at 16 43 30" src="https://github.com/jpmorganchase/salt-ds/assets/31695437/bc1a8174-40a8-4693-888f-4535e2333f18">
<img width="964" alt="Screenshot 2023-06-27 at 16 43 39" src="https://github.com/jpmorganchase/salt-ds/assets/31695437/04c64f32-9af8-4ac7-b9f7-aed9fa45c061">