### PR TITLE
Adds Badge component docs to site

### DIFF
--- a/packages/lab/stories/badge/badge.stories.tsx
+++ b/packages/lab/stories/badge/badge.stories.tsx
@@ -69,7 +69,7 @@ export const ListStory: ComponentStory<typeof Badge> = () => {
       <ListItem>Level 2</ListItem>
       <ListItem>Level 3</ListItem>
       <ListItem>
-        Level 4<Badge value={"NEW"} />{" "}
+        Level 4<Badge value={"NEW"} />
       </ListItem>
     </List>
   );

--- a/site/docs/components/badge/accessibility.mdx
+++ b/site/docs/components/badge/accessibility.mdx
@@ -1,0 +1,13 @@
+---
+# Leave the frontmatter as is
+title:
+  $ref: ./#/title
+layout: DetailComponent
+sidebar:
+  label: Accessibility
+data:
+  $ref: ./#/data
+---
+
+- If custom colors are used, consider the minimum contrast guidance outlined in WCAG 2.1 documentation. The document recommends that the visual presentation of text and images of text has a contrast ratio of at least 4.5:1.
+- We recommend only using the accent color for Badge. But for overrides, you should consider accessibility where possible.

--- a/site/docs/components/badge/examples.mdx
+++ b/site/docs/components/badge/examples.mdx
@@ -1,0 +1,38 @@
+---
+# Leave the frontmatter as is
+title:
+  $ref: ./#/title
+layout: DetailComponent
+sidebar:
+  label: Examples
+data:
+  $ref: ./#/data
+---
+
+<LivePreviewControls>
+
+<LivePreview componentName="component-name" exampleName="ComponentExample" title="Icon badge">
+
+Badge is positioned in the top right corner when placed on a child component, for example with Icon.
+
+</LivePreview>
+
+<LivePreview componentName="component-name" exampleName="ComponentExample" title="Words Badge">
+
+</LivePreview>
+
+<LivePreview componentName="component-name" exampleName="ComponentExample" title="Badge with maximum number">
+
+Specify the maximum number to be displayed with `max`. If `value` exceeds `max`, suffix `+` will be appended.
+
+</LivePreview>
+
+<LivePreview componentName="component-name" exampleName="ComponentExample" title="Badge with string">
+
+`value` can accept both number and string.
+
+</LivePreview>
+
+{/* Add more <LivePreview>...</LivePreview> blocks here as needed */}
+
+</LivePreviewControls>

--- a/site/docs/components/badge/index.mdx
+++ b/site/docs/components/badge/index.mdx
@@ -1,0 +1,26 @@
+---
+title: Badge
+data:
+  description: A Badge is a numeric annotation that indicates the number of outstanding items that need to be addressed. It can appear in the top right of an element (usually an icon) or inline next to an element. For numerical characters the badge will truncate after 3 digits. For strings there is no inbuilt truncation but it is advised to not exceed 4 characters. Badge is used to reflect a change of state and should therefore be used in conjunction with integrative components e.g Button and List
+
+  # Fill in the info from the content template's "Metadata" table below.
+  # To omit optional items, comment them out with #
+  sourceCodeUrl: "https://github.com/jpmorganchase/salt-ds/tree/main/packages/core/src/badge/"
+  package:
+    name: "@salt-ds/core"
+  alsoKnownAs: []
+  relatedComponents: [
+      # Add a { name: "...", relationship: "..." } block for each
+      # related component here (separated by commas).
+      # Permitted values for relationship are: "similarTo" or
+      # "contains".
+      { name: "Tag", relationship: "similarTo" },
+      { name: "Pill", relationship: "similarTo" },
+    ]
+  # stickerSheet: "https://figma.com/..."
+
+# Leave this as is
+layout: DetailComponent
+---
+
+{/* This area stays blank */}

--- a/site/docs/components/badge/usage.mdx
+++ b/site/docs/components/badge/usage.mdx
@@ -34,5 +34,5 @@ import { Badge } from "@salt-ds/core";
 
 ### Content
 
-- If a numeric annotation exceeds the max value passed as a prop, a plus (+) sign will be displayed after the max value stated. In the case that no max value is passed to the component, the value will truncate after 3 digits and therefore display 999+ for any values over 999.
-- For strings there is no inbuilt truncation but it is advised to not exceed 4 characters.
+- If a numeric annotation exceeds the max value passed as a prop, a plus (+) sign will be displayed after the max value stated. In the case that no max value is passed to the component, the value will truncate after three digits and therefore display 999+ for any values over 999.
+- For strings there is no inbuilt truncation but it is advised to not exceed four characters.

--- a/site/docs/components/badge/usage.mdx
+++ b/site/docs/components/badge/usage.mdx
@@ -1,0 +1,38 @@
+---
+# Leave the frontmatter as is
+title:
+  $ref: ./#/title
+layout: DetailComponent
+sidebar:
+  label: Usage
+data:
+  $ref: ./#/data
+---
+
+### Using the Badge component
+
+#### When not to use Component Name
+
+- Badge must not indicate status through color, such as red-amber-green or progress. Instead, use the Pill component.
+- Don’t allow users to edit the contents of Badge. To accept user input, consider using an interactive Pill.
+
+### Import
+
+{/* Update the text and code snippet below as needed: */}
+
+To import Badge from the core Salt package, use:
+
+```js
+import { Badge } from "@salt-ds/core";
+```
+
+### Props
+
+{/* TODO: Update this to grab from core package when component is released */}
+
+<PropsTable packageName="labs" componentName="Badge" />
+
+### Content
+
+- If a numeric annotation exceeds the max value passed as a prop, a plus (+) sign will be displayed after the max value stated. In the case that no max value is passed to the component, the value will truncate after 3 digits and therefore display 999+ for any values over 999.
+- For strings there is no inbuilt truncation but it is advised to not exceed 4 characters.


### PR DESCRIPTION
Adds the Badge component docs from the completed Word template to the site

### Notes for reviewers:

* You can preview this page here: https://saltdesignsystem-git-add-badge-docs-joshwooding.vercel.app/salt/components/badge/usage
* This PR only converts the text content from Word to MDX. The content has already been reviewed in Word, so you just need to focus your review on whether or not it's been added to the site correctly.
* The example code still needs to be migrated out of Storybook, so you will just see a dummy example on the page for now (but the titles & descriptions for each example should already be correct)
* The props table will appear empty because it's expecting to find the code in the `core` package, but this component is still in `labs`. I figured it's better to do it this way around rather than setting it to `labs` now and risking forgetting to update that before this page goes live to consumers. (I did test it with labs though and the props appears correctly, so this _will_ work when the time comes)
* I'm aware that the Accessibility tab needs some spacing between the tabs and the text. However, this is a bug in the page styling and nothing to do with this component's content. I'll therefore address that in a separate PR