### PR TITLE
Removed extra CSS from the ag-grid theme

### DIFF
--- a/.changeset/cuddly-kings-count.md
+++ b/.changeset/cuddly-kings-count.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/ag-grid-theme": patch
+---
+
+Fixed invalid CSS being generated for heights

--- a/.changeset/late-beds-melt.md
+++ b/.changeset/late-beds-melt.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/ag-grid-theme": patch
+---
+
+Removed extra CSS from the theme.

--- a/packages/ag-grid-theme/css/_salt-ag-theme-mixin.scss
+++ b/packages/ag-grid-theme/css/_salt-ag-theme-mixin.scss
@@ -11,12 +11,6 @@
     border: none;
   }
 
-  .ag-root-wrapper *,
-  .ag-root-wrapper *::before,
-  .ag-root-wrapper *::after {
-    box-sizing: border-box;
-  }
-
   .ag-ltr,
   .ag-rtl {
     .ag-has-focus .ag-cell-focus:not(.ag-cell-range-selected),

--- a/packages/ag-grid-theme/css/_uitk-ag-theme-mixin.scss
+++ b/packages/ag-grid-theme/css/_uitk-ag-theme-mixin.scss
@@ -381,11 +381,6 @@
     border: 2px dotted var(--agGrid-color-focus);
   }
 
-  .ag-header-cell:after {
-    top: var(--agGrid-separatorGap);
-    bottom: var(--agGrid-separatorGap);
-  }
-
   .ag-header-cell.ag-floating-filter::after {
     display: none;
   }

--- a/packages/ag-grid-theme/css/salt-ag-theme.scss
+++ b/packages/ag-grid-theme/css/salt-ag-theme.scss
@@ -293,7 +293,7 @@ $ag-theme-salt-params-high: map-merge(
   $salt-ag-theme-default-params,
   (
     row-height: 24px,
-    header-height: 24,
+    header-height: 24px,
     font-size: 11px,
     cell-horizontal-padding: 4px,
     list-item-height: 24px,
@@ -315,7 +315,7 @@ $ag-theme-salt-params-high-compact: map-merge(
   $salt-ag-theme-default-params,
   (
     row-height: 20px,
-    header-height: 20,
+    header-height: 20px,
     font-size: 11px,
     cell-horizontal-padding: 4px,
     list-item-height: 20px,
@@ -359,7 +359,7 @@ $ag-theme-salt-params-low: map-merge(
   $salt-ag-theme-default-params,
   (
     row-height: 48px,
-    header-height: 48,
+    header-height: 48px,
     font-size: 14px,
     cell-horizontal-padding: 12px,
     list-item-height: 48px,
@@ -381,7 +381,7 @@ $ag-theme-salt-params-touch: map-merge(
   $salt-ag-theme-default-params,
   (
     row-height: 60px,
-    header-height: 60,
+    header-height: 60px,
     font-size: 16px,
     cell-horizontal-padding: 16px,
     list-item-height: 60px,

--- a/packages/ag-grid-theme/css/uitk-ag-theme.scss
+++ b/packages/ag-grid-theme/css/uitk-ag-theme.scss
@@ -235,7 +235,7 @@ $ag-theme-uitk-params-high: map-merge(
   $uitk-ag-theme-default-params,
   (
     row-height: 20px,
-    header-height: 20,
+    header-height: 20px,
     font-size: 10px,
     header-column-separator-height: 10px,
     cell-horizontal-padding: 5px,
@@ -258,7 +258,7 @@ $ag-theme-uitk-params-medium: map-merge(
   $uitk-ag-theme-default-params,
   (
     row-height: 24px,
-    header-height: 24,
+    header-height: 24px,
     font-size: 12px,
     header-column-separator-height: 10px,
     cell-horizontal-padding: 6px,
@@ -281,7 +281,7 @@ $ag-theme-uitk-params-low: map-merge(
   $uitk-ag-theme-default-params,
   (
     row-height: 32px,
-    header-height: 32,
+    header-height: 32px,
     font-size: 14px,
     header-column-separator-height: 10px,
     cell-horizontal-padding: 6px,
@@ -304,7 +304,7 @@ $ag-theme-uitk-params-touch: map-merge(
   $uitk-ag-theme-default-params,
   (
     row-height: 32px,
-    header-height: 32,
+    header-height: 32px,
     font-size: 14px,
     header-column-separator-height: 10px,
     cell-horizontal-padding: 6px,


### PR DESCRIPTION
`box-sizing: border-box;` is already in ag grid default theme.