### PR TITLE
Add `--salt-size-indicator` and deprecate some size tokens

### DIFF
--- a/.changeset/chilled-jeans-hear.md
+++ b/.changeset/chilled-jeans-hear.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/theme": minor
+---
+
+Added a new size token: `--salt-size-indicator`

--- a/.changeset/chilly-buttons-agree.md
+++ b/.changeset/chilly-buttons-agree.md
@@ -1,0 +1,19 @@
+---
+"@salt-ds/theme": patch
+---
+
+Deprecated the following size tokens:
+
+| Name                              | Replacement                               |
+| --------------------------------- | ----------------------------------------- |
+| `--salt-size-basis-unit`          | 4px                                       |
+| `--salt-size-adornmentGap`        | `--salt-spacing-75`                       |
+| `--salt-size-container-spacing`   | `--salt-spacing-300`                      |
+| `--salt-size-divider-strokeWidth` | `--salt-size-border`                      |
+| `--salt-size-separator-height`    | `--salt-size-base`                        |
+| `--salt-size-stackable`           | `--salt-size-base` + `--salt-spacing-100` |
+| `--salt-size-unit`                | `--salt-spacing-100`                      |
+| `--salt-size-compact`             | `--salt-size-adornment`                   |
+| `--salt-size-accent`              | `--salt-size-bar`                         |
+| `--salt-size-sharktooth-height`   | 5px                                       |
+| `--salt-size-sharktooth-width`    | 10px                                      |

--- a/packages/theme/css/deprecated/foundations.css
+++ b/packages/theme/css/deprecated/foundations.css
@@ -32,7 +32,41 @@
   --salt-size-divider-strokeWidth: var(--salt-size-separator-strokeWidth);
 
   --salt-size-detail: var(--salt-size-compact);
+  --salt-size-basis-unit: 4px;
+
+  --salt-size-adornmentGap: calc(0.75 * var(--salt-size-unit));
+  --salt-size-container-spacing: calc(3 * var(--salt-size-unit));
+  --salt-size-separator-strokeWidth: 1px;
+  --salt-size-selectable: calc(var(--salt-size-base) - (1.5 * var(--salt-size-unit)) - (0.5 * var(--salt-size-basis-unit)));
+  --salt-size-separator-height: calc(var(--salt-size-compact) + 1.5 * var(--salt-size-basis-unit));
+  --salt-size-sharktooth-height: 5px;
+  --salt-size-sharktooth-width: 10px;
+  --salt-size-stackable: calc(var(--salt-size-base) + var(--salt-size-unit));
 
   /* Z Index */
   --salt-zIndex-docked: 1050;
+}
+
+.salt-density-high {
+  --salt-size-unit: calc(var(--salt-size-basis-unit) * 1);
+  --salt-size-compact: calc(var(--salt-size-basis-unit) * 1.5);
+  --salt-size-accent: calc(var(--salt-size-basis-unit) * 0.5);
+}
+
+.salt-density-medium {
+  --salt-size-unit: calc(var(--salt-size-basis-unit) * 2);
+  --salt-size-compact: calc(var(--salt-size-basis-unit) * 2);
+  --salt-size-accent: calc(var(--salt-size-basis-unit) * 1);
+}
+
+.salt-density-low {
+  --salt-size-unit: calc(var(--salt-size-basis-unit) * 3);
+  --salt-size-compact: calc(var(--salt-size-basis-unit) * 2.5);
+  --salt-size-accent: calc(var(--salt-size-basis-unit) * 1.5);
+}
+
+.salt-density-touch {
+  --salt-size-unit: calc(var(--salt-size-basis-unit) * 4);
+  --salt-size-compact: calc(var(--salt-size-basis-unit) * 3);
+  --salt-size-accent: calc(var(--salt-size-basis-unit) * 2);
 }

