### PR TITLE
Fix misc component page issues

### DIFF
--- a/site/docs/components/button/examples.mdx
+++ b/site/docs/components/button/examples.mdx
@@ -10,11 +10,15 @@ data:
 <LivePreviewControls>
 <LivePreview componentName="button" exampleName="CTA" >
 
+### CTA
+
 Use the CTA button for high priority actions.
 
 </LivePreview>
 
 <LivePreview componentName="button" exampleName="Primary" >
+
+### Primary
 
 Use the primary button for routine, non-urgent actions.
 
@@ -22,23 +26,31 @@ Use the primary button for routine, non-urgent actions.
 
 <LivePreview componentName="button" exampleName="Secondary" >
 
+### Secondary
+
 Use the secondary button for non-critical actions that support the user but do not impact a flow.
 
 </LivePreview>
 
-<LivePreview componentName="button" exampleName="IconAndLabel" >
+<LivePreview componentName="button" exampleName="IconAndLabel" title="Icon and label">
+
+### Icon and label
 
 Add an icon before the text to reinforce the button label, or add an icon after the button label to suggest movement or a direction.
 
 </LivePreview>
 
-<LivePreview componentName="button" exampleName="IconOnly" >
+<LivePreview componentName="button" exampleName="IconOnly" title="Icon only">
+
+### Icon only
 
 Display an icon-only button with no label when you have limited on-screen space and the icon is globally understood.
 
 </LivePreview>
 
 <LivePreview componentName="button" exampleName="Disabled" >
+
+### Disabled
 
 Indicates a button that the user can’t interact with.
 

--- a/site/docs/components/button/usage.mdx
+++ b/site/docs/components/button/usage.mdx
@@ -19,7 +19,7 @@ data:
 
 To import Button from the core Salt package, use:
 
