### PR TITLE
Fix `useId`, `useInsertionEffect` not found error when used by webpack

### DIFF
--- a/.changeset/itchy-kids-tell.md
+++ b/.changeset/itchy-kids-tell.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/styles": patch
+---
+
+Fix `useInsertionEffect` not found error bundled by Webpack

--- a/.changeset/stupid-tools-sing.md
+++ b/.changeset/stupid-tools-sing.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Fix `useId` not found error bundled by Webpack

--- a/packages/core/src/utils/useId.ts
+++ b/packages/core/src/utils/useId.ts
@@ -1,8 +1,10 @@
 import * as React from "react";
 
-// eslint-disable-next-line -- Workaround for https://github.com/webpack/webpack/issues/14814
+// Workaround for https://github.com/webpack/webpack/issues/14814#issuecomment-1536757985
+// Without `toString()`, downstream library using webpack to re-bundle will error
+// eslint-disable-next-line
 const maybeReactUseId: undefined | (() => string) = (React as any)[
-  `${"useId"}${""}`
+  "useId".toString()
 ];
 
 let globalId = BigInt(0);

--- a/packages/styles/src/use-style-injection/useStyleInjection.ts
+++ b/packages/styles/src/use-style-injection/useStyleInjection.ts
@@ -1,9 +1,9 @@
 import * as React from "react";
 import { useInsertionPoint } from "./InsertionPointProvider";
 
-/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment -- Workaround for https://github.com/webpack/webpack/issues/14814 */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any -- Workaround for https://github.com/webpack/webpack/issues/14814#issuecomment-1536757985 */
 const maybeUseInsertionEffect: typeof React.useLayoutEffect =
-  (React as any)[`${"useInsertionEffect"}${""}`] ?? React.useLayoutEffect;
+  (React as any)["useInsertionEffect".toString()] ?? React.useLayoutEffect;
 /* eslint-enable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
 
 export interface UseComponentCssInjection {


### PR DESCRIPTION
Fixes #2567

Issue raised when app is using a library re-bundling Salt.

- Reference https://github.com/webpack/webpack/issues/14814#issuecomment-1536757985

- [x] Apply same fix to `useInsertionEffect` 

Thanks to @DavieReid suggesting the fix


----

Tested [snapshot release](https://github.com/jpmorganchase/salt-ds/pull/2561#issuecomment-1750756560) with CTA@5 & React@17