### PR TITLE
Border layout site docs

### DIFF
--- a/site/docs/components/border-layout/accessibility.mdx
+++ b/site/docs/components/border-layout/accessibility.mdx
@@ -10,7 +10,7 @@ data:
 
 ### Best practices
 
-When building a page layout, it is important to make sure we use semantic HTML. This, means using the correct HTML elements for their intended purpose as much as possible.
+When building a page layout, it is important to make sure we use semantic HTML. This means using the correct HTML elements for their intended purpose as much as possible.
 
 The Border Layout and Border Item components support this behavior by allowing access to a prop called `as` that allows you to render the appropriate HTML instead of a plain `div`.
 

--- a/site/docs/components/border-layout/accessibility.mdx
+++ b/site/docs/components/border-layout/accessibility.mdx
@@ -8,7 +8,7 @@ data:
   $ref: ./#/data
 ---
 
-### Best practises
+### Best practices
 
 When building a page layout, is it important to make sure we use semantic HTML. This, means using the correct HTML elements for their intended purpose as much as possible.
 

--- a/site/docs/components/border-layout/accessibility.mdx
+++ b/site/docs/components/border-layout/accessibility.mdx
@@ -10,6 +10,22 @@ data:
 
 ### Best practises
 
-When building a page layout is it important to make sure we use semantic HTML, which means using the correct HTML elements for their intended purpose as much as possible.
+When building a page layout, is it important to make sure we use semantic HTML. This, means using the correct HTML elements for their intended purpose as much as possible.
 
 The Border Layout and Border Item components support this behavior by allowing access to a prop called `as` that allows you to render the appropriate HTML instead of a plain `div`.
+
+```tsx
+<BorderItem position="north" as="nav">
+  <ul>
+    <li>
+      <a href="#">Link</a>
+    </li>
+    <li>
+      <a href="#">Link</a>
+    </li>
+    <li>
+      <a href="#">Link</a>
+    </li>
+  </ul>
+</BorderItem>
+```

--- a/site/docs/components/border-layout/accessibility.mdx
+++ b/site/docs/components/border-layout/accessibility.mdx
@@ -10,7 +10,7 @@ data:
 
 ### Best practices
 
-When building a page layout, is it important to make sure we use semantic HTML. This, means using the correct HTML elements for their intended purpose as much as possible.
+When building a page layout, it is important to make sure we use semantic HTML. This, means using the correct HTML elements for their intended purpose as much as possible.
 
 The Border Layout and Border Item components support this behavior by allowing access to a prop called `as` that allows you to render the appropriate HTML instead of a plain `div`.
 

--- a/site/docs/components/border-layout/accessibility.mdx
+++ b/site/docs/components/border-layout/accessibility.mdx
@@ -3,7 +3,7 @@ title:
   $ref: ./#/title
 layout: DetailComponent
 sidebar:
-  label: Accessibility
+  exclude: true
 data:
   $ref: ./#/data
 ---

--- a/site/docs/components/border-layout/accessibility.mdx
+++ b/site/docs/components/border-layout/accessibility.mdx
@@ -1,0 +1,15 @@
+---
+title:
+  $ref: ./#/title
+layout: DetailComponent
+sidebar:
+  label: Accessibility
+data:
+  $ref: ./#/data
+---
+
+### Best practises
+
+When building a page layout is it important to make sure we use semantic HTML, which means using the correct HTML elements for their intended purpose as much as possible.
+
+The Border Layout and Border Item components support this behavior by allowing access to a prop called `as` that allows you to render the appropriate HTML instead of a plain `div`.

--- a/site/docs/components/border-layout/examples.mdx
+++ b/site/docs/components/border-layout/examples.mdx
@@ -11,27 +11,25 @@ data:
 <LivePreviewControls>
 <LivePreview componentName="border-layout" exampleName="Default" >
 
-Border Layout can be set to display 5 regions: North, East, South, West and Center. At least one Center region must be defined in the layout.
+Border Layout can be set to display five regions: North, East, South, West and Center. At least one region but must be displayed alongside the Center region in the layout.
 
-By default, there is no gap between regions.
+By default, there are no gaps between regions.
 
 </LivePreview>
 
 <LivePreview componentName="border-layout" exampleName="CustomRegionSize" >
 
-The size of regions can be manually defined. This example demonstrates how to set the West and East regions to a fixed width, with a responsive Center region.
+You can manually define the size of regions. This example shows how to set the West and East regions to a fixed width, with a responsive Center region.
 
-**Tip**: This layout would work well where a fixed-width side navigation is required, alongside responsive page content.
+This layout would work well where a fixed-width side navigation is required, alongside responsive page content.
 
 </LivePreview>
 
 <LivePreview componentName="border-layout" exampleName="GapBetweenRegions" >
 
