### PR TITLE
Dropdown / Combobox renders behind Dialog

### DIFF
--- a/packages/lab/src/combo-box-next/ComboBoxNext.css
+++ b/packages/lab/src/combo-box-next/ComboBoxNext.css
@@ -10,5 +10,5 @@
   border-color: var(--salt-selectable-borderColor-selected);
   box-shadow: var(--salt-overlayable-shadow-popout);
   max-height: calc((var(--salt-size-base) + var(--salt-spacing-100)) * var(--comboBoxNext-itemCount, 5));
-  z-index: calc(var(--salt-zIndex-appHeader) - 1);
+  z-index: calc(var(--salt-zIndex-modal) + 1);
 }

--- a/packages/lab/src/dropdown-next/DropdownNext.css
+++ b/packages/lab/src/dropdown-next/DropdownNext.css
@@ -48,7 +48,7 @@
   border-color: var(--salt-selectable-borderColor-selected);
   box-shadow: var(--salt-overlayable-shadow-popout);
   max-height: calc((var(--salt-size-base) + var(--salt-spacing-100)) * 5);
-  z-index: calc(var(--salt-zIndex-appHeader) - 1);
+  z-index: calc(var(--salt-zIndex-modal) + 1);
 }
 
 /* Styling applied to dropdown button if `disabled={true}` */


### PR DESCRIPTION
Both Dialog and ComboboxNext / DropdownNext use floating-ui Portal therefore they are competing for z-index and Dialog is using a higher z-index.  https://github.com/jpmorganchase/salt-ds/issues/2495

Change makes the ComboboxNext / DropdownNext z-index greater than the Dialog.
If a user opens dropdown / combobox and then a dialog, it would be considered a click away and therefore closing the dropdown or combobox avoiding the unwanted scenario where a dropdown / combobox in the background takes precedence over a dialog.
Alternatively the z-index of Dialog could be decreased, but i thought the above method made more sense.


