### PR TITLE
Fix inverted images on Salt site

### DIFF
--- a/site/src/css/utilities/index.css
+++ b/site/src/css/utilities/index.css
@@ -1,1 +1,2 @@
 @import "./spacing.css";
+@import "./patches.css";

--- a/site/src/css/utilities/patches.css
+++ b/site/src/css/utilities/patches.css
@@ -1,6 +1,6 @@
 /* Temporary (hopefully!) patches and work-arounds to override/undo issues from 3rd party CSS */
 
 /* Prevent Mosaic theme from inverting all images */
-.salt-theme[data-mode=dark] main img:not(.no-filter) {
+.salt-theme[data-mode="dark"] main img:not(.no-filter) {
   filter: none;
 }

--- a/site/src/css/utilities/patches.css
+++ b/site/src/css/utilities/patches.css
@@ -1,6 +1,6 @@
 /* Temporary (hopefully!) patches and work-arounds to override/undo issues from 3rd party CSS */
 
 /* Prevent Mosaic theme from inverting all images */
-[data-mode=dark] main img:not(.no-filter) {
+.salt-theme[data-mode=dark] main img:not(.no-filter) {
   filter: none;
 }

--- a/site/src/css/utilities/patches.css
+++ b/site/src/css/utilities/patches.css
@@ -1,0 +1,6 @@
+/* Temporary (hopefully!) patches and work-arounds to override/undo issues from 3rd party CSS */
+
+/* Prevent Mosaic theme from inverting all images */
+[data-mode=dark] main img:not(.no-filter) {
+  filter: none;
+}


### PR DESCRIPTION
Adds a temporary CSS workaround for Mosaic CSS which is inverting images on our site. Once they release a fix, we can remove this again.