### PR TITLE
Update storysource addon syntax

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -25,7 +25,7 @@ const config: StorybookConfig = {
     getAbsolutePath("@storybook/addon-links"),
     getAbsolutePath("@storybook/addon-a11y"),
     getAbsolutePath("@storybook/addon-mdx-gfm"),
-    getAbsolutePath("@storybook/addon-storysource"),
+    "@storybook/addon-storysource",
   ],
   async viteFinal(config, { configType }) {
     // customize the Vite config here


### PR DESCRIPTION
This seems to fix below error

```
WARN   Failed to load preset: {"name":"/Users/zhihaocui/projects/salt-ds/node_modules/@storybook/addon-storysource/preset.js"} on level 2
./node_modules/@storybook/addon-storysource/preset.js:1
import './dist/preset';
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at internalCompileFunction (node:internal/vm:73:18)
    at wrapSafe (node:internal/modules/cjs/loader:1176:20)
    at Module._compile (node:internal/modules/cjs/loader:1218:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Object.newLoader (./node_modules/@storybook/core-common/node_modules/esbuild-register/dist/node.js:2262:9)
    at extensions..js (./node_modules/@storybook/core-common/node_modules/esbuild-register/dist/node.js:4838:24)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at Module.require (node:internal/modules/cjs/loader:1141:19)
    at require (node:internal/modules/cjs/helpers:110:18)
```