### PR TITLE
Column separator height fix ag-grid theme

### DIFF
--- a/.changeset/new-colts-march.md
+++ b/.changeset/new-colts-march.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/ag-grid-theme": patch
+---
+
+Fixed column separator height and floating filter height

--- a/packages/ag-grid-theme/css/_salt-ag-theme-mixin.scss
+++ b/packages/ag-grid-theme/css/_salt-ag-theme-mixin.scss
@@ -265,9 +265,15 @@
     border: 2px solid transparent;
   }
 
-  .ag-header-cell:after {
-    top: var(--agGrid-separatorGap);
-    bottom: var(--agGrid-separatorGap);
+  .ag-header-container .ag-header-cell:after {
+    height: calc(var(--salt-size-base) - 2 * var(--salt-size-adornment));
+    top: calc(
+      50% - 0.5 * (var(--salt-size-base) - 2 * var(--salt-size-adornment))
+    );
+  }
+
+  .ag-pinned-left-header .ag-header-cell:after {
+    height: 0;
   }
 
   .ag-keyboard-focus .ag-header-cell:focus:after {
@@ -557,5 +563,11 @@
   .ag-header-cell.ag-floating-filter {
     padding-left: 0;
     padding-right: 1px;
+    border-bottom: 0;
+  }
+
+  .ag-header-cell-auto-height .ag-header-cell-text {
+    overflow: auto;
+    white-space: pre-wrap;
   }
 }

--- a/packages/ag-grid-theme/css/salt-ag-theme.scss
+++ b/packages/ag-grid-theme/css/salt-ag-theme.scss
@@ -2,25 +2,21 @@
 
 div[class*="ag-theme-salt-touch"] {
   --agGrid-padding-default: 16px;
-  --agGrid-separatorGap-default: 20px;
   --agGrid-cornerTag-size-default: 14px;
 }
 
 div[class*="ag-theme-salt-low"] {
   --agGrid-padding-default: 12px;
-  --agGrid-separatorGap-default: 16px;
   --agGrid-cornerTag-size-default: 12px;
 }
 
 div[class*="ag-theme-salt-medium"] {
   --agGrid-padding-default: 8px;
-  --agGrid-separatorGap-default: 12px;
   --agGrid-cornerTag-size-default: 10px;
 }
 
 div[class*="ag-theme-salt-high"] {
   --agGrid-padding-default: 8px;
-  --agGrid-separatorGap-default: 8px;
   --agGrid-cornerTag-size-default: 8px;
 }
 
@@ -28,7 +24,6 @@ div[class*="ag-theme-salt-high-compact"] {
   --salt-size-base: 16px;
 
   --agGrid-padding-default: 8px;
-  --agGrid-separatorGap-default: 8px;
   --agGrid-cornerTag-size-default: 8px;
 }
 
@@ -97,11 +92,6 @@ div[class*="ag-theme-salt"] {
   --agGrid-header-fontWeight: var(
     --saltAgGrid-header-fontWeight,
     var(--salt-text-label-fontWeight-strong)
-  );
-
-  --agGrid-separatorGap: var(
-    --saltAgGrid-separatorGap,
-    var(--agGrid-separatorGap-default)
   );
 
   --agGrid-row-background-selected: var(
@@ -305,7 +295,6 @@ $ag-theme-salt-params-high: map-merge(
     row-height: 24px,
     header-height: 24,
     font-size: 11px,
-    header-column-separator-height: 8px,
     cell-horizontal-padding: 4px,
     list-item-height: 24px,
     icon-size: 12px,
@@ -328,7 +317,6 @@ $ag-theme-salt-params-high-compact: map-merge(
     row-height: 20px,
     header-height: 20,
     font-size: 11px,
-    header-column-separator-height: 8px,
     cell-horizontal-padding: 4px,
     list-item-height: 20px,
     icon-size: 12px,
@@ -351,7 +339,6 @@ $ag-theme-salt-params-medium: map-merge(
     row-height: 36px,
     header-height: 36px,
     font-size: 12px,
-    header-column-separator-height: 10px,
     cell-horizontal-padding: 8px,
     list-item-height: 36px,
     icon-size: 12px,
@@ -374,7 +361,6 @@ $ag-theme-salt-params-low: map-merge(
     row-height: 48px,
     header-height: 48,
     font-size: 14px,
-    header-column-separator-height: 10px,
     cell-horizontal-padding: 12px,
     list-item-height: 48px,
     icon-size: 12px,
@@ -397,7 +383,6 @@ $ag-theme-salt-params-touch: map-merge(
     row-height: 60px,
     header-height: 60,
     font-size: 16px,
-    header-column-separator-height: 10px,
     cell-horizontal-padding: 16px,
     list-item-height: 60px,
     icon-size: 12px,

--- a/packages/ag-grid-theme/stories/ag-grid.stories.tsx
+++ b/packages/ag-grid-theme/stories/ag-grid.stories.tsx
@@ -33,4 +33,5 @@ export {
   PinnedRows,
   StatusBar,
   Variants,
+  WrappedHeader,
 } from "./examples";

--- a/packages/ag-grid-theme/stories/dependencies/dataGridExampleColumnsWrap.ts
+++ b/packages/ag-grid-theme/stories/dependencies/dataGridExampleColumnsWrap.ts
@@ -1,45 +1,50 @@
 import { ColDef } from "ag-grid-community";
 
-const dataGridExampleColumns: ColDef[] = [
+const dataGridExampleColumnsWrap: ColDef[] = [
   {
     headerName: "",
     field: "on",
-    width: 70,
+    width: 38,
     checkboxSelection: true,
     headerCheckboxSelection: true,
     pinned: "left",
     suppressMenu: true,
-    resizable: false,
   },
   {
-    headerName: "Name",
+    headerName: "Name of State",
     field: "name",
+    width: 90,
     filterParams: {
       buttons: ["reset", "apply"],
     },
     editable: false,
+    suppressMenu: true,
   },
   {
-    headerName: "Code",
+    headerName: "State code",
     field: "code",
+    width: 80,
   },
   {
-    headerName: "Capital",
+    headerName: "State capital",
     field: "capital",
+    width: 80,
   },
   {
-    headerName: "Population",
+    headerName: "Population at time of data gathering",
     type: "numericColumn",
     field: "population",
     filter: "agNumberColumnFilter",
     editable: true,
     cellClass: ["numeric-cell", "editable-cell"],
+    width: 100,
   },
   {
     headerName: "Date",
     type: "dateColumn",
     field: "date",
     filter: "agDateColumnFilter",
+    width: 80,
   },
 ];
-export default dataGridExampleColumns;
+export default dataGridExampleColumnsWrap;

--- a/packages/ag-grid-theme/stories/examples/WrappedHeader.tsx
+++ b/packages/ag-grid-theme/stories/examples/WrappedHeader.tsx
@@ -1,0 +1,80 @@
+import { ChangeEvent, useEffect, useState } from "react";
+import { AgGridReact, AgGridReactProps } from "ag-grid-react";
+import {
+  StackLayout,
+  FlexItem,
+  FlexLayout,
+  Checkbox,
+  useDensity,
+} from "@salt-ds/core";
+import dataGridExampleColumnsWrap from "../dependencies/dataGridExampleColumnsWrap";
+import dataGridExampleData from "../dependencies/dataGridExampleData";
+import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
+import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
+
+const statusBar = {
+  statusPanels: [
+    {
+      statusPanel: "agTotalRowCountComponent",
+      align: "left",
+    },
+    { statusPanel: "agFilteredRowCountComponent" },
+    { statusPanel: "agSelectedRowCountComponent" },
+    { statusPanel: "agAggregationComponent" },
+  ],
+};
+
+const WrappedHeader = (props: AgGridReactProps) => {
+  const [compact, setCompact] = useState(false);
+  const { switcher, themeName } = useAgGridThemeSwitcher();
+  const { api, agGridProps, containerProps, isGridReady } = useAgGridHelpers(
+    `ag-theme-${themeName}`,
+    compact
+  );
+  const { defaultColDef: propsColDefs, ...restAgGridProps } = agGridProps;
+
+  useEffect(() => {
+    if (isGridReady) {
+      api?.sizeColumnsToFit();
+    }
+  }, [isGridReady]);
+
+  const density = useDensity();
+
+  const handleCompactChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setCompact(event.target.checked);
+  };
+
+  return (
+    <StackLayout gap={4}>
+      <FlexLayout direction="row">
+        {switcher}
+        <FlexItem>
+          <Checkbox
+            checked={compact && density === "high"}
+            label="Compact (for high density only)"
+            onChange={handleCompactChange}
+            disabled={density !== "high"}
+          />
+        </FlexItem>
+      </FlexLayout>
+      <div {...containerProps} style={{ height: "400px", width: "600px" }}>
+        <AgGridReact
+          columnDefs={dataGridExampleColumnsWrap}
+          rowData={dataGridExampleData}
+          statusBar={statusBar}
+          rowSelection="multiple"
+          defaultColDef={{
+            ...propsColDefs,
+            autoHeight: true,
+            autoHeaderHeight: true,
+          }}
+          {...restAgGridProps}
+          {...props}
+        />
+      </div>
+    </StackLayout>
+  );
+};
+
+export default WrappedHeader;

--- a/packages/ag-grid-theme/stories/examples/index.ts
+++ b/packages/ag-grid-theme/stories/examples/index.ts
@@ -21,3 +21,4 @@ export { default as RowGrouping } from "./RowGrouping";
 export { default as RowGroupPanel } from "./RowGroupPanel";
 export { default as StatusBar } from "./StatusBar";
 export { default as Variants } from "./Variants";
+export { default as WrappedHeader } from "./WrappedHeader";


### PR DESCRIPTION
closes #2074 

Also fixes 
- Floating filter height (gap between border and cell height)
- Adds a story for wrapped header text