### PR TITLE
Publish Storybook on every commit on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,10 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
 
       - name: Run Storybook build
-        if: steps.changesets.outputs.published == 'true'
         run: yarn build-storybook
         env:
           NODE_OPTIONS: "--max_old_space_size=6144"
       - name: Publish Storybook
-        if: steps.changesets.outputs.published == 'true'
         uses: cloudflare/pages-action@v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_SALT_API_TOKEN }}


### PR DESCRIPTION
There are changes not appearing on storybook (e.g. https://github.com/jpmorganchase/salt-ds/issues/2546#issuecomment-1746647636), we're publishing site on every main commit, doing same for storybook. Can revert back when things are stable.