### PR TITLE
Ag grid theme update hd compact story

### DIFF
--- a/packages/ag-grid-theme/stories/ag-grid.doc.stories.mdx
+++ b/packages/ag-grid-theme/stories/ag-grid.doc.stories.mdx
@@ -146,10 +146,15 @@ There are three variants of the Salt ag-grid theme: `Primary` (default), `Second
 The class names are:
 
 - `ag-theme-salt-variant-secondary`
+
+<Canvas>
+  <Story id="data-grid-ag-grid-theme--variant-secondary" />
+</Canvas>
+
 - `ag-theme-salt-variant-zebra`
 
 <Canvas>
-  <Story id="data-grid-ag-grid-theme--variants" />
+  <Story id="data-grid-ag-grid-theme--variant-zebra" />
 </Canvas>
 
 #### Checkbox Selection

--- a/packages/ag-grid-theme/stories/ag-grid.stories.tsx
+++ b/packages/ag-grid-theme/stories/ag-grid.stories.tsx
@@ -22,6 +22,7 @@ export {
   Icons,
   FloatingFilter,
   HDCompact,
+  HDCompactDark,
   InfiniteScroll,
   LoadingOverlay,
   MasterDetail,

--- a/packages/ag-grid-theme/stories/dependencies/useAgGridHelpers.ts
+++ b/packages/ag-grid-theme/stories/dependencies/useAgGridHelpers.ts
@@ -61,14 +61,14 @@ export function useAgGridHelpers(
 
   useEffect(() => {
     // setHeaderHeight doesn't work if not in setTimeout
-    requestAnimationFrame(() => {
+    setTimeout(() => {
       if (isGridReady) {
         apiRef.current!.api.resetRowHeights();
         apiRef.current!.api.setHeaderHeight(rowHeight);
         apiRef.current!.api.setFloatingFiltersHeight(rowHeight);
         // TODO how to set listItemHeight as the "ag-filter-virtual-list-item" height? Issue 2479
       }
-    });
+    }, 0);
   }, [rowHeight, isGridReady, agThemeName, listItemHeight]);
 
   return {

--- a/packages/ag-grid-theme/stories/dependencies/useAgGridHelpers.ts
+++ b/packages/ag-grid-theme/stories/dependencies/useAgGridHelpers.ts
@@ -6,12 +6,20 @@ import { LicenseManager } from "ag-grid-enterprise";
 
 LicenseManager.setLicenseKey("your license key");
 
+interface AgGridHelpersProps {
+  agThemeName: string;
+  compact?: boolean;
+  mode?: string;
+  density?: string;
+}
+
 // Helps to set className, rowHeight and headerHeight depending on the current density
-export function useAgGridHelpers(
+export function useAgGridHelpers({
   agThemeName = "ag-theme-uitk",
   compact = false,
-  mode?: string
-): {
+  mode: modeProp,
+  density: densityProp,
+}: AgGridHelpersProps): {
   containerProps: HTMLAttributes<HTMLDivElement>;
   agGridProps: AgGridReactProps;
   isGridReady: boolean;
@@ -21,8 +29,11 @@ export function useAgGridHelpers(
 } {
   const apiRef = useRef<{ api: GridApi; columnApi: ColumnApi }>();
   const [isGridReady, setGridReady] = useState(false);
-  const density = useDensity();
+  const contextDensity = useDensity();
   const { mode: contextMode } = useTheme();
+
+  const mode = modeProp ?? contextMode;
+  const density = densityProp ?? contextDensity;
 
   const [rowHeight, listItemHeight] = useMemo(() => {
     switch ([agThemeName, density].join("-")) {
@@ -51,7 +62,7 @@ export function useAgGridHelpers(
 
   const className = `${agThemeName}-${density}${
     compact && density === "high" ? `-compact` : ``
-  }-${mode ?? contextMode}`;
+  }-${mode}`;
 
   const onGridReady = ({ api, columnApi }: GridReadyEvent) => {
     apiRef.current = { api, columnApi };

--- a/packages/ag-grid-theme/stories/examples/CheckboxSelection.tsx
+++ b/packages/ag-grid-theme/stories/examples/CheckboxSelection.tsx
@@ -7,9 +7,9 @@ import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 
 const CheckboxSelection = (props: AgGridReactProps) => {
   const { switcher, themeName } = useAgGridThemeSwitcher();
-  const { agGridProps, containerProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+  });
 
   return (
     <StackLayout gap={4}>

--- a/packages/ag-grid-theme/stories/examples/Coloration.tsx
+++ b/packages/ag-grid-theme/stories/examples/Coloration.tsx
@@ -7,9 +7,9 @@ import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 
 const Coloration = (props: AgGridReactProps) => {
   const { themeName, switcher } = useAgGridThemeSwitcher();
-  const { containerProps, agGridProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+  });
 
   return (
     <StackLayout gap={4}>

--- a/packages/ag-grid-theme/stories/examples/ColumnGroup.tsx
+++ b/packages/ag-grid-theme/stories/examples/ColumnGroup.tsx
@@ -1,16 +1,15 @@
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
 import { StackLayout } from "@salt-ds/core";
 import dataGridExampleData from "../dependencies/dataGridExampleData";
-import dataGridExampleColumns from "../dependencies/dataGridExampleColumns";
 import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 import { ColDef, ColGroupDef } from "ag-grid-community";
 
 const ColumnGroup = (props: AgGridReactProps) => {
   const { themeName, switcher } = useAgGridThemeSwitcher();
-  const { containerProps, agGridProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+  });
 
   return (
     <StackLayout gap={4}>

--- a/packages/ag-grid-theme/stories/examples/ColumnSpanning.tsx
+++ b/packages/ag-grid-theme/stories/examples/ColumnSpanning.tsx
@@ -7,9 +7,9 @@ import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 
 const ColumnSpanning = (props: AgGridReactProps) => {
   const { themeName, switcher } = useAgGridThemeSwitcher();
-  const { containerProps, agGridProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+  });
 
   return (
     <StackLayout gap={4}>

--- a/packages/ag-grid-theme/stories/examples/ContextMenu.tsx
+++ b/packages/ag-grid-theme/stories/examples/ContextMenu.tsx
@@ -10,15 +10,17 @@ import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 
 const ContextMenu = (props: AgGridReactProps) => {
   const { themeName, switcher } = useAgGridThemeSwitcher();
-  const { containerProps, agGridProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+  });
 
   const getContextMenuItems = (params: GetContextMenuItemsParams) => {
     const result = [
       {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         name: `Alert ${params.value}`,
         action() {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           window.alert(`Alerting about ${params.value}`);
         },
         cssClasses: ["redFont", "bold"],

--- a/packages/ag-grid-theme/stories/examples/CustomFilter.tsx
+++ b/packages/ag-grid-theme/stories/examples/CustomFilter.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Button, FlowLayout, StackLayout } from "@salt-ds/core";
-import { Switch } from "@salt-ds/lab";
 import dataGridExampleData from "../dependencies/dataGridExampleData";
 import customFilterExampleColumns from "../dependencies/customFilterExampleColumns";
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
@@ -12,15 +11,15 @@ const CustomFilter = (props: AgGridReactProps) => {
   const { switcher, themeName } = useAgGridThemeSwitcher();
 
   const [hasSavedState, setHasSavedState] = useState(true);
-  const { api, isGridReady, agGridProps, containerProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`
-  );
+  const { api, isGridReady, agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+  });
 
   useEffect(() => {
     if (isGridReady) {
       api?.sizeColumnsToFit();
     }
-  }, [isGridReady]);
+  }, [api, isGridReady]);
 
   const handlePopMt100kClick = () => {
     const popMt100kComponent = api!.getFilterInstance("population")!;
@@ -63,11 +62,13 @@ const CustomFilter = (props: AgGridReactProps) => {
   };
 
   const saveState = () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
     (window as any).filterState = api!.getFilterModel();
     setHasSavedState(false);
   };
 
   const restoreState = () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
     api!.setFilterModel((window as any).filterState);
     setHasSavedState(true);
   };

--- a/packages/ag-grid-theme/stories/examples/Default.tsx
+++ b/packages/ag-grid-theme/stories/examples/Default.tsx
@@ -6,9 +6,9 @@ import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 
 const Default = (props: AgGridReactProps) => {
   const { themeName, switcher } = useAgGridThemeSwitcher();
-  const { containerProps, agGridProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+  });
 
   return (
     <StackLayout gap={4}>

--- a/packages/ag-grid-theme/stories/examples/DragRowOrder.tsx
+++ b/packages/ag-grid-theme/stories/examples/DragRowOrder.tsx
@@ -7,9 +7,9 @@ import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 
 const DragRowOrder = (props: AgGridReactProps) => {
   const { switcher, themeName } = useAgGridThemeSwitcher();
-  const { agGridProps, containerProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+  });
 
   return (
     <StackLayout gap={4}>

--- a/packages/ag-grid-theme/stories/examples/FloatingFilter.tsx
+++ b/packages/ag-grid-theme/stories/examples/FloatingFilter.tsx
@@ -7,9 +7,9 @@ import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 
 const FloatingFilter = (props: AgGridReactProps) => {
   const { switcher, themeName } = useAgGridThemeSwitcher();
-  const { agGridProps, containerProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+  });
 
   return (
     <StackLayout gap={4}>

--- a/packages/ag-grid-theme/stories/examples/HDCompact.tsx
+++ b/packages/ag-grid-theme/stories/examples/HDCompact.tsx
@@ -1,13 +1,5 @@
-import { ChangeEvent, useEffect, useState } from "react";
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
-import {
-  StackLayout,
-  FlexItem,
-  FlexLayout,
-  Checkbox,
-  useDensity,
-  useTheme,
-} from "@salt-ds/core";
+import { FlexLayout, SaltProvider, StackLayout } from "@salt-ds/core";
 import dataGridExampleColumns from "../dependencies/dataGridExampleColumns";
 import dataGridExampleData from "../dependencies/dataGridExampleData";
 import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
@@ -25,85 +17,30 @@ const statusBar = {
   ],
 };
 
-const getThemeNames = () => {
-  const densities = ["touch", "low", "medium", "high", "high-compact"];
-  const themes: string[] = [];
-
-  densities.forEach((density) => {
-    themes.push(`ag-theme-salt-${density}-light`);
-    themes.push(`ag-theme-salt-${density}-dark`);
-  });
-
-  return themes;
-};
-
 const HDCompact = (props: AgGridReactProps) => {
-  const [compact, setCompact] = useState(false);
   const { switcher, themeName } = useAgGridThemeSwitcher();
-  const { mode } = useTheme();
-  const { api, agGridProps, containerProps, isGridReady } = useAgGridHelpers(
+  const { agGridProps, containerProps } = useAgGridHelpers(
     `ag-theme-${themeName}`,
-    compact
+    true
   );
 
-  useEffect(() => {
-    if (isGridReady) {
-      api?.sizeColumnsToFit();
-    }
-  }, [isGridReady]);
-
-  const density = useDensity();
-
-  useEffect(() => {
-    const gridRoot = document.querySelector<HTMLElement>(`.ag-salt-theme`);
-
-    if (compact) {
-      getThemeNames().forEach((theme) =>
-        gridRoot?.classList.toggle(
-          theme,
-          theme.includes(`${density}-compact`) && theme.includes(mode)
-        )
-      );
-    } else {
-      getThemeNames().forEach((theme) =>
-        gridRoot?.classList.toggle(
-          theme,
-          theme.includes(density) && theme.includes(mode)
-        )
-      );
-    }
-  }, [density, mode]);
-
-  const handleCompactChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setCompact(event.target.checked);
-  };
-
   return (
-    <StackLayout gap={4}>
-      <FlexLayout direction="row">
-        {switcher}
-        <FlexItem>
-          <Checkbox
-            checked={compact && density === "high"}
-            label="Compact (for high density only)"
-            onChange={handleCompactChange}
-            disabled={density !== "high"}
+    <SaltProvider density="high">
+      <StackLayout gap={4}>
+        <FlexLayout direction="row">{switcher}</FlexLayout>
+        <div {...containerProps}>
+          <AgGridReact
+            columnDefs={dataGridExampleColumns}
+            rowData={dataGridExampleData}
+            statusBar={statusBar}
+            rowSelection="multiple"
+            {...agGridProps}
+            {...props}
+            enableRangeSelection={true}
           />
-        </FlexItem>
-      </FlexLayout>
-      <div {...containerProps}>
-        <AgGridReact
-          columnDefs={dataGridExampleColumns}
-          rowData={dataGridExampleData}
-          statusBar={statusBar}
-          rowSelection="multiple"
-          {...agGridProps}
-          {...props}
-          enableRangeSelection={true}
-          className="ag-salt-theme"
-        />
-      </div>
-    </StackLayout>
+        </div>
+      </StackLayout>
+    </SaltProvider>
   );
 };
 

--- a/packages/ag-grid-theme/stories/examples/HDCompact.tsx
+++ b/packages/ag-grid-theme/stories/examples/HDCompact.tsx
@@ -19,10 +19,11 @@ const statusBar = {
 
 const HDCompact = (props: AgGridReactProps) => {
   const { switcher, themeName } = useAgGridThemeSwitcher();
-  const { agGridProps, containerProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`,
-    true
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+    compact: true,
+    density: "high",
+  });
 
   return (
     <SaltProvider density="high">

--- a/packages/ag-grid-theme/stories/examples/HDCompactDark.tsx
+++ b/packages/ag-grid-theme/stories/examples/HDCompactDark.tsx
@@ -20,11 +20,12 @@ const statusBar = {
 const HDCompactDark = (props: AgGridReactProps) => {
   const mode = "dark";
   const { switcher, themeName } = useAgGridThemeSwitcher();
-  const { agGridProps, containerProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`,
-    true,
-    mode
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+    compact: true,
+    density: "high",
+    mode,
+  });
 
   return (
     <SaltProvider mode={mode} density="high">

--- a/packages/ag-grid-theme/stories/examples/HDCompactDark.tsx
+++ b/packages/ag-grid-theme/stories/examples/HDCompactDark.tsx
@@ -17,15 +17,17 @@ const statusBar = {
   ],
 };
 
-const HDCompact = (props: AgGridReactProps) => {
+const HDCompactDark = (props: AgGridReactProps) => {
+  const mode = "dark";
   const { switcher, themeName } = useAgGridThemeSwitcher();
   const { agGridProps, containerProps } = useAgGridHelpers(
     `ag-theme-${themeName}`,
-    true
+    true,
+    mode
   );
 
   return (
-    <SaltProvider density="high">
+    <SaltProvider mode={mode} density="high">
       <StackLayout gap={4}>
         <FlexLayout direction="row">{switcher}</FlexLayout>
         <div {...containerProps}>
@@ -53,8 +55,8 @@ const HDCompact = (props: AgGridReactProps) => {
   );
 };
 
-HDCompact.parameters = {
+HDCompactDark.parameters = {
   chromatic: { disableSnapshot: false },
 };
 
-export default HDCompact;
+export default HDCompactDark;

--- a/packages/ag-grid-theme/stories/examples/Icons.tsx
+++ b/packages/ag-grid-theme/stories/examples/Icons.tsx
@@ -17,7 +17,9 @@ const Icons = () => {
   });
   const { switcher, themeName } = useAgGridThemeSwitcher();
 
-  const { containerProps } = useAgGridHelpers(`ag-theme-${themeName}`);
+  const { containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+  });
   const styles = themeName === "salt" ? saltStyles : uitkStyles;
 
   return (
@@ -29,6 +31,7 @@ const Icons = () => {
             <div
               {...containerProps}
               style={{ "--icon-content": styles[key] } as CSSProperties}
+              key={key}
             >
               {key}
             </div>

--- a/packages/ag-grid-theme/stories/examples/InfiniteScroll.tsx
+++ b/packages/ag-grid-theme/stories/examples/InfiniteScroll.tsx
@@ -24,9 +24,9 @@ const dataSourceRows = generateData(dataGridExampleData);
 
 const InfiniteScroll = (props: AgGridReactProps) => {
   const { switcher, themeName } = useAgGridThemeSwitcher();
-  const { isGridReady, agGridProps, containerProps, api } = useAgGridHelpers(
-    `ag-theme-${themeName}`
-  );
+  const { isGridReady, agGridProps, containerProps, api } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+  });
 
   useEffect(() => {
     if (isGridReady) {
@@ -43,7 +43,7 @@ const InfiniteScroll = (props: AgGridReactProps) => {
         },
       });
     }
-  }, [isGridReady]);
+  }, [api, isGridReady]);
 
   return (
     <StackLayout gap={4}>
@@ -63,8 +63,11 @@ const InfiniteScroll = (props: AgGridReactProps) => {
 };
 
 const infiniteScrollComponents = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   loadingRenderer(params: any) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (params.value !== undefined) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
       return params.value;
     } else {
       return <Spinner size="default" />;

--- a/packages/ag-grid-theme/stories/examples/LoadingOverlay.tsx
+++ b/packages/ag-grid-theme/stories/examples/LoadingOverlay.tsx
@@ -8,9 +8,9 @@ import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 
 const LoadingOverlay = (props: AgGridReactProps) => {
   const { switcher, themeName } = useAgGridThemeSwitcher();
-  const { agGridProps, containerProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+  });
 
   const getModalStyle: CSSProperties = {
     position: "absolute",

--- a/packages/ag-grid-theme/stories/examples/MasterDetail.tsx
+++ b/packages/ag-grid-theme/stories/examples/MasterDetail.tsx
@@ -8,9 +8,9 @@ import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 
 const MasterDetail = (props: AgGridReactProps) => {
   const { switcher, themeName } = useAgGridThemeSwitcher();
-  const { agGridProps, containerProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+  });
 
   const gridRef = useRef<AgGridReact>(null);
 

--- a/packages/ag-grid-theme/stories/examples/MasterDetailDark.tsx
+++ b/packages/ag-grid-theme/stories/examples/MasterDetailDark.tsx
@@ -38,6 +38,7 @@ const MasterDetailDark = (props: AgGridReactProps) => {
               detailGridOptions: { columnDefs },
               // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
               getDetailRowData: (params: any) =>
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
                 params.successCallback(rowData),
             }}
             masterDetail={true}

--- a/packages/ag-grid-theme/stories/examples/MasterDetailDark.tsx
+++ b/packages/ag-grid-theme/stories/examples/MasterDetailDark.tsx
@@ -9,11 +9,10 @@ import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 const MasterDetailDark = (props: AgGridReactProps) => {
   const mode = "dark";
   const { switcher, themeName } = useAgGridThemeSwitcher();
-  const { agGridProps, containerProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`,
-    false,
-    mode
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+    mode,
+  });
 
   const gridRef = useRef<AgGridReact>(null);
 

--- a/packages/ag-grid-theme/stories/examples/NoDataOverlay.tsx
+++ b/packages/ag-grid-theme/stories/examples/NoDataOverlay.tsx
@@ -1,7 +1,6 @@
 import { CSSProperties, useEffect, useRef, useState } from "react";
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
 import { Button, Card, H2, StatusIndicator } from "@salt-ds/core";
-import { ErrorIcon, WarningIcon } from "@salt-ds/icons";
 import dataGridExampleColumns from "../dependencies/dataGridExampleColumns";
 import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
@@ -10,15 +9,15 @@ const NoDataOverlay = (props: AgGridReactProps) => {
   const [showModal, setShowModal] = useState(true);
   const containerRef = useRef<HTMLDivElement>(null);
   const { switcher, themeName } = useAgGridThemeSwitcher();
-  const { isGridReady, api, agGridProps, containerProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`
-  );
+  const { isGridReady, api, agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+  });
 
   useEffect(() => {
     if (isGridReady) {
       api!.sizeColumnsToFit();
     }
-  }, [isGridReady]);
+  }, [api, isGridReady]);
 
   const reloadData = () => {
     setShowModal(false);

--- a/packages/ag-grid-theme/stories/examples/Pagination.tsx
+++ b/packages/ag-grid-theme/stories/examples/Pagination.tsx
@@ -17,9 +17,9 @@ const generateData = (states: typeof dataGridExampleData) =>
 
 const PagedGrid = (props: AgGridReactProps) => {
   const { switcher, themeName } = useAgGridThemeSwitcher();
-  const { agGridProps, containerProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+  });
 
   return (
     <StackLayout gap={4}>

--- a/packages/ag-grid-theme/stories/examples/ParentChildRows.tsx
+++ b/packages/ag-grid-theme/stories/examples/ParentChildRows.tsx
@@ -7,9 +7,9 @@ import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 
 const ParentChildRows = (props: AgGridReactProps) => {
   const { switcher, themeName } = useAgGridThemeSwitcher();
-  const { agGridProps, containerProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+  });
 
   return (
     <StackLayout gap={4}>
@@ -21,7 +21,9 @@ const ParentChildRows = (props: AgGridReactProps) => {
           {...agGridProps}
           {...props}
           columnDefs={parentChildExampleColumns}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           getDataPath={(data: any) => {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
             return data.orgHierarchy;
           }}
           groupDefaultExpanded={-1}

--- a/packages/ag-grid-theme/stories/examples/PinnedRows.tsx
+++ b/packages/ag-grid-theme/stories/examples/PinnedRows.tsx
@@ -23,6 +23,7 @@ const fields = function <T>(fieldName: keyof T, rows: T[]) {
   return rows.map((row) => row[fieldName]);
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const headerRow: any[] = [
   {
     name: "Top",
@@ -49,9 +50,9 @@ const PinnedRowsExample = function PinnedRowsExample({
   ...rest
 }: PinnedRowsExampleProps) {
   const { switcher, themeName } = useAgGridThemeSwitcher();
-  const { agGridProps, containerProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+  });
 
   const getColumnData = () => {
     return fields(aggregateColumn, rowData!).filter(

--- a/packages/ag-grid-theme/stories/examples/RowGroupPanel.tsx
+++ b/packages/ag-grid-theme/stories/examples/RowGroupPanel.tsx
@@ -7,9 +7,9 @@ import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 
 const RowGroupPanel = (props: AgGridReactProps) => {
   const { switcher, themeName } = useAgGridThemeSwitcher();
-  const { agGridProps, containerProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+  });
 
   return (
     <StackLayout gap={4}>

--- a/packages/ag-grid-theme/stories/examples/RowGrouping.tsx
+++ b/packages/ag-grid-theme/stories/examples/RowGrouping.tsx
@@ -7,9 +7,9 @@ import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 
 const RowGrouping = (props: AgGridReactProps) => {
   const { switcher, themeName } = useAgGridThemeSwitcher();
-  const { agGridProps, containerProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+  });
 
   return (
     <StackLayout gap={4}>

--- a/packages/ag-grid-theme/stories/examples/StatusBar.tsx
+++ b/packages/ag-grid-theme/stories/examples/StatusBar.tsx
@@ -19,9 +19,9 @@ const statusBar = {
 
 const StatusBar = (props: AgGridReactProps) => {
   const { switcher, themeName } = useAgGridThemeSwitcher();
-  const { agGridProps, containerProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+  });
 
   return (
     <StackLayout gap={4}>

--- a/packages/ag-grid-theme/stories/examples/StatusBarDark.tsx
+++ b/packages/ag-grid-theme/stories/examples/StatusBarDark.tsx
@@ -20,11 +20,10 @@ const statusBar = {
 const StatusBar = (props: AgGridReactProps) => {
   const mode = "dark";
   const { switcher, themeName } = useAgGridThemeSwitcher();
-  const { agGridProps, containerProps } = useAgGridHelpers(
-    `ag-theme-${themeName}`,
-    false,
-    mode
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+    mode,
+  });
 
   return (
     <SaltProvider mode={mode}>

--- a/packages/ag-grid-theme/stories/examples/VariantSecondary.tsx
+++ b/packages/ag-grid-theme/stories/examples/VariantSecondary.tsx
@@ -6,7 +6,9 @@ import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 import dataGridExampleColumns from "../dependencies/dataGridExampleColumns";
 
 const VariantSecondary = (props: AgGridReactProps) => {
-  const { agGridProps, containerProps } = useAgGridHelpers("ag-theme-salt");
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-salt`,
+  });
   const { className } = containerProps;
 
   return (

--- a/packages/ag-grid-theme/stories/examples/VariantSecondaryDark.tsx
+++ b/packages/ag-grid-theme/stories/examples/VariantSecondaryDark.tsx
@@ -7,11 +7,10 @@ import dataGridExampleColumns from "../dependencies/dataGridExampleColumns";
 
 const VariantZebraDark = (props: AgGridReactProps) => {
   const mode = "dark";
-  const { agGridProps, containerProps } = useAgGridHelpers(
-    `ag-theme-salt`,
-    false,
-    mode
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-salt`,
+    mode,
+  });
   const { className } = containerProps;
 
   return (

--- a/packages/ag-grid-theme/stories/examples/VariantZebra.tsx
+++ b/packages/ag-grid-theme/stories/examples/VariantZebra.tsx
@@ -6,7 +6,9 @@ import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 import dataGridExampleColumns from "../dependencies/dataGridExampleColumns";
 
 const VariantZebra = (props: AgGridReactProps) => {
-  const { agGridProps, containerProps } = useAgGridHelpers("ag-theme-salt");
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-salt`,
+  });
   const { className } = containerProps;
 
   return (

--- a/packages/ag-grid-theme/stories/examples/VariantZebraDark.tsx
+++ b/packages/ag-grid-theme/stories/examples/VariantZebraDark.tsx
@@ -7,11 +7,10 @@ import dataGridExampleColumns from "../dependencies/dataGridExampleColumns";
 
 const VariantZebraDark = (props: AgGridReactProps) => {
   const mode = "dark";
-  const { agGridProps, containerProps } = useAgGridHelpers(
-    `ag-theme-salt`,
-    false,
-    mode
-  );
+  const { agGridProps, containerProps } = useAgGridHelpers({
+    agThemeName: `ag-theme-salt`,
+    mode,
+  });
   const { className } = containerProps;
 
   return (

--- a/packages/ag-grid-theme/stories/examples/WrappedHeader.tsx
+++ b/packages/ag-grid-theme/stories/examples/WrappedHeader.tsx
@@ -27,17 +27,17 @@ const statusBar = {
 const WrappedHeader = (props: AgGridReactProps) => {
   const [compact, setCompact] = useState(false);
   const { switcher, themeName } = useAgGridThemeSwitcher();
-  const { api, agGridProps, containerProps, isGridReady } = useAgGridHelpers(
-    `ag-theme-${themeName}`,
-    compact
-  );
+  const { api, agGridProps, containerProps, isGridReady } = useAgGridHelpers({
+    agThemeName: `ag-theme-${themeName}`,
+    compact,
+  });
   const { defaultColDef: propsColDefs, ...restAgGridProps } = agGridProps;
 
   useEffect(() => {
     if (isGridReady) {
       api?.sizeColumnsToFit();
     }
-  }, [isGridReady]);
+  }, [api, isGridReady]);
 
   const density = useDensity();
 

--- a/packages/ag-grid-theme/stories/examples/index.ts
+++ b/packages/ag-grid-theme/stories/examples/index.ts
@@ -9,6 +9,7 @@ export { default as Coloration } from "./Coloration";
 export { default as Icons } from "./Icons";
 export { default as FloatingFilter } from "./FloatingFilter";
 export { default as HDCompact } from "./HDCompact";
+export { default as HDCompactDark } from "./HDCompactDark";
 export { default as LoadingOverlay } from "./LoadingOverlay";
 export { default as MasterDetail } from "./MasterDetail";
 export { default as MasterDetailDark } from "./MasterDetailDark";


### PR DESCRIPTION
Update useAgGridHelpers to take `mode` and `density` args so we can override the global theme. Needed for the dark examples and HDCompact story where we want to set the `high` density.
