### PR TITLE
Make ToggleButton `value` prop optional instead of `undefined`

### DIFF
--- a/packages/core/src/toggle-button/ToggleButton.tsx
+++ b/packages/core/src/toggle-button/ToggleButton.tsx
@@ -16,7 +16,7 @@ import toggleButtonCss from "./ToggleButton.css";
 export interface ToggleButtonProps extends ComponentProps<"button"> {
   selected?: boolean;
   onChange?: (event: MouseEvent<HTMLButtonElement>) => void;
-  value: string | ReadonlyArray<string> | number | undefined;
+  value?: string | ReadonlyArray<string> | number;
 }
 
 const withBaseName = makePrefixer("saltToggleButton");


### PR DESCRIPTION
In later versions of TypeScript (e.g. 5.1.6 & 4.9.5), `<ToggleButton />` will give below TS error. Update `value` prop to be optional to achieve the same effect.

```
Property 'value' is missing in type '{ children: (string | Element)[]; }' but required in type 'Omit<ToggleButtonProps, "ref">'.ts(2741)
```