### PR TITLE
Fix FormField adds extra "padding" below the input

### DIFF
--- a/.changeset/young-timers-explain.md
+++ b/.changeset/young-timers-explain.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Fixes extra padding below a control in Form Field when no helper text provided

--- a/packages/core/src/form-field/FormField.css
+++ b/packages/core/src/form-field/FormField.css
@@ -19,18 +19,16 @@
 .saltFormField-labelLeft {
   align-self: center;
   grid-template-columns: var(--formField-label-width, 40%) 1fr;
-  grid-template-areas:
-    "label controls";
+  grid-template-areas: "label controls";
 }
 
 .saltFormField-labelRight {
   align-self: center;
   grid-template-columns: var(--formField-label-width, 40%) 1fr;
-  grid-template-areas:
-    "label controls";
+  grid-template-areas: "label controls";
 }
 
-.saltFormField-labelLeft .saltFormFieldHelperText, 
+.saltFormField-labelLeft .saltFormFieldHelperText,
 .saltFormField-labelRight .saltFormFieldHelperText {
   grid-area: 2 / 2;
 }

--- a/packages/core/src/form-field/FormField.css
+++ b/packages/core/src/form-field/FormField.css
@@ -9,24 +9,30 @@
 .saltFormField-labelTop {
   grid-template-areas:
     "label"
-    "controls"
-    "helperText";
+    "controls";
+}
+
+.saltFormField-labelTop .saltFormFieldHelperText {
+  grid-area: 3 / 1;
 }
 
 .saltFormField-labelLeft {
   align-self: center;
   grid-template-columns: var(--formField-label-width, 40%) 1fr;
   grid-template-areas:
-    "label controls"
-    "auto helperText";
+    "label controls";
 }
 
 .saltFormField-labelRight {
   align-self: center;
   grid-template-columns: var(--formField-label-width, 40%) 1fr;
   grid-template-areas:
-    "label controls"
-    "auto helperText";
+    "label controls";
+}
+
+.saltFormField-labelLeft .saltFormFieldHelperText, 
+.saltFormField-labelRight .saltFormFieldHelperText {
+  grid-area: 2 / 2;
 }
 
 .saltFormField-labelRight .saltFormFieldLabel,


### PR DESCRIPTION
closes #2497

ideally would use :has selector instead

Note that the same would apply above if no label is provided. I've only added the fix for helper text. I don't see why a label wouldn't be provided, the control would probably just be used itself in that case?