### PR TITLE
Component page text tweaks

### DIFF
--- a/site/docs/components/index.mdx
+++ b/site/docs/components/index.mdx
@@ -14,7 +14,13 @@ in Figma when logged in to the JPMC network.
 They include accessibility and design specifications for each component,
 with designs for light and dark modes in all four densities.
 
-_Need a component that's not listed? Salt is under active development and new components are released on a regular basis.  
-Check out our [roadmap](../about/roadmap) to see what's coming next._
+<Callout title="Need a component that's not listed?">
+
+Salt is under active development and new components are released on a regular basis.
+Check out our [roadmap](../about/roadmap) to see what's coming next.
+
+</Callout>
+
+## Available and upcoming components
 
 <ComponentsList />

--- a/site/src/components/components/ComponentsList.module.css
+++ b/site/src/components/components/ComponentsList.module.css
@@ -3,7 +3,7 @@
 }
 
 .componentList {
-  margin: calc(var(--salt-size-unit) * 3) 0;
+  margin: 0 0 calc(var(--salt-size-unit) * 3) 0;
 }
 
 .componentList table {


### PR DESCRIPTION
The "Need a component that's not listed? ..." text on the components page currently appears in bold & italic, which contradicts our own Typography foundations guidance.

This PR therefore:

* Places that text into a callout instead
* Adds a heading above the components table, to help separate it from the callout above 