### PR TITLE
Excludes component tab pages from sidebar

### DIFF
--- a/site/docs/components/button/accessibility.mdx
+++ b/site/docs/components/button/accessibility.mdx
@@ -2,7 +2,7 @@
 title: Button
 layout: DetailComponent
 sidebar:
-  label: Accessibility
+  exclude: true
 data:
   $ref: ./#/data
 ---

--- a/site/docs/components/button/examples.mdx
+++ b/site/docs/components/button/examples.mdx
@@ -2,7 +2,7 @@
 title: Button
 layout: DetailComponent
 sidebar:
-  label: Examples
+  exclude: true
 data:
   $ref: ./#/data
 ---

--- a/site/docs/components/button/usage.mdx
+++ b/site/docs/components/button/usage.mdx
@@ -2,7 +2,7 @@
 title: Button
 layout: DetailComponent
 sidebar:
-  label: How to use
+  exclude: true
 data:
   $ref: ./#/data
 ---

--- a/site/docs/components/progress/accessibility.mdx
+++ b/site/docs/components/progress/accessibility.mdx
@@ -4,7 +4,7 @@ title:
   $ref: ./#/title
 layout: DetailComponent
 sidebar:
-  label: Accessibility
+  exclude: true
 data:
   $ref: ./#/data
 ---

--- a/site/docs/components/progress/examples.mdx
+++ b/site/docs/components/progress/examples.mdx
@@ -4,7 +4,7 @@ title:
   $ref: ./#/title
 layout: DetailComponent
 sidebar:
-  label: Examples
+  exclude: true
 data:
   $ref: ./#/data
 ---

--- a/site/docs/components/progress/usage.mdx
+++ b/site/docs/components/progress/usage.mdx
@@ -4,7 +4,7 @@ title:
   $ref: ./#/title
 layout: DetailComponent
 sidebar:
-  label: Usage
+  exclude: true
 data:
   $ref: ./#/data
 ---

--- a/templates/component-pages/component-name/accessibility.mdx
+++ b/templates/component-pages/component-name/accessibility.mdx
@@ -4,7 +4,7 @@ title:
   $ref: ./#/title
 layout: DetailComponent
 sidebar:
-  label: Accessibility
+  exclude: true
 data:
   $ref: ./#/data
 ---

--- a/templates/component-pages/component-name/examples.mdx
+++ b/templates/component-pages/component-name/examples.mdx
@@ -4,7 +4,7 @@ title:
   $ref: ./#/title
 layout: DetailComponent
 sidebar:
-  label: Examples
+  exclude: true
 data:
   $ref: ./#/data
 ---

--- a/templates/component-pages/component-name/usage.mdx
+++ b/templates/component-pages/component-name/usage.mdx
@@ -4,7 +4,7 @@ title:
   $ref: ./#/title
 layout: DetailComponent
 sidebar:
-  label: Usage
+  exclude: true
 data:
   $ref: ./#/data
 ---


### PR DESCRIPTION
Updates the pre-existing component pages and template MDX files, to prevent the per-tab sub-pages from appearing in the left-hand nav.

Note: The left hand nav may appear blank on fresh page loads. This is due to a Mosaic bug, for which a fix has been prepared.