### PR TITLE
Move palette negative/positive tokens to deprecated section 

### DIFF
--- a/packages/theme/css/foundations/palette.css
+++ b/packages/theme/css/foundations/palette.css
@@ -115,7 +115,6 @@
 
   /* Negative */
   --salt-palette-negative-foreground: var(--salt-color-red-700);
-  --salt-palette-negative-foreground-disabled: var(--salt-color-red-700-fade-foreground);
 
   /* Neutral */
   --salt-palette-neutral-primary-background: var(--salt-color-white);
@@ -143,7 +142,6 @@
 
   /* Positive */
   --salt-palette-positive-foreground: var(--salt-color-green-700);
-  --salt-palette-positive-foreground-disabled: var(--salt-color-green-700-fade-foreground);
 
   /* Track */
   --salt-palette-track-background: var(--salt-color-gray-60);
@@ -248,7 +246,6 @@
 
   /* Negative */
   --salt-palette-negative-foreground: var(--salt-color-red-300);
-  --salt-palette-negative-foreground-disabled: var(--salt-color-red-300-fade-foreground);
 
   /* Neutral */
   --salt-palette-neutral-primary-background: var(--salt-color-gray-800);
@@ -276,7 +273,6 @@
 
   /* Positive */
   --salt-palette-positive-foreground: var(--salt-color-green-300);
-  --salt-palette-positive-foreground-disabled: var(--salt-color-green-300-fade-foreground);
 
   /* Track */
   --salt-palette-track-background: var(--salt-color-gray-300);
@@ -318,6 +314,10 @@
   --salt-palette-success-border-disabled: var(--salt-color-green-500-fade-border);
   --salt-palette-success-foreground-disabled: var(--salt-color-green-500-fade-foreground);
   --salt-palette-warning-border-disabled: var(--salt-color-orange-700-fade-border);
+
+  /* Positive/Negative */
+  --salt-palette-positive-foreground-disabled: var(--salt-color-green-700-fade-foreground);
+  --salt-palette-negative-foreground-disabled: var(--salt-color-red-700-fade-foreground);
 }
 
 .salt-theme[data-mode="dark"] {
@@ -348,4 +348,8 @@
   --salt-palette-success-border-disabled: var(--salt-color-green-400-fade-border);
   --salt-palette-success-foreground-disabled: var(--salt-color-green-400-fade-foreground);
   --salt-palette-warning-border-disabled: var(--salt-color-orange-500-fade-border);
+
+  /* Positive/Negative */
+  --salt-palette-positive-foreground-disabled: var(--salt-color-green-300-fade-foreground);
+  --salt-palette-negative-foreground-disabled: var(--salt-color-red-300-fade-foreground);
 }


### PR DESCRIPTION
Very minor; but these weren't moved in the PR when they were deprecated
Moving them makes it clearer
Already documented as deprecated