### PR TITLE
DropdownNext V1: make readonly dropdown focusable; css updates

### DIFF
--- a/packages/lab/src/__tests__/__e2e__/dropdown-next/DropdownNext.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/dropdown-next/DropdownNext.cy.tsx
@@ -140,11 +140,10 @@ describe("GIVEN a disabled Dropdown component", () => {
 });
 
 describe("GIVEN a readonly Dropdown component", () => {
-  it("THEN it should not show icon and not be focusable", () => {
+  it("THEN it should not show icon and be focusable", () => {
     cy.mount(<Readonly />);
 
-    // not focusable
-    cy.findByRole("combobox").focused().should("not.exist");
+    cy.findByRole("combobox").focus().should("have.focus");
 
     cy.findByRole("combobox")
       .should("have.attr", "aria-expanded", "false")

--- a/packages/lab/src/dropdown-next/DropdownNext.css
+++ b/packages/lab/src/dropdown-next/DropdownNext.css
@@ -46,6 +46,7 @@
 
 .saltDropdownNext-list {
   border-color: var(--salt-selectable-borderColor-selected);
+  box-shadow: var(--salt-overlayable-shadow-popout);
   max-height: calc((var(--salt-size-base) + var(--salt-spacing-100)) * 5);
 }
 
@@ -73,8 +74,8 @@
 
   cursor: var(--salt-editable-cursor-readonly);
   background: var(--dropdownNext-background-readonly);
-  padding-left: 0;
-  outline: 0;
+  /* no padding-right when there's no dropdown button icon */
+  padding-right: 0;
 }
 
 /* Styling applied to dropdown button icon if `disabled={true}` or `readOnly={true}` */

--- a/packages/lab/src/dropdown-next/DropdownNext.tsx
+++ b/packages/lab/src/dropdown-next/DropdownNext.tsx
@@ -155,7 +155,7 @@ export const DropdownNext = forwardRef(function DropdownNext(
   };
 
   const handleFocus = (event: FocusEvent<HTMLButtonElement>) => {
-    if (disabled || readOnly) return;
+    if (disabled) return;
     focusHandler(event);
     onFocus?.(event);
   };
@@ -206,7 +206,7 @@ export const DropdownNext = forwardRef(function DropdownNext(
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-activedescendant={activeDescendant}
-        tabIndex={disabled || readOnly ? -1 : 0}
+        tabIndex={disabled ? -1 : 0}
         aria-owns={listId}
         aria-controls={listId}
         aria-disabled={disabled}

--- a/packages/lab/stories/dropdown-next/dropdown-next.doc.stories.mdx
+++ b/packages/lab/stories/dropdown-next/dropdown-next.doc.stories.mdx
@@ -39,7 +39,7 @@ Tip: See the [Forms pattern](https://www.saltdesignsystem.com/salt/patterns/form
 
 ### Readonly
 
-When `readOnly={true}`, user will not be able to interact with Dropdown, it does not receive focus on any interaction.
+When `readOnly={true}`, user will not be able to interact with Dropdown apart from focusing on it.
 Use when you would like the user to know that the pre-selected value is valid but changes are not permitted.
 
 <Canvas>


### PR DESCRIPTION
closes #2179 
- make readonly dropdown focusable
- add box-shadow to dropdown list
- remove padding-right for readonly dropdown as no dropdown button icon present
- update cypress 