### PR TITLE
fixes links to roadmap page

### DIFF
--- a/site/docs/components/index.mdx
+++ b/site/docs/components/index.mdx
@@ -15,6 +15,6 @@ They include accessibility and design specifications for each component,
 with designs for light and dark modes in all four densities.
 
 _Need a component that's not listed? Salt is under active development and new components are released on a regular basis.  
-Check out our [roadmap](../getting-started/roadmap) to see what's coming next._
+Check out our [roadmap](../about/roadmap) to see what's coming next._
 
 <ComponentsList />

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -85,7 +85,7 @@ const cards: CardProps[] = [
         Salt site and legacy UI Toolkit.
       </p>
     ),
-    url: "./getting-started/roadmap",
+    url: "./about/roadmap",
     footerText: "View our planning schedule",
     keylineColor: "var(--site-tertiary-accent-orange)",
   },


### PR DESCRIPTION
The roadmap page moved to the about section and this broke a couple of internal links. This PR fixes that.