### PR TITLE
Add supported platform docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,10 +31,6 @@ storybook-static
 
 # misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
 .eslintcache
 
 npm-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # IDEs
-.idea/*
-!.idea/runConfigurations
+.idea
 .vscode/launch.json
 /.VSCodeCounter
 *.iml

--- a/site/.env.local
+++ b/site/.env.local
@@ -1,0 +1,2 @@
+MOSAIC_ACTIVE_MODE_URL=http://localhost:8080
+MOSAIC_MODE=active

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -3,7 +3,6 @@
 
 # Misc
 .DS_Store
-.env.local
 
 # Generated files
 /.tmp/

--- a/site/docs/about/supported-platforms.mdx
+++ b/site/docs/about/supported-platforms.mdx
@@ -15,7 +15,7 @@ Dependent on the minimum supported browsers of your application, you may need to
 
 ## React
 
-Salt supports the most recent, stable versions of React, as a minimum we support 16.0.0 but recommend the newest version that you application will support.
+Salt supports the most recent, stable versions of React, as a minimum we support 16.14.0 but recommend the newest version that your application will support.
 
 ## Server Side Rendering (SSR)
 

--- a/site/docs/getting-started/supported-platforms.mdx
+++ b/site/docs/getting-started/supported-platforms.mdx
@@ -1,0 +1,22 @@
+---
+title: Supported Platforms
+layout: DetailTechnical
+---
+
+Salt supports the latest, stable releases of all major browsers and platforms.  
+
+## Browser
+
+Dependent on the minimum supported browsers of your application, you may need to provide your own polyfills.
+
+| Chrome | Firefox  | Edge    | Safari (macOS) | Safari (iOS) | IE                |
+| ------ | -------- | ------- | -------------- | ------------ | ----------------- |
+| >= 86  |  >= 86   |  >= 85  |  >= 15.4       | >= 15.4      | Un-supported / 11 |
+
+## React
+
+Salt supports the most recent, stable versions of React, as a minimum we support 16.0.0 but recommend the newest version that you application will support. 
+
+## Server Side Rendering (SSR)
+
+Salt supports SSR, we recommend the Long Term Support (LTS) version of [Node.js](https://nodejs.org/en).

--- a/site/docs/getting-started/supported-platforms.mdx
+++ b/site/docs/getting-started/supported-platforms.mdx
@@ -3,19 +3,19 @@ title: Supported Platforms
 layout: DetailTechnical
 ---
 
-Salt supports the latest, stable releases of all major browsers and platforms.  
+Salt supports the latest, stable releases of all major browsers and platforms.
 
 ## Browser
 
 Dependent on the minimum supported browsers of your application, you may need to provide your own polyfills.
 
-| Chrome | Firefox  | Edge    | Safari (macOS) | Safari (iOS) | IE                |
-| ------ | -------- | ------- | -------------- | ------------ | ----------------- |
-| >= 86  |  >= 86   |  >= 85  |  >= 15.4       | >= 15.4      | Un-supported / 11 |
+| Chrome | Firefox | Edge  | Safari (macOS) | Safari (iOS) | IE                |
+| ------ | ------- | ----- | -------------- | ------------ | ----------------- |
+| >= 86  | >= 86   | >= 85 | >= 15.4        | >= 15.4      | Un-supported / 11 |
 
 ## React
 
-Salt supports the most recent, stable versions of React, as a minimum we support 16.0.0 but recommend the newest version that you application will support. 
+Salt supports the most recent, stable versions of React, as a minimum we support 16.0.0 but recommend the newest version that you application will support.
 
 ## Server Side Rendering (SSR)
 


### PR DESCRIPTION
Added a page which describes the `Supported Platforms`, this page can be used to describe browser and platform versions.
Initially just a placeholder to align us all on the minimum browser versions.

Whilst creating this page, noticed that `active` mode was not supported by the site, so you had to change the snapshots to edit a page. With the `.env.local` file, you can not edit the page sources, locally and refresh the browser.

Also, noticed the IntelliJ (.idea) files were not ignored correctly