### PR TITLE
Remove browser versions from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,6 @@ browsers, outlined in the table below.
 |                  | Chrome      | JAWS          |
 | macOS            | Safari      | VoiceOver     |
 
-## Browser compatibility
-
-| Web Browser  | Version         |
-| ------------ | --------------- |
-| Firefox      | 38+             |
-| Chrome, Edge | last 2 versions |
-
 ## Thanks
 
 <a href="https://www.chromatic.com/">


### PR DESCRIPTION
Firefox version is not an accurate description on what's supported by our code, e.g. css gap, focus visible.

It's better we put it back once true version support is defined by product