### PR TITLE
[SaltProvider] Add defaultViewport prop

### DIFF
--- a/packages/core/src/salt-provider/SaltProvider.tsx
+++ b/packages/core/src/salt-provider/SaltProvider.tsx
@@ -10,7 +10,7 @@ import React, {
 import { AriaAnnouncerProvider } from "../aria-announcer";
 import { Breakpoints, DEFAULT_BREAKPOINTS } from "../breakpoints";
 import { Density, Mode, ThemeName } from "../theme";
-import { ViewportProvider } from "../viewport";
+import { ViewportProvider, ViewportProviderProps } from "../viewport";
 import { useIsomorphicLayoutEffect } from "../utils";
 
 import saltProviderCss from "./SaltProvider.css";
@@ -94,7 +94,7 @@ type SaltProviderBaseProps = {
   theme?: ThemeName;
   mode?: Mode;
   breakpoints?: Breakpoints;
-};
+} & Pick<ViewportProviderProps, "defaultViewport">;
 
 interface SaltProviderThatAppliesClassesToChild extends SaltProviderBaseProps {
   children: ReactElement;
@@ -122,6 +122,7 @@ export function SaltProvider({
   theme: themeProp,
   mode: modeProp,
   breakpoints: breakpointsProp,
+  defaultViewport,
 }: SaltProviderProps) {
   const inheritedDensity = useContext(DensityContext);
   const { theme: inheritedThemes, mode: inheritedMode } = useTheme();
@@ -191,7 +192,9 @@ export function SaltProvider({
     <DensityContext.Provider value={density}>
       <ThemeContext.Provider value={themeContextValue}>
         <BreakpointContext.Provider value={breakpoints}>
-          <ViewportProvider>{themedChildren}</ViewportProvider>
+          <ViewportProvider defaultViewport={defaultViewport}>
+            {themedChildren}
+          </ViewportProvider>
         </BreakpointContext.Provider>
       </ThemeContext.Provider>
     </DensityContext.Provider>

--- a/packages/core/src/viewport/ViewportProvider.tsx
+++ b/packages/core/src/viewport/ViewportProvider.tsx
@@ -3,14 +3,22 @@ import { useIsomorphicLayoutEffect } from "../utils";
 
 const ViewportContext = createContext<number | null>(null);
 
-type ViewportProviderProps = {
+export type ViewportProviderProps = {
   children?: ReactNode;
+  /*
+    Set the default value that will be used on initial render.
+    This is mainly intended for use of responsive props in server-side rendering
+  */
+  defaultViewport?: number;
 };
 
-const ViewportProvider = ({ children }: ViewportProviderProps) => {
+const ViewportProvider = ({
+  children,
+  defaultViewport,
+}: ViewportProviderProps) => {
   // Get value directly from the ViewportContext so we can detect if the value is null (no inherited ViewportProvider)
   const existingViewport = useContext(ViewportContext);
-  const [viewport, setViewport] = useState(existingViewport);
+  const [viewport, setViewport] = useState(existingViewport || defaultViewport);
 
   const noExistingViewport = existingViewport === null;
   const viewportValue = existingViewport || viewport || 0;


### PR DESCRIPTION
## Problem
Currently, the layout components offer responsive props as a useful feature which in turn use useViewport to determine which responsive prop to apply. The viewport is set dynamically after first render in the browser by measuring the window size, and the default value is 0. This default value causes a flash of different layout when server-side rendering on anything larger than the smallest mobile screen.

To support ssr I added a defaultViewport value which can be set on the server using either client hints or by parsing the user agent and naively setting the value based on the device. There is a way to do it as a user but it is not ideal.

## Alternative
There is a way to do this as a user by importing the ViewportContext and setting the value yourself however, you must remember to set it back to null on first render otherwise the viewport will always be the set to your initial value because ViewportProvider inherits from itself. And it has to be null specifically, not undefined.

Here is how I did it in my project.

```
import { useState, useEffect } from 'react';
import { ViewportContext } from '@salt-ds/core';

export function MyViewportProvider({
  children,
  defaultViewport
}: {
  children: React.ReactNode;
  defaultViewport?: number;
}) {
  const [value, setValue] = useState(defaultViewport);
  useEffect(() => {
    setFirstRender(null);
  }, []);

  return (
    <ViewportContext.Provider value={value}>
      {children}
    </ViewportContext.Provider>
  );
}
```