### PR TITLE
Fix examples code preview on the site docs

### DIFF
--- a/site/next.config.js
+++ b/site/next.config.js
@@ -61,8 +61,6 @@ module.exports = {
       config.resolve.fallback = { fs: false };
     }
 
-    config.optimization.minimize = false;
-
     return config;
   },
   env: {},

--- a/site/package.json
+++ b/site/package.json
@@ -36,7 +36,8 @@
     "@philpl/buble": "^0.19.7",
     "@types/react": "^18.0.26",
     "next": "^13.3.0",
-    "next-auth": "^4.20.1"
+    "next-auth": "^4.20.1",
+    "raw-loader": "^4.0.2"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "13.4.7",
@@ -47,7 +48,6 @@
     "eslint-config-next": "^13.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-element-to-jsx-string": "^15.0.0",
     "react-markdown": "^8.0.7"
   }
 }

--- a/site/src/components/components/LivePreview.tsx
+++ b/site/src/components/components/LivePreview.tsx
@@ -1,5 +1,4 @@
 import { FC, ChangeEvent, useState, ReactNode, ReactElement } from "react";
-import reactElementToJSXString from "react-element-to-jsx-string";
 import clsx from "clsx";
 import { Switch } from "@salt-ds/lab";
 import { SaltProvider } from "@salt-ds/core";
@@ -38,7 +37,8 @@ export const LivePreview: FC<LivePreviewProps> = ({
   const ComponentExample: () => ReactElement =
     require(`../../examples/${componentName}`)[exampleName];
 
-  const exampleJSX = ComponentExample && ComponentExample();
+  const codePreview =
+    require(`!!raw-loader!../../examples/${componentName}/${exampleName}.tsx`).default;
 
   const {
     density,
@@ -92,11 +92,7 @@ export const LivePreview: FC<LivePreviewProps> = ({
 
         {showCode && (
           <Pre className={styles.codePreview}>
-            <div className="language-tsx">
-              {reactElementToJSXString(exampleJSX, {
-                showFunctions: true,
-              })}
-            </div>
+            <div className="language-tsx">{codePreview}</div>
           </Pre>
         )}
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5134,9 +5134,9 @@ __metadata:
     eslint-config-next: ^13.0.0
     next: ^13.3.0
     next-auth: ^4.20.1
+    raw-loader: ^4.0.2
     react: ^18.2.0
     react-dom: ^18.2.0
-    react-element-to-jsx-string: ^15.0.0
     react-markdown: ^8.0.7
   languageName: unknown
   linkType: soft
@@ -26529,20 +26529,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-element-to-jsx-string@npm:^15.0.0":
-  version: 15.0.0
-  resolution: "react-element-to-jsx-string@npm:15.0.0"
-  dependencies:
-    "@base2/pretty-print-object": 1.0.1
-    is-plain-object: 5.0.0
-    react-is: 18.1.0
-  peerDependencies:
-    react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
-    react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
-  checksum: c3907cc4c1d3e9ecc8ca7727058ebcba6ec89848d9e07bfd2c77ee8f28f1ad99bf55e38359dec8a1125de83d41ac09a2874f53c41415edc86ffa9840fa1b7856
-  languageName: node
-  linkType: hard
-
 "react-error-boundary@npm:^3.1.4":
   version: 3.1.4
   resolution: "react-error-boundary@npm:3.1.4"
@@ -26620,13 +26606,6 @@ __metadata:
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 9d6d111d8990dc98bc5402c1266a808b0459b5d54830bbea24c12d908b536df7883f268a7868cfaedde3dd9d4e0d574db456f84d2e6df9c4526f99bb4b5344d8
-  languageName: node
-  linkType: hard
-
-"react-is@npm:18.1.0":
-  version: 18.1.0
-  resolution: "react-is@npm:18.1.0"
-  checksum: d206a0fe6790851bff168727bfb896de02c5591695afb0c441163e8630136a3e13ee1a7ddd59fdccddcc93968b4721ae112c10f790b194b03b35a3dc13a355ef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Replace `reactElementToJSXString` with webpack's `raw-loader` which will render the whole example file as a string (not just the output)
- Enable webpack's optimisation on the site
- Preview at https://saltdesignsystem-git-replace-react-element-to-jsx-fed-team.vercel.app/salt/components/accordion/examples (any component)