### PR TITLE
Fix interactable card styling

### DIFF
--- a/.changeset/twelve-rabbits-pretend.md
+++ b/.changeset/twelve-rabbits-pretend.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Fixed interactable card styles clashing with card styles in the production build

--- a/packages/core/src/card/InteractableCard.css
+++ b/packages/core/src/card/InteractableCard.css
@@ -1,11 +1,23 @@
 /* Styles applied to InteractableCard */
 .saltInteractableCard {
+  background: var(--saltCard-background, var(--salt-container-primary-background));
+  box-shadow: var(--saltCard-boxShadow, var(--salt-overlayable-shadow));
+  color: var(--saltCard-color, var(--salt-text-primary-foreground));
+  height: var(--saltCard-height, auto);
+  min-height: var(--saltCard-minHeight, 100%);
+  overflow: hidden;
   border-width: var(--saltCard-borderWidth, var(--card-borderWidth));
   border-style: var(--saltCard-borderStyle, var(--salt-container-borderStyle));
   border-color: var(--saltCard-borderColor, var(--salt-accent-borderColor));
   border-radius: var(--saltCard-borderRadius, 0);
   display: block;
   transition: box-shadow var(--salt-duration-instant) cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Styles applied to Card content */
+.saltInteractableCard-content {
+  height: 100%;
+  padding: var(--saltCard-padding, var(--salt-size-container-spacing));
 }
 
 /* Styles applied to InteractableCard if `accentPlacement="bottom"` (default) */

--- a/packages/core/src/card/InteractableCard.tsx
+++ b/packages/core/src/card/InteractableCard.tsx
@@ -1,9 +1,8 @@
 import { clsx } from "clsx";
-import { forwardRef } from "react";
+import { ComponentPropsWithoutRef, forwardRef } from "react";
 import { useWindow } from "@salt-ds/window";
 import { useComponentCssInjection } from "@salt-ds/styles";
 
-import { Card, CardProps } from "./Card";
 import { capitalize, makePrefixer } from "../utils";
 import { useInteractableCard } from "./useInteractableCard";
 
@@ -12,8 +11,7 @@ import interactableCardCss from "./InteractableCard.css";
 const withBaseName = makePrefixer("saltInteractableCard");
 
 // TODO: Remove omissions when Card props deprecated
-export interface InteractableCardProps
-  extends Omit<CardProps, "disabled" | "interactable"> {
+export interface InteractableCardProps extends ComponentPropsWithoutRef<"div"> {
   /**
    * Accent border position: defaults to "bottom"
    */

--- a/packages/core/src/card/InteractableCard.tsx
+++ b/packages/core/src/card/InteractableCard.tsx
@@ -58,7 +58,7 @@ export const InteractableCard = forwardRef<
   const { tabIndex, ...restCardProps } = cardProps;
 
   return (
-    <Card
+    <div
       {...restCardProps}
       className={clsx(
         withBaseName(),
@@ -72,7 +72,7 @@ export const InteractableCard = forwardRef<
       {...rest}
       ref={ref}
     >
-      {children}
-    </Card>
+      <div className={withBaseName("content")}>{children}</div>
+    </div>
   );
 });


### PR DESCRIPTION
This updates interactable card to follow our best practices so that it does not depend on card. This was causing an issue in production build, where the styles would clash.