### PR TITLE
Adds Drawer component docs

### DIFF
--- a/site/docs/components/drawer/accessibility.mdx
+++ b/site/docs/components/drawer/accessibility.mdx
@@ -1,0 +1,12 @@
+---
+# Leave the frontmatter as is
+title:
+  $ref: ./#/title
+layout: DetailComponent
+sidebar:
+  label: Accessibility
+data:
+  $ref: ./#/data
+---
+
+You can customize or disable the animations using the `prefers-reduced-motion` CSS media feature.

--- a/site/docs/components/drawer/examples.mdx
+++ b/site/docs/components/drawer/examples.mdx
@@ -1,0 +1,22 @@
+---
+# Leave the frontmatter as is
+title:
+  $ref: ./#/title
+layout: DetailComponent
+sidebar:
+  label: Examples
+data:
+  $ref: ./#/data
+---
+
+<LivePreviewControls>
+
+<LivePreview componentName="component-name" exampleName="ComponentExample" title="Component Example Title">
+
+Drawer examples to be added
+
+</LivePreview>
+
+{/* Add more <LivePreview>...</LivePreview> blocks here as needed */}
+
+</LivePreviewControls>

--- a/site/docs/components/drawer/index.mdx
+++ b/site/docs/components/drawer/index.mdx
@@ -1,0 +1,29 @@
+---
+title: Drawer
+data:
+  description: "A Drawer is an expandable panel that users can open and close with a sliding animation.
+
+Use this component to display content as an overlay or embedded within the application layout. With Drawer, the user can view additional content without navigating away from the current screen."
+
+  # Fill in the info from the content template's "Metadata" table below.
+  # To omit optional items, comment them out with #
+  sourceCodeUrl: "https://github.com/jpmorganchase/salt-ds/tree/main/packages/core/src/drawer"
+  package:
+    name: "@salt-ds/core"
+  alsoKnownAs: ["Sidebar"]
+  relatedComponents: [
+      # Add a { name: "...", relationship: "..." } block for each
+      # related component here (separated by commas).
+      # Permitted values for relationship are: "similarTo" or
+      # "contains".
+      { name: "Dialog", relationship: "similarTo" },
+      { name: "Scrim", relationship: "similarTo" },
+      { name: "Scrim", relationship: "contains" },
+    ]
+  # stickerSheet: "https://figma.com/..."
+
+# Leave this as is
+layout: DetailComponent
+---
+
+{/* This area stays blank */}

--- a/site/docs/components/drawer/usage.mdx
+++ b/site/docs/components/drawer/usage.mdx
@@ -1,0 +1,49 @@
+---
+# Leave the frontmatter as is
+title:
+  $ref: ./#/title
+layout: DetailComponent
+sidebar:
+  label: Usage
+data:
+  $ref: ./#/data
+---
+
+### Using the Component Name component
+
+Use this component by wrapping it around your content and setting the desired position. For example:
+
+```jsx
+<Drawer isOpen={open} position="right">
+  <DrawerContentExample />
+</Drawer>
+```
+
+Provide a component like a Button so that users can open and close the Drawer.
+
+The Drawer displays a visual overlay, also known as a scrim, over the existing content. It also plays relevant animations when opening and closing. You can disable all of these visuals via props.
+
+#### When to use Drawer
+
+Use Drawer when you need additional content, such as a form or sidebar navigation, to be displayed in a specific area of the screen.
+
+#### When not to use Component Name
+
+If you want your content split between pages or tabs, consider Deck Layout instead.
+
+### Import
+
+{/* Update the text and code snippet below as needed: */}
+
+To import Component Name from the core Salt package, use:
+
+```js
+import { Drawer } from "@salt-ds/core";
+```
+
+### Props
+
+{/* Update packageName and componentName below as needed */}
+{/* packageName is optional and defaults to "core" if omitted */}
+
+<PropsTable packageName="core" componentName="Drawer" />

--- a/site/docs/components/drawer/usage.mdx
+++ b/site/docs/components/drawer/usage.mdx
@@ -14,7 +14,7 @@ data:
 Use this component by wrapping it around your content and setting the desired position. For example:
 
 ```jsx
-<Drawer isOpen={open} position="right">
+<Drawer isOpen position="right">
   Your drawer's contents...
 </Drawer>
 ```

--- a/site/docs/components/drawer/usage.mdx
+++ b/site/docs/components/drawer/usage.mdx
@@ -35,7 +35,7 @@ If you want your content split between pages or tabs, consider Deck Layout inste
 
 {/* Update the text and code snippet below as needed: */}
 
-To import Component Name from the core Salt package, use:
+To import Drawer from the core Salt package, use:
 
 ```js
 import { Drawer } from "@salt-ds/core";

--- a/site/docs/components/drawer/usage.mdx
+++ b/site/docs/components/drawer/usage.mdx
@@ -15,7 +15,7 @@ Use this component by wrapping it around your content and setting the desired po
 
 ```jsx
 <Drawer isOpen={open} position="right">
-  <DrawerContentExample />
+  Your drawer's contents...
 </Drawer>
 ```
 

--- a/site/docs/components/drawer/usage.mdx
+++ b/site/docs/components/drawer/usage.mdx
@@ -9,7 +9,7 @@ data:
   $ref: ./#/data
 ---
 
-### Using the Component Name component
+### Using the Drawer component
 
 Use this component by wrapping it around your content and setting the desired position. For example:
 

--- a/site/docs/components/drawer/usage.mdx
+++ b/site/docs/components/drawer/usage.mdx
@@ -27,7 +27,7 @@ The Drawer displays a visual overlay, also known as a scrim, over the existing c
 
 Use Drawer when you need additional content, such as a form or sidebar navigation, to be displayed in a specific area of the screen.
 
-#### When not to use Component Name
+#### When not to use Drawer
 
 If you want your content split between pages or tabs, consider Deck Layout instead.
 


### PR DESCRIPTION
Adds the Badge component docs from the completed Word template to the site

### Notes for reviewers:

* You can preview this page here: https://saltdesignsystem-git-add-drawer-docs-joshwooding.vercel.app/salt/components/drawer/
* This PR only converts the text content from Word to MDX. The content has already been reviewed in Word, so you just need to focus your review on whether or not it's been added to the site correctly.
* The example code still needs to be migrated out of Storybook, so you will just see a dummy example on the page for now (but the titles & descriptions for each example should already be correct)
* The props table will appear empty because it's expecting to find the code in the `core` package, but this component is still in `labs`. I figured it's better to do it this way around rather than setting it to `labs` now and risking forgetting to update that before this page goes live to consumers. (I did test it with labs though and the props appears correctly, so this _will_ work when the time comes)
* I'm aware that the Accessibility tab needs some spacing between the tabs and the text. However, this is a bug in the page styling and nothing to do with this component's content. I'll therefore address that in a separate PR