### PR TITLE
Configurable typography

### DIFF
--- a/packages/theme/css/foundations/typography.css
+++ b/packages/theme/css/foundations/typography.css
@@ -1,5 +1,5 @@
 .salt-theme {
-  --salt-typography-fontFamily: "Open Sans";
+  --salt-typography-fontFamily: var(--saltTypography-fontFamily, "Open Sans");
   --salt-typography-fontFamily-code: "PT Mono";
 
   --salt-typography-fontWeight-light: 300;


### PR DESCRIPTION
Every time we render SaltProvider in the component tree it "resets" the font family we may have overwritten somewhere up in the tree because `.salt-theme` class name redeclares this particular variable. This PR follows the components css variable theming approach. We could pass a single global css variable to configure foundational aspects of the salt theme and it will cascade down.