### PR TITLE
fix bug in GridLayout where columnGap and rowGap couldn't be zero

### DIFF
--- a/.changeset/sour-fireants-crash.md
+++ b/.changeset/sour-fireants-crash.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Fixed bug in GridLayout where `columnGap` and `rowGap` couldn't be set to zero

--- a/packages/core/src/grid-layout/GridLayout.tsx
+++ b/packages/core/src/grid-layout/GridLayout.tsx
@@ -84,8 +84,8 @@ export const GridLayout: GridLayoutComponent = forwardRef(
       ...style,
       "--gridLayout-columns": gridColumns,
       "--gridLayout-rows": gridRows,
-      "--gridLayout-columnGap": gridColumnGap || gridGap,
-      "--gridLayout-rowGap": gridRowGap || gridGap,
+      "--gridLayout-columnGap": gridColumnGap ?? gridGap,
+      "--gridLayout-rowGap": gridRowGap ?? gridGap,
     };
 
     return (


### PR DESCRIPTION
Fixing bug in GridLayout where columnGap/rowGap couldn't be set to zero, as logic was determining zero as falsey causing the default (non-zero) value to be used