### PR TITLE
Corrects min. React 16 version in package dependencies

### DIFF
--- a/.changeset/hungry-toes-beam.md
+++ b/.changeset/hungry-toes-beam.md
@@ -1,0 +1,11 @@
+---
+"@salt-ds/core": patch
+"@salt-ds/countries": patch
+"@salt-ds/data-grid": patch
+"@salt-ds/icons": patch
+"@salt-ds/lab": patch
+"@salt-ds/styles": patch
+"@salt-ds/window": patch
+---
+
+Corrected the minimum supported version of React. It has been updated to 16.14.0 due to the support for the new [JSX transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,9 +5,9 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "peerDependencies": {
-    "@types/react": ">=16.8.6",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0"
+    "@types/react": ">=16.14.0",
+    "react": ">=16.14.0",
+    "react-dom": ">=16.14.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/countries/package.json
+++ b/packages/countries/package.json
@@ -12,9 +12,9 @@
     "clean": "rimraf ./src/components"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.6",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0"
+    "@types/react": ">=16.14.0",
+    "react": ">=16.14.0",
+    "react-dom": ">=16.14.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/data-grid/package.json
+++ b/packages/data-grid/package.json
@@ -5,9 +5,9 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "peerDependencies": {
-    "@types/react": ">=16.8.6",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0"
+    "@types/react": ">=16.14.0",
+    "react": ">=16.14.0",
+    "react-dom": ">=16.14.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -9,9 +9,9 @@
     "clean": "rimraf ./src/components"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.6",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0"
+    "@types/react": ">=16.14.0",
+    "react": ">=16.14.0",
+    "react-dom": ">=16.14.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -5,9 +5,9 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "peerDependencies": {
-    "@types/react": ">=16.8.6",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0"
+    "@types/react": ">=16.14.0",
+    "react": ">=16.14.0",
+    "react-dom": ">=16.14.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -5,9 +5,9 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "peerDependencies": {
-    "@types/react": ">=16.8.6",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0"
+    "@types/react": ">=16.14.0",
+    "react": ">=16.14.0",
+    "react-dom": ">=16.14.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/window/package.json
+++ b/packages/window/package.json
@@ -5,9 +5,9 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "peerDependencies": {
-    "@types/react": ">=16.8.6",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0"
+    "@types/react": ">=16.14.0",
+    "react": ">=16.14.0",
+    "react-dom": ">=16.14.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5530,9 +5530,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@salt-ds/core@workspace:packages/core"
   peerDependencies:
-    "@types/react": ">=16.8.6"
-    react: ">=16.8.0"
-    react-dom: ">=16.8.0"
+    "@types/react": ">=16.14.0"
+    react: ">=16.14.0"
+    react-dom: ">=16.14.0"
   peerDependenciesMeta:
     "@types/react":
       optional: true
@@ -5548,9 +5548,9 @@ __metadata:
     rimraf: ^4.4.0
     svgo: ^3.0.0
   peerDependencies:
-    "@types/react": ">=16.8.6"
-    react: ">=16.8.0"
-    react-dom: ">=16.8.0"
+    "@types/react": ">=16.14.0"
+    react: ">=16.14.0"
+    react-dom: ">=16.14.0"
   peerDependenciesMeta:
     "@types/react":
       optional: true
@@ -5561,9 +5561,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@salt-ds/data-grid@workspace:packages/data-grid"
   peerDependencies:
-    "@types/react": ">=16.8.6"
-    react: ">=16.8.0"
-    react-dom: ">=16.8.0"
+    "@types/react": ">=16.14.0"
+    react: ">=16.14.0"
+    react-dom: ">=16.14.0"
   peerDependenciesMeta:
     "@types/react":
       optional: true
@@ -5578,9 +5578,9 @@ __metadata:
     rimraf: ^4.4.0
     svgo: ^3.0.0
   peerDependencies:
-    "@types/react": ">=16.8.6"
-    react: ">=16.8.0"
-    react-dom: ">=16.8.0"
+    "@types/react": ">=16.14.0"
+    react: ">=16.14.0"
+    react-dom: ">=16.14.0"
   peerDependenciesMeta:
     "@types/react":
       optional: true
@@ -5591,9 +5591,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@salt-ds/lab@workspace:packages/lab"
   peerDependencies:
-    "@types/react": ">=16.8.6"
-    react: ">=16.8.0"
-    react-dom: ">=16.8.0"
+    "@types/react": ">=16.14.0"
+    react: ">=16.14.0"
+    react-dom: ">=16.14.0"
   peerDependenciesMeta:
     "@types/react":
       optional: true
@@ -5730,9 +5730,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@salt-ds/styles@workspace:packages/styles"
   peerDependencies:
-    "@types/react": ">=16.8.6"
-    react: ">=16.8.0"
-    react-dom: ">=16.8.0"
+    "@types/react": ">=16.14.0"
+    react: ">=16.14.0"
+    react-dom: ">=16.14.0"
   peerDependenciesMeta:
     "@types/react":
       optional: true
@@ -5764,9 +5764,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@salt-ds/window@workspace:packages/window"
   peerDependencies:
-    "@types/react": ">=16.8.6"
-    react: ">=16.8.0"
-    react-dom: ">=16.8.0"
+    "@types/react": ">=16.14.0"
+    react: ">=16.14.0"
+    react-dom: ">=16.14.0"
   peerDependenciesMeta:
     "@types/react":
       optional: true


### PR DESCRIPTION
The various Salt packages incorrectly list React 16.8.0 as their minimum version. However, our code relies on the JSX transform, which was not added until 16.14.0.

Therefore, consumers who try to use Salt with React 16.8.0 - 16.13.x will encounter build errors. At least one consumer is known to have been tripped up by this.

This PR corrects our dependencies.