-A gap can be added between each region. `Gap` is a multiplier that aligns to the [Salt spacing system](https://www.saltdesignsystem.com/salt/foundations/spacing).
+A gap can be added between each region. The`gap` property is a multiplier that aligns to the [Salt spacing system](https://www.saltdesignsystem.com/salt/foundations/spacing).
 
-**Tip**:
-
-- The standard gap between column and row elements is 3x.
+- The standard gap between column and row elements in Salt is 3 times the base unit.
 
 - Use `columnGap` and `rowGap` properties to set a specific gap in a particular dimension or `gap` to update both values simultaneously.
 
@@ -57,7 +55,7 @@ User the `verticalAlignment` and `horizontalAlignment` properties of the Border 
 
 <LivePreview componentName="border-layout" exampleName="StickyPositioning" >
 
-Use the `sticky` property of the Border Item wrapper to define a region as sticky. When set to `true`, content in surrounding regions will scroll beneath a ‘sticky’ Border Item.
+Use the `sticky` property of the Border Item wrapper to define a region as sticky. When set to `true`, content in surrounding regions will scroll beneath a `sticky` Border Item.
 
 This is particularly useful if you require a header, (in the North region) or side navigation (in the West) to remain visible at all times.
 

--- a/site/docs/components/border-layout/examples.mdx
+++ b/site/docs/components/border-layout/examples.mdx
@@ -1,0 +1,47 @@
+---
+title:
+  $ref: ./#/title
+layout: DetailComponent
+sidebar:
+  label: Examples
+data:
+  $ref: ./#/data
+---
+
+<LivePreviewControls>
+<LivePreview componentName="button" exampleName="CTA" >
+
+Use the CTA button for high priority actions.
+
+</LivePreview>
+
+<LivePreview componentName="button" exampleName="Primary" >
+
+Use the primary button for routine, non-urgent actions.
+
+</LivePreview>
+
+<LivePreview componentName="button" exampleName="Secondary" >
+
+Use the secondary button for non-critical actions that support the user but do not impact a flow.
+
+</LivePreview>
+
+<LivePreview componentName="button" exampleName="IconAndLabel" >
+
+Add an icon before the text to reinforce the button label, or add an icon after the button label to suggest movement or a direction.
+
+</LivePreview>
+
+<LivePreview componentName="button" exampleName="IconOnly" >
+
+Display an icon-only button with no label when you have limited on-screen space and the icon is globally understood.
+
+</LivePreview>
+
+<LivePreview componentName="button" exampleName="Disabled" >
+
+Indicates a button that the user can’t interact with.
+
+</LivePreview>
+</LivePreviewControls>

--- a/site/docs/components/border-layout/examples.mdx
+++ b/site/docs/components/border-layout/examples.mdx
@@ -33,7 +33,7 @@ This layout would work well where a fixed-width side navigation is required, alo
 
 ### Gap between regions
 
-A gap can be added between each region. The`gap` property is a multiplier that aligns to the [Salt spacing system](https://www.saltdesignsystem.com/salt/foundations/spacing).
+A gap can be added between each region. The `gap` property is a multiplier that aligns to the [Salt spacing system](https://www.saltdesignsystem.com/salt/foundations/spacing).
 
 - The standard gap between column and row elements in Salt is 3 times the base unit.
 

--- a/site/docs/components/border-layout/examples.mdx
+++ b/site/docs/components/border-layout/examples.mdx
@@ -33,7 +33,7 @@ This layout would work well where a fixed-width side navigation is required, alo
 
 ### Gap between regions
 
-A gap can be added between each region. The `gap` property is a multiplier that aligns to the [Salt spacing system](https://www.saltdesignsystem.com/salt/foundations/spacing).
+A gap can be added between each region. The `gap` property is a multiplier that aligns to the [Salt spacing system](/salt/foundations/spacing).
 
 - The standard gap between column and row elements in Salt is 3 times the base unit.
 

--- a/site/docs/components/border-layout/examples.mdx
+++ b/site/docs/components/border-layout/examples.mdx
@@ -55,4 +55,12 @@ User the `verticalAlignment` and `horizontalAlignment` properties of the Border 
 
 </LivePreview>
 
+<LivePreview componentName="border-layout" exampleName="StickyPositioning" >
+
+Use the `sticky` property of the Border Item wrapper to define a region as sticky. When set to `true`, content in surrounding regions will scroll beneath a ‘sticky’ Border Item.
+
+This is particularly useful if you require a header, (in the North region) or side navigation (in the West) to remain visible at all times.
+
+</LivePreview>
+
 </LivePreviewControls>

--- a/site/docs/components/border-layout/examples.mdx
+++ b/site/docs/components/border-layout/examples.mdx
@@ -9,39 +9,50 @@ data:
 ---
 
 <LivePreviewControls>
-<LivePreview componentName="button" exampleName="CTA" >
+<LivePreview componentName="border-layout" exampleName="Default" >
 
-Use the CTA button for high priority actions.
+Border Layout can be set to display 5 regions: North, East, South, West and Center. At least one Center region must be defined in the layout.
 
-</LivePreview>
-
-<LivePreview componentName="button" exampleName="Primary" >
-
-Use the primary button for routine, non-urgent actions.
+By default, there is no gap between regions.
 
 </LivePreview>
 
-<LivePreview componentName="button" exampleName="Secondary" >
+<LivePreview componentName="border-layout" exampleName="CustomRegionSize" >
 
-Use the secondary button for non-critical actions that support the user but do not impact a flow.
+The size of regions can be manually defined. This example demonstrates how to set the West and East regions to a fixed width, with a responsive Center region.
 
-</LivePreview>
-
-<LivePreview componentName="button" exampleName="IconAndLabel" >
-
-Add an icon before the text to reinforce the button label, or add an icon after the button label to suggest movement or a direction.
+**Tip**: This layout would work well where a fixed-width side navigation is required, alongside responsive page content.
 
 </LivePreview>
 
-<LivePreview componentName="button" exampleName="IconOnly" >
+<LivePreview componentName="border-layout" exampleName="GapBetweenRegions" >
 
-Display an icon-only button with no label when you have limited on-screen space and the icon is globally understood.
+A gap can be added between each region. `Gap` is a multiplier that aligns to the [Salt spacing system](https://www.saltdesignsystem.com/salt/foundations/spacing).
+
+**Tip**:
+
+- The standard gap between column and row elements is 3x.
+
+- Use `columnGap` and `rowGap` properties to set a specific gap in a particular dimension or `gap` to update both values simultaneously.
 
 </LivePreview>
 
-<LivePreview componentName="button" exampleName="Disabled" >
+<LivePreview componentName="border-layout" exampleName="HideRegions" >
 
-Indicates a button that the user can’t interact with.
+Border Layout can display any combination of Border Items. This example demonstrates a layout with North, East and Center regions.
 
 </LivePreview>
+
+<LivePreview componentName="border-layout" exampleName="BorderItemPosition" >
+
+Set the `position` property of the Border Item wrapper to define where content should be displayed in the layout: North, East, South, West, Center.
+
+</LivePreview>
+
+<LivePreview componentName="border-layout" exampleName="BorderItemAlignment" >
+
+User the `verticalAlignment` and `horizontalAlignment` properties of the Border Item wrapper to determine how content should be aligned in the region.
+
+</LivePreview>
+
 </LivePreviewControls>

--- a/site/docs/components/border-layout/examples.mdx
+++ b/site/docs/components/border-layout/examples.mdx
@@ -3,7 +3,7 @@ title:
   $ref: ./#/title
 layout: DetailComponent
 sidebar:
-  label: Examples
+  exclude: true
 data:
   $ref: ./#/data
 ---

--- a/site/docs/components/border-layout/examples.mdx
+++ b/site/docs/components/border-layout/examples.mdx
@@ -11,6 +11,8 @@ data:
 <LivePreviewControls>
 <LivePreview componentName="border-layout" exampleName="Default" >
 
+### Default
+
 Border Layout can be set to display five regions: North, East, South, West and Center. At least one region but must be displayed alongside the Center region in the layout.
 
 By default, there are no gaps between regions.
@@ -19,6 +21,8 @@ By default, there are no gaps between regions.
 
 <LivePreview componentName="border-layout" exampleName="CustomRegionSize" >
 
+### Custom region size
+
 You can manually define the size of regions. This example shows how to set the West and East regions to a fixed width, with a responsive Center region.
 
 This layout would work well where a fixed-width side navigation is required, alongside responsive page content.
@@ -26,6 +30,8 @@ This layout would work well where a fixed-width side navigation is required, alo
 </LivePreview>
 
 <LivePreview componentName="border-layout" exampleName="GapBetweenRegions" >
+
+### Gap between regions
 
 A gap can be added between each region. The`gap` property is a multiplier that aligns to the [Salt spacing system](https://www.saltdesignsystem.com/salt/foundations/spacing).
 
@@ -37,11 +43,15 @@ A gap can be added between each region. The`gap` property is a multiplier that a
 
 <LivePreview componentName="border-layout" exampleName="HideRegions" >
 
+### Hide regions
+
 Border Layout can display any combination of Border Items. This example demonstrates a layout with North, East and Center regions.
 
 </LivePreview>
 
 <LivePreview componentName="border-layout" exampleName="BorderItemPosition" >
+
+### Border Item position
 
 Set the `position` property of the Border Item wrapper to define where content should be displayed in the layout: North, East, South, West, Center.
 
@@ -49,11 +59,15 @@ Set the `position` property of the Border Item wrapper to define where content s
 
 <LivePreview componentName="border-layout" exampleName="BorderItemAlignment" >
 
+### Border Item alignment
+
 User the `verticalAlignment` and `horizontalAlignment` properties of the Border Item wrapper to determine how content should be aligned in the region.
 
 </LivePreview>
 
 <LivePreview componentName="border-layout" exampleName="StickyPositioning" >
+
+### Sticky positioning
 
 Use the `sticky` property of the Border Item wrapper to define a region as sticky. When set to `true`, content in surrounding regions will scroll beneath a `sticky` Border Item.
 

--- a/site/docs/components/border-layout/examples.mdx
+++ b/site/docs/components/border-layout/examples.mdx
@@ -61,7 +61,7 @@ Set the `position` property of the Border Item wrapper to define where content s
 
 ### Border Item alignment
 
-User the `verticalAlignment` and `horizontalAlignment` properties of the Border Item wrapper to determine how content should be aligned in the region.
+Use the `verticalAlignment` and `horizontalAlignment` properties of the Border Item wrapper to determine how content should be aligned in the region.
 
 </LivePreview>
 

--- a/site/docs/components/border-layout/index.mdx
+++ b/site/docs/components/border-layout/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Border Layout
 data:
-  description: It defines five distinct regions. Four of these regions surround a main content region and are used forelements such as a footer, header or side navigation. Border Layout is built on top of the Grid Layout component and it is specifically intended for entire website pages or application screens, where there is at least one additional region alongside the main area.
+  description: It defines five distinct regions. Four of these regions surround a main content region and are used for elements such as a footer, header or side navigation. Border Layout is built on top of the Grid Layout component and it is specifically intended for entire website pages or application screens, where there is at least one additional region alongside the main area.
   sourceCodeUrl: "https://github.com/jpmorganchase/salt-ds/blob/main/packages/core/src/border-layout/BorderLayout.tsx"
   package:
     name: "@salt-ds/core"

--- a/site/docs/components/border-layout/index.mdx
+++ b/site/docs/components/border-layout/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Border Layout
 data:
-  description: It defines five distinct regions. Four of these regions surround a main content region and are used for elements such as a footer, header or side navigation. Border Layout is built on top of the Grid Layout component and it is specifically intended for entire website pages or application screens, where there is at least one additional region alongside the main area.
+  description: Border Layout manages the top-level layout of your application, website, or widget. It defines five distinct regions. Four of these regions surround a main content region and are used for elements such as a footer, header or side navigation. Border Layout is built on top of Grid Layout and is specifically intended for entire website pages or application screens, where there is at least one additional region alongside the main area.
   sourceCodeUrl: "https://github.com/jpmorganchase/salt-ds/blob/main/packages/core/src/border-layout/BorderLayout.tsx"
   package:
     name: "@salt-ds/core"

--- a/site/docs/components/border-layout/index.mdx
+++ b/site/docs/components/border-layout/index.mdx
@@ -1,15 +1,14 @@
 ---
 title: Border Layout
 data:
-  description: Defines the main content regions of an application, region or widget, such as a footer, header or side navigation. The Border Layout is built using Grid Layout and it is intended for laying out large sections of content, such as pages, where there is at least a main area with a header and footer.
+  description: It defines five distinct regions. Four of these regions surround a main content region and are used forelements such as a footer, header or side navigation. Border Layout is built on top of the Grid Layout component and it is specifically intended for entire website pages or application screens, where there is at least one additional region alongside the main area.
   sourceCodeUrl: "https://github.com/jpmorganchase/salt-ds/blob/main/packages/core/src/border-layout/BorderLayout.tsx"
   package:
     name: "@salt-ds/core"
-  alsoKnownAs: ["Grid"]
+  alsoKnownAs: ["Grid", "Side panel", "Header", "Main"]
   relatedComponents:
     [
       { name: "Grid Layout", relationship: "similarTo" },
-      { name: "Border Item", relationship: "similarTo" },
       { name: "Grid Layout", relationship: "contains" },
     ]
   stickerSheet: ""

--- a/site/docs/components/border-layout/index.mdx
+++ b/site/docs/components/border-layout/index.mdx
@@ -1,0 +1,17 @@
+---
+title: Border Layout
+data:
+  description: Defines the main content regions of an application, region or widget, such as a footer, header or side navigation. The Border Layout is built using Grid Layout and it is intended for laying out large sections of content, such as pages, where there is at least a main area with a header and footer.
+  sourceCodeUrl: "https://github.com/jpmorganchase/salt-ds/blob/main/packages/core/src/border-layout/BorderLayout.tsx"
+  package:
+    name: "@salt-ds/core"
+  alsoKnownAs: ["Grid"]
+  relatedComponents:
+    [
+      { name: "Grid Layout", relationship: "similarTo" },
+      { name: "Border Item", relationship: "similarTo" },
+      { name: "Grid Layout", relationship: "contains" },
+    ]
+  stickerSheet: ""
+layout: DetailComponent
+---

--- a/site/docs/components/border-layout/usage.mdx
+++ b/site/docs/components/border-layout/usage.mdx
@@ -1,0 +1,36 @@
+---
+title:
+  $ref: ./#/title
+layout: DetailComponent
+sidebar:
+  label: How to use
+data:
+  $ref: ./#/data
+---
+
+### Using the Border Layout component
+
+Usage information for this component. Copy the content from the content
+template's "How to use" section here.
+
+### Import
+
+To import Button from the core Salt package, use:
+
+```
+import { BorderItem, BorderLayout } from "@salt-ds/core";
+```
+
+### Props
+
+<PropsTable componentName="BorderLayout" />
+
+### Content
+
+Add text from "Content" section here when available, or else remove this
+section.
+
+### References
+
+Add text from "References" section here when available, or else remove this
+section.

--- a/site/docs/components/border-layout/usage.mdx
+++ b/site/docs/components/border-layout/usage.mdx
@@ -3,7 +3,7 @@ title:
   $ref: ./#/title
 layout: DetailComponent
 sidebar:
-  label: How to use
+  exclude: true
 data:
   $ref: ./#/data
 ---

--- a/site/docs/components/border-layout/usage.mdx
+++ b/site/docs/components/border-layout/usage.mdx
@@ -18,7 +18,7 @@ data:
 
 - For a customized layout that you can control in both row and column dimensions (for example, a Dashboard). Instead, use Grid Layout.
 
-- For a side panel which temporarily reveals relevant content, consider using a Drawer component instead of a border layout region.
+- For a side panel that temporarily reveals relevant content, consider using a Drawer component instead of a border layout region.
 
 ### Import
 

--- a/site/docs/components/border-layout/usage.mdx
+++ b/site/docs/components/border-layout/usage.mdx
@@ -16,7 +16,7 @@ data:
 
 - You’re not managing the top-level layout of your application, but the layout inside one of the five Border Layout regions.
 
-- If you want a customized layout that you can control in both row and column dimensions (for example, a Dashboard) we recommend using Grid Layout.
+- For a customized layout that you can control in both row and column dimensions (for example, a Dashboard). Instead, use Grid Layout.
 
 - If you want a side panel which temporarily reveals relevant content, consider using a Drawer component instead of a border layout region.
 

--- a/site/docs/components/border-layout/usage.mdx
+++ b/site/docs/components/border-layout/usage.mdx
@@ -8,10 +8,17 @@ data:
   $ref: ./#/data
 ---
 
-### Using the Border Layout component
+### When to use Border Layout
 
-Usage information for this component. Copy the content from the content
-template's "How to use" section here.
+- You need to manage the top-level layout of your application, or page, with at least one additional region alongside the main content area (e.g., for navigation or a footer).
+
+### When not to use Border Layout
+
+- You’re not managing the top-level layout of your application, but the layout inside one of the five Border Layout regions.
+
+- If you want a customized layout that you can control in both row and column dimensions (for example, a Dashboard) we recommend using Grid Layout.
+
+- If you want a side panel which temporarily reveals relevant content, consider using a Drawer component instead of a border layout region.
 
 ### Import
 
@@ -24,13 +31,3 @@ import { BorderItem, BorderLayout } from "@salt-ds/core";
 ### Props
 
 <PropsTable componentName="BorderLayout" />
-
-### Content
-
-Add text from "Content" section here when available, or else remove this
-section.
-
-### References
-
-Add text from "References" section here when available, or else remove this
-section.

--- a/site/docs/components/border-layout/usage.mdx
+++ b/site/docs/components/border-layout/usage.mdx
@@ -10,7 +10,7 @@ data:
 
 ### When to use Border Layout
 
-- You need to manage the top-level layout of your application, or page, with at least one additional region alongside the main content area (e.g., for navigation or a footer).
+- To manage the top-level layout of your application, or page, with at least one additional region alongside the main content area (e.g., for navigation or a footer).
 
 ### When not to use Border Layout
 

--- a/site/docs/components/border-layout/usage.mdx
+++ b/site/docs/components/border-layout/usage.mdx
@@ -18,7 +18,7 @@ data:
 
 - For a customized layout that you can control in both row and column dimensions (for example, a Dashboard). Instead, use Grid Layout.
 
-- If you want a side panel which temporarily reveals relevant content, consider using a Drawer component instead of a border layout region.
+- For a side panel which temporarily reveals relevant content, consider using a Drawer component instead of a border layout region.
 
 ### Import
 

--- a/site/docs/components/border-layout/usage.mdx
+++ b/site/docs/components/border-layout/usage.mdx
@@ -22,7 +22,7 @@ data:
 
 ### Import
 
-To import Button from the core Salt package, use:
+To import Border Layout from the core Salt package, use:
 
 ```
 import { BorderItem, BorderLayout } from "@salt-ds/core";

--- a/site/src/examples/border-layout/BorderItemAlignment.module.css
+++ b/site/src/examples/border-layout/BorderItemAlignment.module.css
@@ -1,0 +1,16 @@
+.container {
+  display: flex;
+  flex-direction: column;
+}
+
+.borderLayout {
+  min-height: 200px;
+}
+
+.radioButtonGroups {
+  margin-top: var(--salt-spacing-300);
+  text-transform: capitalize;
+  display: flex;
+  flex-direction: column;
+  gap: var(--salt-spacing-100);
+}

--- a/site/src/examples/border-layout/BorderItemAlignment.module.css
+++ b/site/src/examples/border-layout/BorderItemAlignment.module.css
@@ -9,7 +9,6 @@
 
 .radioButtonGroups {
   margin-top: var(--salt-spacing-300);
-  text-transform: capitalize;
   display: flex;
   flex-direction: column;
   gap: var(--salt-spacing-100);

--- a/site/src/examples/border-layout/BorderItemAlignment.tsx
+++ b/site/src/examples/border-layout/BorderItemAlignment.tsx
@@ -11,36 +11,27 @@ import {
 import styles from "./index.module.css";
 import borderItemAlignmentStyles from "./BorderItemAlignment.module.css";
 
-const alignmentOptions = borderItemAlignment.map((alignment, index) => ({
-  label: alignment,
-  value: `option${index + 1}`,
-}));
+type BorderItemAlignmentType = typeof borderItemAlignment[number];
 
 export const BorderItemAlignment = (): ReactElement => {
-  const [verticalOption, setVerticalOption] = useState("option4");
-  const [horizontalOption, setHorizontalOption] = useState("option4");
+  const [verticalAlignment, setVerticalAlignment] =
+    useState<BorderItemAlignmentType>("stretch");
+  const [horizontalAlignment, setHorizontalAlignment] =
+    useState<BorderItemAlignmentType>("stretch");
 
   const handleVerticalChange: ChangeEventHandler<HTMLInputElement> = (
     event
   ) => {
     const { value } = event.target;
-    setVerticalOption(value);
+    setVerticalAlignment(value);
   };
 
   const handleHorizontalChange: ChangeEventHandler<HTMLInputElement> = (
     event
   ) => {
     const { value } = event.target;
-    setHorizontalOption(value);
+    setHorizontalAlignment(value);
   };
-
-  const verticalAlignment =
-    alignmentOptions.find(({ value }) => value === verticalOption)?.label ||
-    "stretch";
-
-  const horizontalAlignment =
-    alignmentOptions.find(({ value }) => value === horizontalOption)?.label ||
-    "stretch";
 
   return (
     <div className={borderItemAlignmentStyles.container}>
@@ -68,10 +59,14 @@ export const BorderItemAlignment = (): ReactElement => {
             aria-label="Vertical alignment Controls"
             name="verticalAlignment"
             onChange={handleVerticalChange}
-            value={verticalOption}
+            value={verticalAlignment}
           >
-            {alignmentOptions.map(({ label, value }) => (
-              <RadioButton key={value} label={label} value={value} />
+            {borderItemAlignment.map((alignment) => (
+              <RadioButton
+                key={alignment}
+                label={alignment}
+                value={alignment}
+              />
             ))}
           </RadioButtonGroup>
         </FormField>
@@ -83,10 +78,14 @@ export const BorderItemAlignment = (): ReactElement => {
             aria-label="Horizontal alignment Controls"
             name="horizontalAlignment"
             onChange={handleHorizontalChange}
-            value={horizontalOption}
+            value={horizontalAlignment}
           >
-            {alignmentOptions.map(({ label, value }) => (
-              <RadioButton key={value} label={label} value={value} />
+            {borderItemAlignment.map((alignment) => (
+              <RadioButton
+                key={alignment}
+                label={alignment}
+                value={alignment}
+              />
             ))}
           </RadioButtonGroup>
         </FormField>

--- a/site/src/examples/border-layout/BorderItemAlignment.tsx
+++ b/site/src/examples/border-layout/BorderItemAlignment.tsx
@@ -23,14 +23,14 @@ export const BorderItemAlignment = (): ReactElement => {
     event
   ) => {
     const { value } = event.target;
-    setVerticalAlignment(value);
+    setVerticalAlignment(value as BorderItemAlignmentType);
   };
 
   const handleHorizontalChange: ChangeEventHandler<HTMLInputElement> = (
     event
   ) => {
     const { value } = event.target;
-    setHorizontalAlignment(value);
+    setHorizontalAlignment(value as BorderItemAlignmentType);
   };
 
   return (

--- a/site/src/examples/border-layout/BorderItemAlignment.tsx
+++ b/site/src/examples/border-layout/BorderItemAlignment.tsx
@@ -1,0 +1,96 @@
+import { ReactElement, useState, ChangeEventHandler } from "react";
+import {
+  BorderLayout,
+  BorderItem,
+  GRID_ALIGNMENT_BASE as borderItemAlignment,
+  RadioButtonGroup,
+  RadioButton,
+  FormField,
+  FormFieldLabel,
+} from "@salt-ds/core";
+import styles from "./index.module.css";
+import borderItemAlignmentStyles from "./BorderItemAlignment.module.css";
+
+const alignmentOptions = borderItemAlignment.map((alignment, index) => ({
+  label: alignment,
+  value: `option${index + 1}`,
+}));
+
+export const BorderItemAlignment = (): ReactElement => {
+  const [verticalOption, setVerticalOption] = useState("option4");
+  const [horizontalOption, setHorizontalOption] = useState("option4");
+
+  const handleVerticalChange: ChangeEventHandler<HTMLInputElement> = (
+    event
+  ) => {
+    const { value } = event.target;
+    setVerticalOption(value);
+  };
+
+  const handleHorizontalChange: ChangeEventHandler<HTMLInputElement> = (
+    event
+  ) => {
+    const { value } = event.target;
+    setHorizontalOption(value);
+  };
+
+  const verticalAlignment =
+    alignmentOptions.find(({ value }) => value === verticalOption)?.label ||
+    "stretch";
+
+  const horizontalAlignment =
+    alignmentOptions.find(({ value }) => value === horizontalOption)?.label ||
+    "stretch";
+
+  return (
+    <div className={borderItemAlignmentStyles.container}>
+      <BorderLayout className={borderItemAlignmentStyles.borderLayout}>
+        <BorderItem position="north" className={styles.borderItem}>
+          North
+        </BorderItem>
+        <BorderItem position="west" className={styles.borderItem}>
+          West
+        </BorderItem>
+        <BorderItem
+          position="center"
+          className={styles.borderItem}
+          horizontalAlignment={horizontalAlignment}
+          verticalAlignment={verticalAlignment}
+        >
+          Center
+        </BorderItem>
+      </BorderLayout>
+      <div className={borderItemAlignmentStyles.radioButtonGroups}>
+        <FormField>
+          <FormFieldLabel>Vertical alignment</FormFieldLabel>
+          <RadioButtonGroup
+            direction={"horizontal"}
+            aria-label="Vertical alignment Controls"
+            name="verticalAlignment"
+            onChange={handleVerticalChange}
+            value={verticalOption}
+          >
+            {alignmentOptions.map(({ label, value }) => (
+              <RadioButton key={value} label={label} value={value} />
+            ))}
+          </RadioButtonGroup>
+        </FormField>
+
+        <FormField>
+          <FormFieldLabel>Horizontal alignment</FormFieldLabel>
+          <RadioButtonGroup
+            direction={"horizontal"}
+            aria-label="Horizontal alignment Controls"
+            name="horizontalAlignment"
+            onChange={handleHorizontalChange}
+            value={horizontalOption}
+          >
+            {alignmentOptions.map(({ label, value }) => (
+              <RadioButton key={value} label={label} value={value} />
+            ))}
+          </RadioButtonGroup>
+        </FormField>
+      </div>
+    </div>
+  );
+};

--- a/site/src/examples/border-layout/BorderItemAlignment.tsx
+++ b/site/src/examples/border-layout/BorderItemAlignment.tsx
@@ -64,7 +64,9 @@ export const BorderItemAlignment = (): ReactElement => {
             {borderItemAlignment.map((alignment) => (
               <RadioButton
                 key={alignment}
-                label={alignment}
+                label={`${alignment.charAt(0).toUpperCase()}${alignment.slice(
+                  1
+                )}`}
                 value={alignment}
               />
             ))}
@@ -83,7 +85,9 @@ export const BorderItemAlignment = (): ReactElement => {
             {borderItemAlignment.map((alignment) => (
               <RadioButton
                 key={alignment}
-                label={alignment}
+                label={`${alignment.charAt(0).toUpperCase()}${alignment.slice(
+                  1
+                )}`}
                 value={alignment}
               />
             ))}

--- a/site/src/examples/border-layout/BorderItemPosition.module.css
+++ b/site/src/examples/border-layout/BorderItemPosition.module.css
@@ -1,0 +1,14 @@
+.container {
+  display: flex;
+  flex-direction: column;
+}
+
+.container .active {
+  font-weight: var(--salt-text-fontWeight-strong);
+  background: var(--salt-container-secondary-background);
+}
+
+.radioButtonGroup {
+  margin-top: var(--salt-spacing-300);
+  text-transform: capitalize;
+}

--- a/site/src/examples/border-layout/BorderItemPosition.module.css
+++ b/site/src/examples/border-layout/BorderItemPosition.module.css
@@ -10,5 +10,4 @@
 
 .radioButtonGroup {
   margin-top: var(--salt-spacing-300);
-  text-transform: capitalize;
 }

--- a/site/src/examples/border-layout/BorderItemPosition.tsx
+++ b/site/src/examples/border-layout/BorderItemPosition.tsx
@@ -76,7 +76,13 @@ export const BorderItemPosition = (): ReactElement => {
             value={position}
           >
             {borderPosition.map((position) => (
-              <RadioButton key={position} label={position} value={position} />
+              <RadioButton
+                key={position}
+                label={`${position.charAt(0).toUpperCase()}${position.slice(
+                  1
+                )}`}
+                value={position}
+              />
             ))}
           </RadioButtonGroup>
         </FormField>

--- a/site/src/examples/border-layout/BorderItemPosition.tsx
+++ b/site/src/examples/border-layout/BorderItemPosition.tsx
@@ -1,0 +1,93 @@
+import { ReactElement, useState, ChangeEventHandler } from "react";
+import clsx from "clsx";
+import {
+  BorderLayout,
+  BorderItem,
+  BORDER_POSITION as borderPosition,
+  RadioButtonGroup,
+  RadioButton,
+  FormField,
+  FormFieldLabel,
+} from "@salt-ds/core";
+import styles from "./index.module.css";
+import borderItemPositionStyles from "./BorderItemPosition.module.css";
+
+const positionOptions = borderPosition.map((position, index) => ({
+  label: position,
+  value: `option${index + 1}`,
+}));
+
+export const BorderItemPosition = (): ReactElement => {
+  const [option, setOption] = useState("option2");
+
+  const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+    const { value } = event.target;
+    setOption(value);
+  };
+
+  const position =
+    positionOptions.find(({ value }) => value === option)?.label || "west";
+
+  return (
+    <div className={borderItemPositionStyles.container}>
+      <BorderLayout>
+        <BorderItem
+          position="north"
+          className={clsx(styles.borderItem, {
+            [borderItemPositionStyles.active]: position === "north",
+          })}
+        >
+          North
+        </BorderItem>
+        <BorderItem
+          position="west"
+          className={clsx(styles.borderItem, {
+            [borderItemPositionStyles.active]: position === "west",
+          })}
+        >
+          West
+        </BorderItem>
+        <BorderItem
+          position="center"
+          className={clsx(styles.borderItem, {
+            [borderItemPositionStyles.active]: position === "center",
+          })}
+        >
+          Center
+        </BorderItem>
+        <BorderItem
+          position="east"
+          className={clsx(styles.borderItem, {
+            [borderItemPositionStyles.active]: position === "east",
+          })}
+        >
+          East
+        </BorderItem>
+        <BorderItem
+          position="south"
+          className={clsx(styles.borderItem, {
+            [borderItemPositionStyles.active]: position === "south",
+          })}
+        >
+          South
+        </BorderItem>
+      </BorderLayout>
+      <div className={borderItemPositionStyles.radioButtonGroup}>
+        <FormField>
+          <FormFieldLabel>Position</FormFieldLabel>
+          <RadioButtonGroup
+            direction={"horizontal"}
+            aria-label="Position Controls"
+            name="position"
+            onChange={handleChange}
+            value={option}
+          >
+            {positionOptions.map(({ label, value }) => (
+              <RadioButton key={value} label={label} value={value} />
+            ))}
+          </RadioButtonGroup>
+        </FormField>
+      </div>
+    </div>
+  );
+};

--- a/site/src/examples/border-layout/BorderItemPosition.tsx
+++ b/site/src/examples/border-layout/BorderItemPosition.tsx
@@ -4,6 +4,7 @@ import {
   BorderLayout,
   BorderItem,
   BORDER_POSITION as borderPosition,
+  BorderPosition,
   RadioButtonGroup,
   RadioButton,
   FormField,
@@ -12,21 +13,13 @@ import {
 import styles from "./index.module.css";
 import borderItemPositionStyles from "./BorderItemPosition.module.css";
 
-const positionOptions = borderPosition.map((position, index) => ({
-  label: position,
-  value: `option${index + 1}`,
-}));
-
 export const BorderItemPosition = (): ReactElement => {
-  const [option, setOption] = useState("option2");
+  const [position, setPosition] = useState<BorderPosition>("west");
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
     const { value } = event.target;
-    setOption(value);
+    setPosition(value as BorderPosition);
   };
-
-  const position =
-    positionOptions.find(({ value }) => value === option)?.label || "west";
 
   return (
     <div className={borderItemPositionStyles.container}>
@@ -80,10 +73,10 @@ export const BorderItemPosition = (): ReactElement => {
             aria-label="Position Controls"
             name="position"
             onChange={handleChange}
-            value={option}
+            value={position}
           >
-            {positionOptions.map(({ label, value }) => (
-              <RadioButton key={value} label={label} value={value} />
+            {borderPosition.map((position) => (
+              <RadioButton key={position} label={position} value={position} />
             ))}
           </RadioButtonGroup>
         </FormField>

--- a/site/src/examples/border-layout/CustomRegionSize.tsx
+++ b/site/src/examples/border-layout/CustomRegionSize.tsx
@@ -1,0 +1,32 @@
+import { ReactElement } from "react";
+import clsx from "clsx";
+import { BorderLayout, BorderItem } from "@salt-ds/core";
+import styles from "./index.module.css";
+
+export const CustomRegionSize = (): ReactElement => (
+  <BorderLayout style={{ width: "90%" }}>
+    <BorderItem position="north" className={styles.borderItem}>
+      North
+    </BorderItem>
+    <BorderItem
+      position="west"
+      className={styles.borderItem}
+      style={{ width: 100 }}
+    >
+      West
+    </BorderItem>
+    <BorderItem position="center" className={styles.borderItem}>
+      Center
+    </BorderItem>
+    <BorderItem
+      position="east"
+      className={styles.borderItem}
+      style={{ width: 100 }}
+    >
+      East
+    </BorderItem>
+    <BorderItem position="south" className={styles.borderItem}>
+      South
+    </BorderItem>
+  </BorderLayout>
+);

--- a/site/src/examples/border-layout/Default.tsx
+++ b/site/src/examples/border-layout/Default.tsx
@@ -1,0 +1,23 @@
+import { ReactElement } from "react";
+import { BorderLayout, BorderItem } from "@salt-ds/core";
+import styles from "./index.module.css";
+
+export const Default = (): ReactElement => (
+  <BorderLayout>
+    <BorderItem position="north" className={styles.borderItem}>
+      North
+    </BorderItem>
+    <BorderItem position="west" className={styles.borderItem}>
+      West
+    </BorderItem>
+    <BorderItem position="center" className={styles.borderItem}>
+      Center
+    </BorderItem>
+    <BorderItem position="east" className={styles.borderItem}>
+      East
+    </BorderItem>
+    <BorderItem position="south" className={styles.borderItem}>
+      South
+    </BorderItem>
+  </BorderLayout>
+);

--- a/site/src/examples/border-layout/GapBetweenRegions.tsx
+++ b/site/src/examples/border-layout/GapBetweenRegions.tsx
@@ -1,0 +1,24 @@
+import { ReactElement } from "react";
+import clsx from "clsx";
+import { BorderLayout, BorderItem } from "@salt-ds/core";
+import styles from "./index.module.css";
+
+export const GapBetweenRegions = (): ReactElement => (
+  <BorderLayout className={styles.borderLayout} gap={3}>
+    <BorderItem position="north" className={styles.borderItem}>
+      North
+    </BorderItem>
+    <BorderItem position="west" className={styles.borderItem}>
+      West
+    </BorderItem>
+    <BorderItem position="center" className={styles.borderItem}>
+      Center
+    </BorderItem>
+    <BorderItem position="east" className={styles.borderItem}>
+      East
+    </BorderItem>
+    <BorderItem position="south" className={styles.borderItem}>
+      South
+    </BorderItem>
+  </BorderLayout>
+);

--- a/site/src/examples/border-layout/HideRegions.module.css
+++ b/site/src/examples/border-layout/HideRegions.module.css
@@ -1,0 +1,4 @@
+.borderLayout {
+  min-width: 230px;
+  min-height: 200px;
+}

--- a/site/src/examples/border-layout/HideRegions.tsx
+++ b/site/src/examples/border-layout/HideRegions.tsx
@@ -1,0 +1,19 @@
+import { ReactElement } from "react";
+import clsx from "clsx";
+import { BorderLayout, BorderItem } from "@salt-ds/core";
+import styles from "./index.module.css";
+import hideRegionsStyles from "./HideRegions.module.css";
+
+export const HideRegions = (): ReactElement => (
+  <BorderLayout className={hideRegionsStyles.borderLayout}>
+    <BorderItem position="north" className={styles.borderItem}>
+      North
+    </BorderItem>
+    <BorderItem position="west" className={styles.borderItem}>
+      West
+    </BorderItem>
+    <BorderItem position="center" className={styles.borderItem}>
+      Center
+    </BorderItem>
+  </BorderLayout>
+);

--- a/site/src/examples/border-layout/StickyPositioning.module.css
+++ b/site/src/examples/border-layout/StickyPositioning.module.css
@@ -1,0 +1,11 @@
+.borderLayout {
+  height: 200px;
+  width: 260px;
+}
+
+.center {
+  flex-direction: column;
+  overflow: auto;
+  justify-content: unset;
+  text-align: center;
+}

--- a/site/src/examples/border-layout/StickyPositioning.tsx
+++ b/site/src/examples/border-layout/StickyPositioning.tsx
@@ -1,0 +1,36 @@
+import { ReactElement } from "react";
+import clsx from "clsx";
+import { BorderLayout, BorderItem } from "@salt-ds/core";
+import styles from "./index.module.css";
+import stickyPositioningStyles from "./StickyPositioning.module.css";
+
+export const StickyPositioning = (): ReactElement => (
+  <BorderLayout className={stickyPositioningStyles.borderLayout}>
+    <BorderItem position="north" sticky className={styles.borderItem}>
+      North
+    </BorderItem>
+    <BorderItem position="west" className={styles.borderItem}>
+      West
+    </BorderItem>
+    <BorderItem
+      position="center"
+      className={clsx(styles.borderItem, stickyPositioningStyles.center)}
+    >
+      <p>Center</p>
+      <p>
+        Center Dolor ea veniam velit esse ex nulla non anim officia commodo.
+        Exercitation elit exercitation reprehenderit exercitation quis cillum
+        fugiat id ad eu laboris. Amet sint sit elit elit id in do. Do nostrud
+        non excepteur esse. Dolor velit sunt mollit tempor ex Lorem quis amet
+        sit reprehenderit. Ut tempor cupidatat est velit excepteur. Officia
+        voluptate ipsum eiusmod elit. Velit do ipsum officia pariatur cupidatat
+        sint laborum nostrud sit officia tempor nostrud. Aliquip incididunt id
+        ex pariatur. Culpa nisi proident et est tempor incididunt ipsum.
+        Reprehenderit do dolore enim non fugiat culpa quis nisi tempor in.
+        Exercitation adipisicing cupidatat qui officia pariatur magna. Duis et
+        ut ut magna magna sit aute cupidatat. Irure sint excepteur elit eu
+        pariatur ut aliqua sint sunt.
+      </p>
+    </BorderItem>
+  </BorderLayout>
+);

--- a/site/src/examples/border-layout/index.module.css
+++ b/site/src/examples/border-layout/index.module.css
@@ -6,7 +6,6 @@
   align-items: center;
   justify-content: center;
   font-weight: var(--salt-text-fontWeight-small);
-  text-transform: capitalize;
   border: var(--borderLayout-border);
   margin: calc(var(--salt-size-border) * -1) 0 0 calc(var(--salt-size-border) * -1);
 }

--- a/site/src/examples/border-layout/index.module.css
+++ b/site/src/examples/border-layout/index.module.css
@@ -1,0 +1,12 @@
+.borderItem {
+  --borderLayout-border: var(--salt-size-border) var(--salt-container-borderStyle) var(--salt-container-secondary-borderColor);
+
+  padding: var(--salt-spacing-300);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: var(--salt-text-fontWeight-small);
+  text-transform: capitalize;
+  border: var(--borderLayout-border);
+  margin: calc(var(--salt-size-border) * -1) 0 0 calc(var(--salt-size-border) * -1);
+}

--- a/site/src/examples/border-layout/index.module.css
+++ b/site/src/examples/border-layout/index.module.css
@@ -1,11 +1,9 @@
 .borderItem {
-  --borderLayout-border: var(--salt-size-border) var(--salt-container-borderStyle) var(--salt-container-secondary-borderColor);
-
   padding: var(--salt-spacing-300);
   display: flex;
   align-items: center;
   justify-content: center;
   font-weight: var(--salt-text-fontWeight-small);
-  border: var(--borderLayout-border);
+  border: var(--salt-size-border) var(--salt-container-borderStyle) var(--salt-container-secondary-borderColor);
   margin: calc(var(--salt-size-border) * -1) 0 0 calc(var(--salt-size-border) * -1);
 }

--- a/site/src/examples/border-layout/index.ts
+++ b/site/src/examples/border-layout/index.ts
@@ -1,0 +1,6 @@
+export * from "./Default";
+export * from "./CustomRegionSize";
+export * from "./GapBetweenRegions";
+export * from "./HideRegions";
+export * from "./BorderItemPosition";
+export * from "./BorderItemAlignment";

--- a/site/src/examples/border-layout/index.ts
+++ b/site/src/examples/border-layout/index.ts
@@ -4,3 +4,4 @@ export * from "./GapBetweenRegions";
 export * from "./HideRegions";
 export * from "./BorderItemPosition";
 export * from "./BorderItemAlignment";
+export * from "./StickyPositioning";


### PR DESCRIPTION
Adds the `BorderLayout` docs and examples to the site

Preview at: https://saltdesignsystem-git-border-layout-docs-fed-team.vercel.app/salt/components/border-layout/examples

