### PR TITLE
remove repeated tokens & changeset from theme

### DIFF
--- a/.changeset/afraid-tigers-rest.md
+++ b/.changeset/afraid-tigers-rest.md
@@ -1,9 +1,0 @@
----
-"@salt-ds/theme": minor
----
-
-New token added in `size.css` foundations:
-
-```diff
-+ --salt-size-bar-small
-```

--- a/packages/theme/css/foundations/size.css
+++ b/packages/theme/css/foundations/size.css
@@ -1,7 +1,6 @@
 .salt-density-high {
   --salt-size-adornment: 6px;
   --salt-size-bar: 2px;
-  --salt-size-bar-small: 2px;
   --salt-size-base: 20px;
   --salt-size-border: 1px;
   --salt-size-icon: 12px;
@@ -13,7 +12,6 @@
 .salt-density-medium {
   --salt-size-adornment: 8px;
   --salt-size-bar: 4px;
-  --salt-size-bar-small: 2px;
   --salt-size-base: 28px;
   --salt-size-border: 1px;
   --salt-size-icon: 12px;
@@ -25,7 +23,6 @@
 .salt-density-low {
   --salt-size-adornment: 10px;
   --salt-size-bar: 6px;
-  --salt-size-bar-small: 2px;
   --salt-size-base: 36px;
   --salt-size-border: 1px;
   --salt-size-icon: 14px;
@@ -37,7 +34,6 @@
 .salt-density-touch {
   --salt-size-adornment: 12px;
   --salt-size-bar: 8px;
-  --salt-size-bar-small: 2px;
   --salt-size-base: 44px;
   --salt-size-border: 1px;
   --salt-size-icon: 16px;


### PR DESCRIPTION
PR for Spinner and Progress introduced same foundations/size `--salt-size-bar-small` token, remove repeated reference of it 