-```
+```js
 import { Button } from "@salt-ds/core";
 ```
 

--- a/site/src/components/components/ExamplesListView.tsx
+++ b/site/src/components/components/ExamplesListView.tsx
@@ -6,7 +6,6 @@ import {
   Dropdown,
 } from "@salt-ds/lab";
 import useIsMobileView from "../../utils/useIsMobileView";
-import { Heading3 } from "../mdx/h3";
 import { formatComponentExampleName } from "./formatComponentExampleName";
 
 import styles from "./ExamplesListView.module.css";
@@ -15,7 +14,7 @@ type ExamplesListViewProps = { examples: ReactElement[] };
 
 const ExamplesListView: FC<ExamplesListViewProps> = ({ examples }) => {
   const examplesList: string[] = Children.map(examples, ({ props }) =>
-    props.title ? props.title : props.exampleName
+    formatComponentExampleName(props.exampleName, props.title)
   );
 
   const [selectedItem, setSelectedItem] = useState<string | null>(
@@ -31,22 +30,23 @@ const ExamplesListView: FC<ExamplesListViewProps> = ({ examples }) => {
   const examplesArray = Children.toArray(examples) as ReactElement[];
 
   const selectedExample: ReactElement =
-    examplesArray.find(({ props }) => props.exampleName === selectedItem) ||
-    examplesArray[0];
+    examplesArray.find(
+      ({ props }) =>
+        formatComponentExampleName(props.exampleName, props.title) ===
+        selectedItem
+    ) || examplesArray[0];
 
   const {
-    props: { children: exampleCopy, title, exampleName, ...restProps },
+    props: { children: exampleCopy, ...restProps },
     ...rest
   } = selectedExample;
 
   const list = isMobileView ? (
     <FormField label="Select an example">
       <Dropdown
-        defaultSelected={examplesList[0]}
         source={examplesList}
         selected={selectedItem}
         onSelectionChange={handleSelect}
-        itemToString={(item) => formatComponentExampleName(item)}
       />
     </FormField>
   ) : (
@@ -60,23 +60,18 @@ const ExamplesListView: FC<ExamplesListViewProps> = ({ examples }) => {
         source={examplesList}
         onSelect={handleSelect}
         selected={selectedItem}
-        defaultSelected={examplesList[0]}
-        itemToString={(item) => formatComponentExampleName(item)}
       />
     </div>
   );
 
   const componentExample = {
-    props: { list, exampleName, ...restProps },
+    props: { list, ...restProps },
     ...rest,
   };
 
   return (
     <>
       {componentExample}
-      <Heading3>
-        {title ? title : formatComponentExampleName(exampleName)}
-      </Heading3>
       {exampleCopy}
     </>
   );

--- a/site/src/components/components/LivePreview.tsx
+++ b/site/src/components/components/LivePreview.tsx
@@ -4,9 +4,7 @@ import clsx from "clsx";
 import { Switch } from "@salt-ds/lab";
 import { SaltProvider } from "@salt-ds/core";
 import { Pre } from "../mdx/pre";
-import { Heading3 } from "../mdx/h3";
 import { useLivePreviewControls } from "./useLivePreviewControls";
-import { formatComponentExampleName } from "./formatComponentExampleName";
 import useIsMobileView from "../../utils/useIsMobileView";
 
 import styles from "./LivePreview.module.css";
@@ -22,7 +20,6 @@ type LivePreviewProps = {
 export const LivePreview: FC<LivePreviewProps> = ({
   componentName,
   exampleName,
-  title,
   list,
   children,
 }) => {
@@ -46,12 +43,6 @@ export const LivePreview: FC<LivePreviewProps> = ({
 
   return (
     <>
-      {!list && (
-        <Heading3>
-          {title ? title : formatComponentExampleName(exampleName)}
-        </Heading3>
-      )}
-
       {children}
       <div className={styles.container}>
         <div

--- a/site/src/components/components/formatComponentExampleName.ts
+++ b/site/src/components/components/formatComponentExampleName.ts
@@ -1,7 +1,9 @@
 const exampleNameRegex = /[A-Z]?[a-z]+|[0-9]+|[A-Z]+(?![a-z])/g;
 
-export const formatComponentExampleName = (name: string) => {
+export const formatComponentExampleName = (name: string, title?: string) => {
+  if (title) {
+    return title;
+  }
   const formattedName = name.match(exampleNameRegex);
-
   return formattedName ? formattedName.join(" ") : name;
 };

--- a/site/src/components/keyboard-controls/KeyboardControls.module.css
+++ b/site/src/components/keyboard-controls/KeyboardControls.module.css
@@ -1,6 +1,5 @@
 .table {
   table-layout: initial;
-  margin-top: calc(2 * var(--salt-size-unit));
   margin-bottom: calc(2 * var(--salt-size-unit));
 }
 

--- a/site/src/layouts/DetailComponent/DetailComponent.module.css
+++ b/site/src/layouts/DetailComponent/DetailComponent.module.css
@@ -1,0 +1,14 @@
+/*
+  Rendered markdown always seems to be wrapped in
+  <div class="wrapper"><div>...</div></div> (sigh!).
+  So, to select the first item _within_ the actual rendered markdown, we need
+  to use this lenghty selector:
+*/
+.tabPanel > :global(.wrapper) > div > :first-child {
+  /*
+    Ensure there is an appropriate minimum space between the Tabs and the
+    content below, so that if the first thing happens to not be a heading, it
+    doesn't butt up against the Tabs. (3x is the same as H3's margin-top)
+  */
+  margin-top: calc(var(--salt-size-unit) * 3);
+}

--- a/site/src/layouts/DetailComponent/DetailComponent.tsx
+++ b/site/src/layouts/DetailComponent/DetailComponent.tsx
@@ -18,6 +18,7 @@ import TitleWithDrawer from "./TitleWithDrawer";
 import MobileDrawer from "./MobileDrawer";
 import useIsMobileView from "../../utils/useIsMobileView";
 import { AllExamplesViewContext } from "../../utils/useAllExamplesView";
+import styles from "./DetailComponent.module.css";
 
 const tabs = [
   { id: 0, name: "examples", label: "Examples" },
@@ -138,7 +139,7 @@ export const DetailComponent: FC<LayoutProps> = ({ children }) => {
           onActiveChange={updateRouteWhenTabChanges}
         >
           {tabs.map(({ id, label }) => (
-            <TabPanel key={id} label={label}>
+            <TabPanel key={id} label={label} className={styles.tabPanel}>
               {children}
             </TabPanel>
           ))}

--- a/site/src/layouts/DetailComponent/SecondarySidebar.tsx
+++ b/site/src/layouts/DetailComponent/SecondarySidebar.tsx
@@ -7,6 +7,7 @@ import { Data, Relationship } from "./DetailComponent";
 import { useAllExamplesView } from "../../utils/useAllExamplesView";
 
 import styles from "./SecondarySidebar.module.css";
+import { useRoute } from "@jpmorganchase/mosaic-store";
 
 type LinkWithLogoProps = {
   href: string;
@@ -28,6 +29,8 @@ type SecondarySidebarProps = {
   tableOfContents?: ReactNode;
 };
 
+const examplesTabRoute = /\/examples$/;
+
 const SecondarySidebar: FC<SecondarySidebarProps> = ({
   additionalData,
   tableOfContents,
@@ -42,6 +45,7 @@ const SecondarySidebar: FC<SecondarySidebarProps> = ({
     askQuestion,
   } = additionalData || {};
 
+  const { route = "" } = useRoute();
   const { allExamplesView } = useAllExamplesView();
 
   const alsoKnownAsPills = alsoKnownAs && alsoKnownAs.length > 0 && (
@@ -129,9 +133,10 @@ const SecondarySidebar: FC<SecondarySidebarProps> = ({
 
   return (
     <div className={styles.sidebar}>
-      {allExamplesView && tableOfContents && (
-        <div className={styles.tableOfContents}>{tableOfContents}</div>
-      )}
+      {(!examplesTabRoute.test(route) || allExamplesView) &&
+        tableOfContents && (
+          <div className={styles.tableOfContents}>{tableOfContents}</div>
+        )}
       <div className={styles.wrapper}>
         {alsoKnownAsPills}
         {relatedComponentsPills("similarTo", "Similar to")}

--- a/site/src/layouts/DetailComponent/SecondarySidebar.tsx
+++ b/site/src/layouts/DetailComponent/SecondarySidebar.tsx
@@ -44,7 +44,7 @@ const SecondarySidebar: FC<SecondarySidebarProps> = ({
 
   const { allExamplesView } = useAllExamplesView();
 
-  const alsoKnownAsPills = alsoKnownAs && (
+  const alsoKnownAsPills = alsoKnownAs && alsoKnownAs.length > 0 && (
     <>
       <Heading4>Also known as</Heading4>
       <div className={styles.pills}>
@@ -58,19 +58,27 @@ const SecondarySidebar: FC<SecondarySidebarProps> = ({
   const relatedComponentsPills = (
     relationshipName: Relationship,
     heading: string
-  ) =>
-    relatedComponents && (
-      <>
-        <Heading4>{heading}</Heading4>
-        <div className={styles.pills}>
-          {relatedComponents
-            .filter(({ relationship }) => relationship === relationshipName)
-            .map(({ name }) => (
+  ) => {
+    const components =
+      (relatedComponents &&
+        relatedComponents.filter(
+          ({ relationship }) => relationship === relationshipName
+        )) ||
+      [];
+
+    return (
+      components.length > 0 && (
+        <>
+          <Heading4>{heading}</Heading4>
+          <div className={styles.pills}>
+            {components.map(({ name }) => (
               <Pill key={name} label={name} />
             ))}
-        </div>
-      </>
+          </div>
+        </>
+      )
     );
+  };
 
   const componentResourcesList = (
     <>

--- a/templates/component-pages/component-name/examples.mdx
+++ b/templates/component-pages/component-name/examples.mdx
@@ -13,12 +13,17 @@ data:
 
 <LivePreview componentName="component-name" exampleName="ComponentExample" title="Component Example Title">
 
+### Component Example Title
+
 Brief description of this example. The text should be copied from the
 corresponding example in the content template's "Examples" section.
 
-The `title` prop is optional. If you omit it, the `exampleName` will be used
-as a title for this example (with spaces inserted, so "ComponentExample" would
-display as "Component Example").
+The `title` prop's value is used to display the example's name in the list view
+and should therefore match the heading within this section.
+
+If you omit it, the `exampleName` will be displayed in the list for this example
+(with spaces inserted, so "ComponentExample" would display as
+"Component Example").
 
 </LivePreview>
 

--- a/templates/component-pages/component-name/usage.mdx
+++ b/templates/component-pages/component-name/usage.mdx
@@ -20,7 +20,7 @@ template's "How to use" section here.
 
 To import Component Name from the core Salt package, use:
 
-```
+```js
 import { ComponentName } from "@salt-ds/core";
 ```
 


### PR DESCRIPTION
Fixes a bunch of minor issues spotted on the component page layout:

* If content in a tab happens to begin with a paragraph of text (or anything else with no top margin), it butts up against the tabs above. I have added some CSS to add a margin-top to the first content item to avoid that scenario.
* If related/similar components or also known as are empty arrays in the component page frontmatter, the corresponding headings would still appear in the right-hand column. I've now fixed it so that they won't.
* Unless the "All examples" view was enabled, the Usage & A11y tabs would not display a TOC. They now will, regardless of what the setting the Examples tab uses
* A previous change to the `<LiveExample>` component that removed the need to include the example heading in its content, prevented the TOC from working on the examples tab (when "All examples" is enabled). Since there didn't seem to be an easy way to dynamically update the TOC, I've changed it back so that you do again need to include the headings there. That way the MDX parsing picks them up and adds them to Mosaic's store, so that they can be displayed in the TOC
* I've updated the import statement in the template and example to use JS syntax highlighting.