### PR TITLE
ListNext fix keyboard nav and expose hook setters

### DIFF
--- a/.changeset/rich-horses-tie.md
+++ b/.changeset/rich-horses-tie.md
@@ -1,0 +1,6 @@
+---
+"@salt-ds/lab": minor
+---
+
+- Fixed tab in `ListNext` keyboard navigation
+- Exposed `setSelectedItem` and `setHighlightedItem` from useList.

--- a/packages/lab/src/list-next/ListNext.tsx
+++ b/packages/lab/src/list-next/ListNext.tsx
@@ -30,7 +30,7 @@ export interface ListNextProps
   /* Value for the controlled version. */
   selected?: string;
   /* Callback for change event. */
-  onChange?: (e: SyntheticEvent, data: { value: string }) => void;
+  onChange?: (event: SyntheticEvent, data: { value: string }) => void;
   /* Initial selection. */
   defaultSelected?: string;
 }

--- a/packages/lab/src/list-next/useList.ts
+++ b/packages/lab/src/list-next/useList.ts
@@ -238,7 +238,7 @@ export const useList = ({
   };
 
   // takes care of keydown when using keyboard navigation
-  const keyDownHandler = (event: KeyboardEvent<HTMLUListElement>) => {
+  const keyDownHandler = (event: KeyboardEvent<HTMLElement>) => {
     const { key } = event;
     const currentItem = getActiveItem();
     let nextItem = currentItem;
@@ -278,6 +278,8 @@ export const useList = ({
           onChange?.(event, { value: nextItem.dataset.value || "" });
         }
         break;
+      case "Tab":
+        break;
       case "PageDown":
       case "PageUp":
       default:
@@ -308,6 +310,8 @@ export const useList = ({
     activeDescendant,
     selectedItem,
     highlightedItem,
+    setSelectedItem,
+    setHighlightedItem,
     contextValue,
     focusVisibleRef,
   };

--- a/packages/lab/src/list-next/useList.ts
+++ b/packages/lab/src/list-next/useList.ts
@@ -278,12 +278,11 @@ export const useList = ({
           onChange?.(event, { value: nextItem.dataset.value || "" });
         }
         break;
-      case "Tab":
-        break;
       case "PageDown":
       case "PageUp":
-      default:
         event.preventDefault();
+        break;
+      default:
         break;
     }
   };

--- a/packages/lab/stories/list-next/list.stories.tsx
+++ b/packages/lab/stories/list-next/list.stories.tsx
@@ -83,11 +83,11 @@ export const Controlled: Story<ListNextProps> = ({ onChange, ...rest }) => {
 
   const handleClick = (index: number) => {
     setSelectedItem(usStateExampleData[index]);
-    setHighlightedIndex(index);
   };
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const inputValue = event.target.value.toLowerCase();
+    setSelectedItem(inputValue);
     const firstMatchingItem =
       inputValue.length - 1 >= 0
         ? usStateExampleData.findIndex((item) =>


### PR DESCRIPTION
In this PR: 

- The previous change in useList meant that any key not purposefully declared in the hook would be prevented to do it's default, which meant `Tab` had to be explicitly declared.
- exposing `setSelectedItem` and `setHighlightedItem` for controlled usage.
- since `keydownHandler` is not guaranteed to be in a list when controlled, changed type
- The hook is setting highlighted when selected, so the example doesn't need to do it anymore.
- setting selectedItem on input change in the example so deleting from the input deletes the selection. 