--- a/packages/theme/css/foundations/size.css
+++ b/packages/theme/css/foundations/size.css
@@ -1,72 +1,39 @@
-/** Size */
-.salt-density-touch,
-.salt-density-low,
-.salt-density-medium,
 .salt-density-high {
-  --salt-size-basis-unit: 4px;
-
-  --salt-size-adornmentGap: calc(0.75 * var(--salt-size-unit));
-  --salt-size-container-spacing: calc(3 * var(--salt-size-unit));
-  --salt-size-separator-strokeWidth: 1px;
-  --salt-size-selectable: calc(var(--salt-size-base) - (1.5 * var(--salt-size-unit)) - (0.5 * var(--salt-size-basis-unit)));
-  --salt-size-separator-height: calc(var(--salt-size-compact) + 1.5 * var(--salt-size-basis-unit));
-  --salt-size-sharktooth-height: 5px;
-  --salt-size-sharktooth-width: 10px;
-  --salt-size-stackable: calc(var(--salt-size-base) + var(--salt-size-unit));
-}
-
-.salt-density-high {
-  --salt-size-unit: calc(var(--salt-size-basis-unit) * 1);
-  --salt-size-compact: calc(var(--salt-size-basis-unit) * 1.5);
-  --salt-size-accent: calc(var(--salt-size-basis-unit) * 0.5);
-
-  /* New size work */
   --salt-size-adornment: 6px;
   --salt-size-bar: 2px;
   --salt-size-base: 20px;
   --salt-size-border: 1px;
-  --salt-size-selectable: 12px;
   --salt-size-icon: 12px;
+  --salt-size-indicator: 1px;
+  --salt-size-selectable: 12px;
 }
 
 .salt-density-medium {
-  --salt-size-unit: calc(var(--salt-size-basis-unit) * 2);
-  --salt-size-compact: calc(var(--salt-size-basis-unit) * 2);
-  --salt-size-accent: calc(var(--salt-size-basis-unit) * 1);
-
-  /* New size work */
   --salt-size-adornment: 8px;
   --salt-size-bar: 4px;
   --salt-size-base: 28px;
   --salt-size-border: 1px;
-  --salt-size-selectable: 14px;
   --salt-size-icon: 12px;
+  --salt-size-indicator: 2px;
+  --salt-size-selectable: 14px;
 }
 
 .salt-density-low {
-  --salt-size-unit: calc(var(--salt-size-basis-unit) * 3);
-  --salt-size-compact: calc(var(--salt-size-basis-unit) * 2.5);
-  --salt-size-accent: calc(var(--salt-size-basis-unit) * 1.5);
-
-  /* New size work */
   --salt-size-adornment: 10px;
   --salt-size-bar: 6px;
   --salt-size-base: 36px;
   --salt-size-border: 1px;
-  --salt-size-selectable: 16px;
   --salt-size-icon: 14px;
+  --salt-size-indicator: 3px;
+  --salt-size-selectable: 16px;
 }
 
 .salt-density-touch {
-  --salt-size-unit: calc(var(--salt-size-basis-unit) * 4);
-  --salt-size-compact: calc(var(--salt-size-basis-unit) * 3);
-  --salt-size-accent: calc(var(--salt-size-basis-unit) * 2);
-
-  /* New size work */
   --salt-size-adornment: 12px;
   --salt-size-bar: 8px;
   --salt-size-base: 44px;
   --salt-size-border: 1px;
-  --salt-size-selectable: 18px;
   --salt-size-icon: 16px;
+  --salt-size-indicator: 4px;
+  --salt-size-selectable: 18px;
 }

--- a/site/docs/foundations/size.mdx
+++ b/site/docs/foundations/size.mdx
@@ -16,6 +16,7 @@ Size refers to the restricted dimensions provided within the design system that 
 | `--salt-size-icon`       | Height and width | 12                | 12          | 14       | 16         |
 | `--salt-size-adornment`  | Height and width | 6                 | 8           | 10       | 12         |
 | `--salt-size-bar`        | Height or width  | 2                 | 4           | 6        | 8          |
+| `--salt-size-indicator`  | Height or width  | 1                 | 2           | 3        | 4          |
 | `--salt-size-border`     | Height or width  | 1                 | 1           | 1        | 1          |
 
 ## Base
@@ -97,6 +98,10 @@ Bar is used to control the thickness of an accent bar, either in vertical or hor
   ]}
   label="Show sizes"
 />
+
+## Indicator
+
+`--salt-size-indicator` controls the thickness of an indicator, like on Tabs or Navigation Item.
 
 ## Border
 


### PR DESCRIPTION
`size-indicator` is needed for navigation item and tabs. Whilst I was there I moved the old size tokens out of the main file

Closes ##2121