### PR TITLE
Adds Stepped Tracker component docs to site

### DIFF
--- a/site/docs/components/stepped-tracker/accessibility.mdx
+++ b/site/docs/components/stepped-tracker/accessibility.mdx
@@ -1,0 +1,12 @@
+---
+# Leave the frontmatter as is
+title:
+  $ref: ./#/title
+layout: DetailComponent
+sidebar:
+  label: Accessibility
+data:
+  $ref: ./#/data
+---
+
+The SteppedTracker uses `aria-step` to indicate which is the current active step.

--- a/site/docs/components/stepped-tracker/examples.mdx
+++ b/site/docs/components/stepped-tracker/examples.mdx
@@ -1,0 +1,34 @@
+---
+# Leave the frontmatter as is
+title:
+  $ref: ./#/title
+layout: DetailComponent
+sidebar:
+  label: Examples
+data:
+  $ref: ./#/data
+---
+
+<LivePreviewControls>
+
+<LivePreview componentName="component-name" exampleName="ComponentExample" title="Basic Features">
+
+The SteppedTracker contains multiple TrackerStep child components. Each TrackerStep indicates its status through its icon. The connectors indicate current active step progress through the process. You should add a label to the TrackerStep using the StepLabel component as follows:
+
+</LivePreview>
+
+<LivePreview componentName="component-name" exampleName="ComponentExample" title="Step Progression">
+
+In normal circumstances, once a step is completed you should both advance the active step, and change the status of the current active step in unison.
+
+</LivePreview>
+
+<LivePreview componentName="component-name" exampleName="ComponentExample" title="Auto Progression">
+
+It may however be appropriate to control the state of steps, and the active step independently if users are able to revisit previous steps or complete step non-sequentially.
+
+</LivePreview>
+
+{/* Add more <LivePreview>...</LivePreview> blocks here as needed */}
+
+</LivePreviewControls>

--- a/site/docs/components/stepped-tracker/index.mdx
+++ b/site/docs/components/stepped-tracker/index.mdx
@@ -1,0 +1,19 @@
+---
+title: Stepped Tracker
+data:
+  description: The Stepped Tracker visually communicates a user’s progress through a linear process. It gives the user context about where they are in the process, as well as an indication of remaining steps and the state of all steps.
+
+  # Fill in the info from the content template's "Metadata" table below.
+  # To omit optional items, comment them out with #
+  sourceCodeUrl: "https://github.com/jpmorganchase/salt-ds/tree/main/packages/core/src/stepped-tracker"
+  package:
+    name: "@salt-ds/core"
+  alsoKnownAs: ["Stepper", "Steps"]
+  relatedComponents: []
+  # stickerSheet: "https://figma.com/..."
+
+# Leave this as is
+layout: DetailComponent
+---
+
+{/* This area stays blank */}

--- a/site/docs/components/stepped-tracker/usage.mdx
+++ b/site/docs/components/stepped-tracker/usage.mdx
@@ -26,7 +26,7 @@ data:
 
 To import Component Name from the core Salt package, use:
 
-```
+```js
 import { SteppedTracker, TrackerStep, StepLabel } from "@salt-ds/core";
 ```
 

--- a/site/docs/components/stepped-tracker/usage.mdx
+++ b/site/docs/components/stepped-tracker/usage.mdx
@@ -1,0 +1,53 @@
+---
+# Leave the frontmatter as is
+title:
+  $ref: ./#/title
+layout: DetailComponent
+sidebar:
+  label: Usage
+data:
+  $ref: ./#/data
+---
+
+### Using the Component Name component
+
+#### When to use Stepped Tracker
+
+- There are multiple steps within a process, such as a wizard or a multi-step form.
+- Where a process can be broken into bite-sized sections that are less daunting than lengthy forms.
+
+#### When not to use Stepped Tracker
+
+- There are less than three sequential steps in a process\
+
+### Import
+
+{/* Update the text and code snippet below as needed: */}
+
+To import Component Name from the core Salt package, use:
+
+```
+import { SteppedTracker, TrackerStep, StepLabel } from "@salt-ds/core";
+```
+
+### Props
+
+{/* Update packageName and componentName below as needed */}
+{/* packageName is optional and defaults to "core" if omitted */}
+
+#### SteppedTracker
+
+<PropsTable packageName="core" componentName="SteppedTracker" />
+
+#### TrackerStep
+
+<PropsTable packageName="core" componentName="TrackerStep" />
+
+#### StepLabel
+
+<PropsTable packageName="core" componentName="StepLabel" />
+
+### Content
+
+- Labels should be one to two words only for easy scanning
+- Message help text should be short and concise

--- a/site/docs/components/stepped-tracker/usage.mdx
+++ b/site/docs/components/stepped-tracker/usage.mdx
@@ -24,7 +24,7 @@ data:
 
 {/* Update the text and code snippet below as needed: */}
 
-To import Component Name from the core Salt package, use:
+To import the Stepped Tracker components from the core Salt package, use:
 
 ```js
 import { SteppedTracker, TrackerStep, StepLabel } from "@salt-ds/core";

--- a/site/docs/components/stepped-tracker/usage.mdx
+++ b/site/docs/components/stepped-tracker/usage.mdx
@@ -18,7 +18,7 @@ data:
 
 #### When not to use Stepped Tracker
 
-- There are less than three sequential steps in a process\
+- There are less than three sequential steps in a process
 
 ### Import
 

--- a/site/docs/components/stepped-tracker/usage.mdx
+++ b/site/docs/components/stepped-tracker/usage.mdx
@@ -9,7 +9,7 @@ data:
   $ref: ./#/data
 ---
 
-### Using the Component Name component
+### Using the Stepped Tracker component
 
 #### When to use Stepped Tracker
 


### PR DESCRIPTION
Adds the Stepped Tracker component docs from the completed Word template to the site

### Notes for reviewers:

* You can preview this page here: https://saltdesignsystem-git-add-stepped-tracker-docs-joshwooding.vercel.app/salt/components/stepped-tracker/usage
* This PR only converts the text content from Word to MDX. The content has already been reviewed in Word, so you just need to focus your review on whether or not it's been added to the site correctly.
* The example code still needs to be migrated out of Storybook, so you will just see a dummy example on the page for now (but the titles & descriptions for each example should already be correct)
* The props table will appear empty because it's expecting to find the code in the `core` package, but this component is still in `labs`. I figured it's better to do it this way around rather than setting it to `labs` now and risking forgetting to update that before this page goes live to consumers. (I did test it with labs though and the props appears correctly, so this _will_ work when the time comes)
* I'm aware that the Accessibility tab needs some spacing between the tabs and the text. However, this is a bug in the page styling and nothing to do with this component's content. I'll therefore address that in a separate PR