### PR TITLE
Add a color prop to Icon

### DIFF
--- a/.changeset/bright-tips-tell.md
+++ b/.changeset/bright-tips-tell.md
@@ -4,10 +4,11 @@
 
 Add a `color` prop to Icon.
 
-This can be used to specify the color used by Icon and supports: primary, secondary and inherit. The default value is secondary.
+This can be used to specify the color used by Icon and supports: primary, secondary and inherit. The default value is "inherit".
 
 ```tsx
 <HomeIcon color="primary" />
 <UserIcon color="secondary" />
 <CloseIcon color="inherit" />
 ```
+*Note:* This changes the default icon color from secondary to primary due to it inheriting the default text style. The previous default of secondary was an error.

--- a/.changeset/bright-tips-tell.md
+++ b/.changeset/bright-tips-tell.md
@@ -1,0 +1,13 @@
+---
+"@salt-ds/icons": minor
+---
+
+Add a `color` prop to Icon.
+
+This can be used to specify the color used by Icon and supports: primary, secondary and inherit. The default value is secondary.
+
+```tsx
+<HomeIcon color="primary" />
+<UserIcon color="secondary" />
+<CloseIcon color="inherit" />
+```

--- a/.changeset/bright-tips-tell.md
+++ b/.changeset/bright-tips-tell.md
@@ -11,4 +11,5 @@ This can be used to specify the color used by Icon and supports: primary, second
 <UserIcon color="secondary" />
 <CloseIcon color="inherit" />
 ```
-*Note:* This changes the default icon color from secondary to primary due to it inheriting the default text style. The previous default of secondary was an error.
+
+_Note:_ This changes the default icon color from secondary to primary due to it inheriting the default text style. The previous default of secondary was an error.

--- a/packages/icons/src/icon/Icon.css
+++ b/packages/icons/src/icon/Icon.css
@@ -1,6 +1,6 @@
 /* Style applied to the root element */
 .saltIcon {
-  --icon-color: var(--saltIcon-color, var(--salt-text-secondary-foreground));
+  --icon-color: currentColor;
   --icon-size-multiplier: var(--saltIcon-size-multiplier, 1);
   --icon-base-size: var(--salt-icon-size-base, 12px);
   /**
@@ -22,10 +22,10 @@
   min-height: var(--icon-size);
 }
 
-.saltIcon:hover {
-  --icon-color: var(--saltIcon-color-hover, var(--salt-text-secondary-foreground));
+.saltIcon-primary {
+  --icon-color: var(--salt-text-primary-foreground);
 }
 
-.saltIcon:active {
-  --icon-color: var(--saltIcon-color-active, var(--salt-text-secondary-foreground));
+.saltIcon-secondary {
+  --icon-color: var(--salt-text-secondary-foreground);
 }

--- a/packages/icons/src/icon/Icon.tsx
+++ b/packages/icons/src/icon/Icon.tsx
@@ -14,6 +14,10 @@ export const makePrefixer =
 const withBaseName = makePrefixer("saltIcon");
 
 export interface IconProps extends SVGAttributes<SVGSVGElement> {
+  /*
+   * The color of the icon. Defaults to "secondary".
+   */
+  color?: "inherit" | "primary" | "secondary";
   /**
    * Multiplier for the base icon size. Should be a positive integer to conform to the rest of the design system.
    */
@@ -23,7 +27,14 @@ export interface IconProps extends SVGAttributes<SVGSVGElement> {
 export const DEFAULT_ICON_SIZE = 1;
 
 export const Icon = forwardRef<SVGSVGElement, IconProps>(function Icon(
-  { children, className, size = DEFAULT_ICON_SIZE, style: styleProp, ...rest },
+  {
+    children,
+    className,
+    color = "inherit",
+    size = DEFAULT_ICON_SIZE,
+    style: styleProp,
+    ...rest
+  },
   ref
 ) {
   const targetWindow = useWindow();
@@ -40,7 +51,11 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>(function Icon(
 
   return (
     <svg
-      className={clsx(withBaseName(), className)}
+      className={clsx(
+        withBaseName(),
+        { [withBaseName(color)]: color !== "inherit" },
+        className
+      )}
       style={style}
       role="img"
       {...rest}

--- a/packages/icons/src/icon/Icon.tsx
+++ b/packages/icons/src/icon/Icon.tsx
@@ -15,7 +15,7 @@ const withBaseName = makePrefixer("saltIcon");
 
 export interface IconProps extends SVGAttributes<SVGSVGElement> {
   /*
-   * The color of the icon. Defaults to "secondary".
+   * The color of the icon. Defaults to "inherit".
    */
   color?: "inherit" | "primary" | "secondary";
   /**

--- a/site/docs/components/icon/examples.mdx
+++ b/site/docs/components/icon/examples.mdx
@@ -29,8 +29,8 @@ data:
   </LivePreview>
   <LivePreview componentName="icon" exampleName="IconColor">
     ### Icon Color
-
-    To override the default color of the icon, use the `--saltIcon-color` CSS variable. This could be necessary to match primary or secondary text. You can find appropriate color variables in the [Typography Foundation](/salt/foundations/typography#color)
+    
+    To override the default color of the icon, use the `color` prop. This allows you to set the color to `primary`, `secondary` or `inherit`.
 
   </LivePreview>
   <LivePreview componentName="icon" exampleName="CustomIcon">

--- a/site/src/examples/icon/IconColor.tsx
+++ b/site/src/examples/icon/IconColor.tsx
@@ -1,13 +1,11 @@
-import { CSSProperties, ReactElement } from "react";
+import { ReactElement } from "react";
 import { AddDocumentIcon } from "@salt-ds/icons";
+import { StackLayout } from "@salt-ds/core";
 
 export const IconColor = (): ReactElement => (
-  <AddDocumentIcon
-    style={
-      {
-        "--saltIcon-color": "var(--salt-status-info-foreground)",
-      } as CSSProperties
-    }
-    size={2}
-  />
+  <StackLayout>
+    <AddDocumentIcon color="inherit" size={2} />
+    <AddDocumentIcon color="primary" size={2} />
+    <AddDocumentIcon color="secondary" size={2} />
+  </StackLayout>
 );


### PR DESCRIPTION
This PR adds a color prop to Icon that supports: primary, secondary and inherit.

There should be another PR to align Text. 

But the reason for this change is to make working with Icon a lot easier, usually Icon will always following the text colour used and currently we have to be very explicit when trying to achieve this. Changing Icon to inherit the text colour by default would reduce a lot of extra code and improve compatibility with the UITK button