### PR TITLE
Fix not loading parent child doc story

### DIFF
--- a/packages/lab/stories/parent-child-layout/parent-child-layout.doc.stories.mdx
+++ b/packages/lab/stories/parent-child-layout/parent-child-layout.doc.stories.mdx
@@ -34,7 +34,7 @@ You want your layout to flow in a single dimension. In this case we recommend yo
 The parent and child component changes to a stacked view once it approaches a specified breakpoint that can be customized via the `stackedAtBreakpoint` prop.
 
 <Canvas>
-  <Story id="lab-layout-parent-child-layout--toolkit-stacked" />
+  <Story id="lab-layout-parent-child-layout--salt-stacked" />
 </Canvas>
 
 #### Reduced motion


### PR DESCRIPTION
Stack example is not loading on [parent child doc](https://storybook.saltdesignsystem.com/?path=/story/documentation-lab-layout-parent-child-layout--page).

To check: fixed in preview doc: https://a6cc41ce.saltdesignsystem-storybook.pages.dev/?path=/docs/documentation-lab-layout-parent-child-layout--page