### PR TITLE
Data Grid Pagination Bug Fix - #2065

### DIFF
--- a/packages/data-grid/src/Grid.tsx
+++ b/packages/data-grid/src/Grid.tsx
@@ -820,7 +820,7 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
         rangeSelection.onKeyboardRangeSelectionEnd();
       }
     },
-    [rangeSelection.onKeyboardRangeSelectionEnd]
+    [rangeSelection]
   );
 
   const editModeKeyHandler = useCallback(
@@ -1151,6 +1151,11 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
       rangeSelection?.selectedCellRange,
     ]
   );
+
+
+  useEffect(() => {
+    setScrollTop(0);
+  }, [rowData]);
 
   useEffect(() => {
     if (onVisibleRowRangeChange) {

--- a/packages/data-grid/src/Grid.tsx
+++ b/packages/data-grid/src/Grid.tsx
@@ -820,7 +820,7 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
         rangeSelection.onKeyboardRangeSelectionEnd();
       }
     },
-    [rangeSelection]
+    [rangeSelection.onKeyboardRangeSelectionEnd]
   );
 
   const editModeKeyHandler = useCallback(

--- a/packages/data-grid/src/Grid.tsx
+++ b/packages/data-grid/src/Grid.tsx
@@ -1152,7 +1152,6 @@ export const Grid = function Grid<T>(props: GridProps<T>) {
     ]
   );
 
-
   useEffect(() => {
     setScrollTop(0);
   }, [rowData]);

--- a/packages/data-grid/src/internal/gridHooks.tsx
+++ b/packages/data-grid/src/internal/gridHooks.tsx
@@ -185,11 +185,13 @@ export function useVisibleRowRange(
       return NumberRange.empty;
     }
     const firstRowHeight = rowHeight + 1; // First row has an extra 1px
+
     const start =
       scrollTop > firstRowHeight
         ? 1 + Math.floor((scrollTop - firstRowHeight) / rowHeight)
         : 0;
     let endPos = scrollTop + clientMidHeight;
+
     if (start === 0) {
       endPos -= 1;
     }
@@ -197,6 +199,7 @@ export function useVisibleRowRange(
       rowCount,
       Math.max(start, Math.ceil(endPos / rowHeight))
     );
+
     return new NumberRange(start, end);
   }, [scrollTop, clientMidHeight, rowHeight, rowCount]);
 }


### PR DESCRIPTION
Error: when scrolling to the bottom of a page and then clicking on a page where scroll is not enabled, (e.g a page with a single row), causing error in NumberRange class where start > end.
Fix: Reset scrollTop = 0 when rowData changes, e.g when pagination occurs

Reproduce Error: 
pagination story > scroll to bottom of grid > click page 8 > error
