### PR TITLE
Fix Linear Progress's bar not animating to the beginning on reset

### DIFF
--- a/.changeset/dull-goats-vanish.md
+++ b/.changeset/dull-goats-vanish.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/lab": patch
+---
+
+Fixed Linear Progress to keep bar visible at 0 for animation

--- a/.changeset/dull-goats-vanish.md
+++ b/.changeset/dull-goats-vanish.md
@@ -2,4 +2,4 @@
 "@salt-ds/lab": patch
 ---
 
-Fixed Linear Progress to keep bar visible at 0 for animation
+Fixed Linear Progress's bar not animating to the beginning on reset

--- a/packages/lab/src/progress/LinearProgress/LinearProgress.css
+++ b/packages/lab/src/progress/LinearProgress/LinearProgress.css
@@ -9,7 +9,7 @@
 .saltLinearProgress-barContainer {
   background: none;
   position: relative;
-  width: calc(100% - 10px);
+  width: 100%;
   overflow: hidden;
   height: var(--salt-size-adornment);
 }

--- a/packages/lab/src/progress/LinearProgress/LinearProgress.tsx
+++ b/packages/lab/src/progress/LinearProgress/LinearProgress.tsx
@@ -82,9 +82,7 @@ export const LinearProgress = forwardRef<HTMLDivElement, LinearProgressProps>(
         {...rest}
       >
         <div className={withBaseName("barContainer")}>
-          {progress !== 0 && (
-            <div className={withBaseName("bar")} style={barStyle} />
-          )}
+          <div className={withBaseName("bar")} style={barStyle} />
           <div className={withBaseName("track")} style={trackStyle} />
         </div>
         {progressInfo}

--- a/packages/lab/stories/progress/circular-progress.stories.tsx
+++ b/packages/lab/stories/progress/circular-progress.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import { Button, FlowLayout, Panel } from "@salt-ds/core";
+import { Button, FlowLayout, StackLayout } from "@salt-ds/core";
 import { CircularProgress, LinearProgress } from "@salt-ds/lab";
 import { useProgressingValue } from "./useProgressingValue";
 
@@ -40,10 +40,10 @@ export const Default: ComponentStory<typeof CircularProgress> = () => (
 );
 
 export const MaxValue: ComponentStory<typeof CircularProgress> = () => (
-  <div>
+  <StackLayout align="center">
     <h3> max = 500, value = 250</h3>
     <CircularProgress aria-label="Download" value={250} max={500} />
-  </div>
+  </StackLayout>
 );
 
 export const ProgressingValue: ComponentStory<typeof CircularProgress> = () => (

--- a/packages/lab/stories/progress/linear-progress.stories.tsx
+++ b/packages/lab/stories/progress/linear-progress.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import { Button, FlowLayout, Panel } from "@salt-ds/core";
+import { Button, FlowLayout, StackLayout } from "@salt-ds/core";
 import { CircularProgress, LinearProgress } from "@salt-ds/lab";
 import { useProgressingValue } from "./useProgressingValue";
 
@@ -43,11 +43,11 @@ export const ProgressingValue: ComponentStory<typeof LinearProgress> = () => (
   <ProgressWithControls ProgressComponent={LinearProgress} />
 );
 
-export const MaxValue: ComponentStory<typeof CircularProgress> = () => (
-  <div>
-    <h3> max = 500, value = 250</h3>
+export const MaxValue: ComponentStory<typeof LinearProgress> = () => (
+  <StackLayout>
+    <h3 style={{ textAlign: "center" }}> max = 500, value = 250</h3>
     <LinearProgress aria-label="Download" value={250} max={500} />
-  </div>
+  </StackLayout>
 );
 
 export const ShowNoInfo: ComponentStory<typeof LinearProgress> = () => (


### PR DESCRIPTION
Fix to stop the progress bar from disappearing on reset (instead of animating back to the start)