### PR TITLE
Fix invalid Tabnext prop on site example

### DIFF
--- a/site/src/examples/badge/InlineBadge.tsx
+++ b/site/src/examples/badge/InlineBadge.tsx
@@ -4,7 +4,7 @@ import { StackLayout } from "@salt-ds/core";
 
 export const InlineBadge = (): ReactElement => (
   <TabstripNext
-    defaultSelected="Home"
+    defaultValue="Home"
     style={{
       maxWidth: 400,
     }}


### PR DESCRIPTION
```
site ➤ yarn build                                                                                                                               git:main*
   Skipping linting
   Checking validity of types .Failed to compile.

./src/examples/badge/InlineBadge.tsx:7:5
Type error: Type '{ children: Element[]; defaultSelected: string; style: { maxWidth: number; }; }' is not assignable to type 'IntrinsicAttributes & TabstripNextProps & RefAttributes<HTMLDivElement>'.
  Property 'defaultSelected' does not exist on type 'IntrinsicAttributes & TabstripNextProps & RefAttributes<HTMLDivElement>'.

   5 | export const InlineBadge = (): ReactElement => (
   6 |   <TabstripNext
>  7 |     defaultSelected="Home"
     |     ^
   8 |     style={{
   9 |       maxWidth: 400,
  10 |     }}
   Checking validity of types .%                          

```