### PR TITLE
Fix form field group left label example

### DIFF
--- a/packages/core/stories/form-field/form-field.stories.tsx
+++ b/packages/core/stories/form-field/form-field.stories.tsx
@@ -647,7 +647,7 @@ export const GroupedWithLabelLeft: ComponentStory<typeof FormField> = (
   props
 ) => {
   const groupedProps: { labelPlacement: FormFieldLabelPlacement } = {
-    labelPlacement: "right",
+    labelPlacement: "left",
   };
 
   return (


### PR DESCRIPTION
Left group was using right alignment