### PR TITLE
Add deployments permission to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  deployments: write
   pull-requests: write
   id-token: write
 


### PR DESCRIPTION
Trying to fix... 
Storybook deployment has failed several times: https://github.com/jpmorganchase/salt-ds/actions/runs/6383223367/job/17323441709