### PR TITLE
DropDown + Combobox: Stop List Blurring on Click of ScrollBar

### DIFF
--- a/.changeset/large-cougars-thank.md
+++ b/.changeset/large-cougars-thank.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/lab": patch
+---
+
+Dopdown: focus returns to dropdown after list select

--- a/packages/core/src/utils/useFloatingUI/README.md
+++ b/packages/core/src/utils/useFloatingUI/README.md
@@ -42,7 +42,7 @@ This custom Floating component will be passed the relevant positioning informati
 
 In a multi-window application this custom Floating Component can be used by consumers as a trigger to spawn/activate another window and render the children of the floating component inside via a portal. Our default floating component uses [Floating Portal](https://floating-ui.com/docs/floatingportal#floatingportal) to do this within the same document.
 
-### Considerations for compoennts
+### Considerations for components
 
 When building a floating component, they key things to think about are as follows:
 

--- a/packages/lab/src/__tests__/__e2e__/combo-box-next/ComboBoxNext.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/combo-box-next/ComboBoxNext.cy.tsx
@@ -9,7 +9,7 @@ const { Default, CustomRenderer, Controlled } =
 describe("GIVEN a Combobox", () => {
   it("SHOULD render all its items", () => {
     cy.mount(<Default />);
-    cy.realPress("Tab");
+    cy.realPress("Tab").realPress("Enter");
 
     Default.args!.source!.forEach((item) => {
       cy.findByRole("option", { name: item }).should("exist");
@@ -17,7 +17,7 @@ describe("GIVEN a Combobox", () => {
   });
   it("SHOULD render with a custom renderer", () => {
     cy.mount(<CustomRenderer />);
-    cy.realPress("Tab");
+    cy.realPress("Tab").realPress("Enter");
 
     cy.findByText("Tokyo").should("exist");
     cy.findByText("Delhi").should("exist");
@@ -91,8 +91,8 @@ describe("GIVEN a Combobox", () => {
         });
       });
     });
-    describe("WHEN controlled selected is passed", () => {
-      it("SHOULD be able to control the open property of portal", () => {
+    describe("WHEN selection is controlled externally", () => {
+      it("SHOULD be able to select with an external action", () => {
         cy.mount(<Controlled />);
         cy.findByRole("combobox").should("have.value", "Baby blue");
         cy.findByRole("button", { name: "Next" }).should("exist");
@@ -101,11 +101,9 @@ describe("GIVEN a Combobox", () => {
       });
     });
     describe("WHEN controlled prop input value is passed", () => {
-      it("SHOULD be able to control the open property of portal", () => {
+      it("SHOULD be able to control the input property on portal", () => {
         cy.mount(<Default inputValue="Blue" />);
         cy.findByRole("combobox").should("have.value", "Blue");
-        cy.realPress("Tab");
-        cy.findAllByRole("option").should("have.length", 2);
       });
     });
   });

--- a/packages/lab/src/combo-box-next/ComboBoxNext.tsx
+++ b/packages/lab/src/combo-box-next/ComboBoxNext.tsx
@@ -166,6 +166,7 @@ export const ComboBoxNext = forwardRef(function ComboBoxNext<T>(
     setHighlightedItem,
     mouseOverHandler,
     mouseDownHandler,
+    listSelectHandler,
   } = useComboBox({
     defaultInputValue,
     inputValue: inputValueProp,
@@ -214,10 +215,6 @@ export const ComboBoxNext = forwardRef(function ComboBoxNext<T>(
       }
     }
     onInputChange?.(event, { value: inputValue ?? "" });
-  };
-
-  const listSelectHandler = () => {
-    setOpen(false);
   };
 
   const adornment = open ? (

--- a/packages/lab/src/combo-box-next/ComboBoxNext.tsx
+++ b/packages/lab/src/combo-box-next/ComboBoxNext.tsx
@@ -122,7 +122,6 @@ export const ComboBoxNext = forwardRef(function ComboBoxNext<T>(
     ListItem = DefaultListItem as unknown as ComboBoxNextProps<T>["ListItem"],
     itemFilter = defaultFilter as unknown as ComboBoxNextProps<T>["itemFilter"],
     onMouseOver,
-    onBlur,
     onFocus,
     onKeyDown,
     onSelect,
@@ -163,14 +162,13 @@ export const ComboBoxNext = forwardRef(function ComboBoxNext<T>(
     focusVisibleRef,
     keyDownHandler,
     focusHandler,
-    blurHandler,
     setSelectedItem,
     setHighlightedItem,
+    handleListSelect,
     mouseOverHandler,
   } = useComboBox({
     defaultInputValue,
     inputValue: inputValueProp,
-    onBlur,
     onFocus,
     onMouseOver,
     onKeyDown,
@@ -183,13 +181,13 @@ export const ComboBoxNext = forwardRef(function ComboBoxNext<T>(
     setOpen,
     floating,
     reference,
-    getTriggerProps,
     getPortalProps,
     getPosition,
+    getTriggerProps,
   } = portalProps;
 
   // floating references
-  const triggerRef = useForkRef(ref, reference);
+  const triggerRef = useForkRef<HTMLInputElement>(ref, reference);
   const inputRef = useForkRef(triggerRef, focusVisibleRef);
 
   const { Component: FloatingComponent } = useFloatingComponent();
@@ -215,7 +213,7 @@ export const ComboBoxNext = forwardRef(function ComboBoxNext<T>(
         setHighlightedItem(filteredSource[0] as unknown as string);
       }
     }
-    onInputChange?.(event, { value: inputValue || "" });
+    onInputChange?.(event, { value: inputValue ?? "" });
   };
 
   const adornment = open ? (
@@ -236,18 +234,17 @@ export const ComboBoxNext = forwardRef(function ComboBoxNext<T>(
         disabled={disabled}
         endAdornment={adornment}
         onChange={onChange}
-        onBlur={blurHandler}
         inputRef={inputRef as Ref<HTMLInputElement>}
         inputProps={{
           "aria-expanded": open,
           tabIndex: disabled ? -1 : 0,
-          onFocus: focusHandler,
           onKeyDown: keyDownHandler,
+          onFocus: focusHandler,
         }}
+        {...getTriggerProps()}
         role="combobox"
         variant={variant}
         value={inputValue}
-        {...getTriggerProps()}
         {...restInputProps}
       />
 
@@ -262,6 +259,7 @@ export const ComboBoxNext = forwardRef(function ComboBoxNext<T>(
           disableFocus
           highlightedItem={highlightedItem}
           onMouseOver={mouseOverHandler}
+          onSelect={handleListSelect}
           selected={selectedItem}
           {...restListProps}
           ref={setListRef}

--- a/packages/lab/src/combo-box-next/ComboBoxNext.tsx
+++ b/packages/lab/src/combo-box-next/ComboBoxNext.tsx
@@ -164,8 +164,8 @@ export const ComboBoxNext = forwardRef(function ComboBoxNext<T>(
     focusHandler,
     setSelectedItem,
     setHighlightedItem,
-    handleListSelect,
     mouseOverHandler,
+    mouseDownHandler,
   } = useComboBox({
     defaultInputValue,
     inputValue: inputValueProp,
@@ -181,13 +181,13 @@ export const ComboBoxNext = forwardRef(function ComboBoxNext<T>(
     setOpen,
     floating,
     reference,
+    getTriggerProps,
     getPortalProps,
     getPosition,
-    getTriggerProps,
   } = portalProps;
 
   // floating references
-  const triggerRef = useForkRef<HTMLInputElement>(ref, reference);
+  const triggerRef = useForkRef(ref, reference);
   const inputRef = useForkRef(triggerRef, focusVisibleRef);
 
   const { Component: FloatingComponent } = useFloatingComponent();
@@ -216,6 +216,10 @@ export const ComboBoxNext = forwardRef(function ComboBoxNext<T>(
     onInputChange?.(event, { value: inputValue ?? "" });
   };
 
+  const listSelectHandler = () => {
+    setOpen(false);
+  };
+
   const adornment = open ? (
     <ChevronUpIcon className={withBaseName("chevron")} />
   ) : (
@@ -234,17 +238,18 @@ export const ComboBoxNext = forwardRef(function ComboBoxNext<T>(
         disabled={disabled}
         endAdornment={adornment}
         onChange={onChange}
+        onMouseDown={mouseDownHandler}
         inputRef={inputRef as Ref<HTMLInputElement>}
         inputProps={{
           "aria-expanded": open,
           tabIndex: disabled ? -1 : 0,
-          onKeyDown: keyDownHandler,
           onFocus: focusHandler,
+          onKeyDown: keyDownHandler,
         }}
-        {...getTriggerProps()}
         role="combobox"
         variant={variant}
         value={inputValue}
+        {...getTriggerProps()}
         {...restInputProps}
       />
 
@@ -259,7 +264,7 @@ export const ComboBoxNext = forwardRef(function ComboBoxNext<T>(
           disableFocus
           highlightedItem={highlightedItem}
           onMouseOver={mouseOverHandler}
-          onSelect={handleListSelect}
+          onSelect={listSelectHandler}
           selected={selectedItem}
           {...restListProps}
           ref={setListRef}

--- a/packages/lab/src/combo-box-next/useComboBox.tsx
+++ b/packages/lab/src/combo-box-next/useComboBox.tsx
@@ -67,13 +67,13 @@ export const useComboBox = ({
     onFocus?.(event);
   };
 
+  const mouseDownHandler = () => {
+    setOpen(!open);
+  };
+
   const mouseOverHandler = (event: SyntheticEvent<HTMLElement>) => {
     setHighlightedItem(event.currentTarget.dataset.value);
     onMouseOver?.(event);
-  };
-
-  const handleListSelect = () => {
-    setOpen(false);
   };
 
   const keyDownHandler = (event: KeyboardEvent<HTMLInputElement>) => {
@@ -123,9 +123,6 @@ export const useComboBox = ({
           setOpen(true);
         }
         break;
-      case "Tab":
-        setOpen(false);
-        break;
       default:
         break;
     }
@@ -141,8 +138,8 @@ export const useComboBox = ({
       setOpen,
       floating,
       reference,
-      getPortalProps,
       getTriggerProps,
+      getPortalProps,
       getPosition,
     },
     // list
@@ -152,9 +149,9 @@ export const useComboBox = ({
     setHighlightedItem,
     activeDescendant,
     focusVisibleRef,
-    handleListSelect,
     keyDownHandler,
     focusHandler,
     mouseOverHandler,
+    mouseDownHandler,
   };
 };

--- a/packages/lab/src/combo-box-next/useComboBox.tsx
+++ b/packages/lab/src/combo-box-next/useComboBox.tsx
@@ -17,7 +17,6 @@ interface UseComboBoxProps {
 export const useComboBox = ({
   defaultInputValue,
   onFocus,
-  onBlur,
   onMouseOver,
   onKeyDown,
   inputValue: inputValueProp,
@@ -64,23 +63,17 @@ export const useComboBox = ({
   }, [selectedItem]);
 
   const focusHandler = (event: FocusEvent<HTMLInputElement>) => {
-    setOpen(true);
     listFocusHandler(event);
     onFocus?.(event);
-  };
-
-  const blurHandler = (event: FocusEvent<HTMLInputElement>) => {
-    setOpen(false);
-    if (!selectedItem) {
-      setSelected(undefined);
-      setHighlightedItem(undefined);
-    }
-    onBlur?.(event);
   };
 
   const mouseOverHandler = (event: SyntheticEvent<HTMLElement>) => {
     setHighlightedItem(event.currentTarget.dataset.value);
     onMouseOver?.(event);
+  };
+
+  const handleListSelect = () => {
+    setOpen(false);
   };
 
   const keyDownHandler = (event: KeyboardEvent<HTMLInputElement>) => {
@@ -130,6 +123,9 @@ export const useComboBox = ({
           setOpen(true);
         }
         break;
+      case "Tab":
+        setOpen(false);
+        break;
       default:
         break;
     }
@@ -145,8 +141,8 @@ export const useComboBox = ({
       setOpen,
       floating,
       reference,
-      getTriggerProps,
       getPortalProps,
+      getTriggerProps,
       getPosition,
     },
     // list
@@ -156,9 +152,9 @@ export const useComboBox = ({
     setHighlightedItem,
     activeDescendant,
     focusVisibleRef,
+    handleListSelect,
     keyDownHandler,
     focusHandler,
-    blurHandler,
     mouseOverHandler,
   };
 };

--- a/packages/lab/src/combo-box-next/useComboBox.tsx
+++ b/packages/lab/src/combo-box-next/useComboBox.tsx
@@ -76,6 +76,10 @@ export const useComboBox = ({
     onMouseOver?.(event);
   };
 
+  const listSelectHandler = () => {
+    setOpen(false);
+  };
+
   const keyDownHandler = (event: KeyboardEvent<HTMLInputElement>) => {
     const { key, altKey } = event;
     switch (key) {
@@ -153,5 +157,6 @@ export const useComboBox = ({
     focusHandler,
     mouseOverHandler,
     mouseDownHandler,
+    listSelectHandler,
   };
 };

--- a/packages/lab/src/combo-box-next/useComboboxPortal.ts
+++ b/packages/lab/src/combo-box-next/useComboboxPortal.ts
@@ -23,7 +23,7 @@ export function useComboboxPortal(props?: UseComboBoxPortalProps) {
     open: openProp,
     onOpenChange: onOpenChangeProp,
     placement: placementProp = "bottom",
-  } = props || {};
+  } = props ?? {};
   const [open, setOpen] = useControlled({
     controlled: openProp,
     default: false,

--- a/packages/lab/src/dropdown-next/DropdownNext.css
+++ b/packages/lab/src/dropdown-next/DropdownNext.css
@@ -86,8 +86,7 @@
 .saltDropdownNext-icon.saltDropdownNext-readOnly,
 .saltDropdownNext-icon.saltDropdownNext-readOnly:hover,
 .saltDropdownNext-icon.saltDropdownNext-readOnly:active,
-.saltDropdownNext-icon
-{
+.saltDropdownNext-icon {
   color: var(--salt-text-primary-foreground-disabled);
 }
 

--- a/packages/lab/src/dropdown-next/DropdownNext.css
+++ b/packages/lab/src/dropdown-next/DropdownNext.css
@@ -85,7 +85,9 @@
 .saltDropdownNext-icon.saltDropdownNext-disabled:active,
 .saltDropdownNext-icon.saltDropdownNext-readOnly,
 .saltDropdownNext-icon.saltDropdownNext-readOnly:hover,
-.saltDropdownNext-icon.saltDropdownNext-readOnly:active {
+.saltDropdownNext-icon.saltDropdownNext-readOnly:active,
+.saltDropdownNext-icon
+{
   color: var(--salt-text-primary-foreground-disabled);
 }
 

--- a/packages/lab/src/dropdown-next/DropdownNext.tsx
+++ b/packages/lab/src/dropdown-next/DropdownNext.tsx
@@ -91,7 +91,6 @@ export const DropdownNext = forwardRef(function DropdownNext(
     highlightedItem: highlightedItemControlProp,
     onFocus,
     onKeyDown,
-    onBlur,
     onMouseOver,
     onMouseDown,
     onSelect,
@@ -129,6 +128,8 @@ export const DropdownNext = forwardRef(function DropdownNext(
     highlightedItem,
     getListItems,
     portalProps,
+    getReferenceProps,
+    refs,
   } = useDropdownNext({
     listProps,
     placement,
@@ -142,12 +143,13 @@ export const DropdownNext = forwardRef(function DropdownNext(
   const {
     focusHandler,
     keyDownHandler,
-    blurHandler,
     mouseOverHandler,
     mouseDownHandler,
+    portalSelectHandler,
   } = handlers;
 
   const triggerRef = useForkRef<HTMLButtonElement>(ref, reference);
+  const portalRef = useForkRef<HTMLButtonElement>(ref, floating);
 
   const getIcon = () => {
     if (readOnly) return;
@@ -170,14 +172,9 @@ export const DropdownNext = forwardRef(function DropdownNext(
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
-    if (disabled || readOnly) return;
+    if (disabled ?? readOnly) return;
     keyDownHandler(event);
     onKeyDown?.(event);
-  };
-
-  const handleBlur = (event: FocusEvent<HTMLButtonElement>) => {
-    blurHandler();
-    onBlur?.(event);
   };
 
   const handleMouseOver = (event: MouseEvent<HTMLButtonElement>) => {
@@ -186,9 +183,14 @@ export const DropdownNext = forwardRef(function DropdownNext(
   };
 
   const handleMouseDown = (event: MouseEvent<HTMLButtonElement>) => {
-    if (disabled || readOnly) return;
+    if (disabled ?? readOnly) return;
     mouseDownHandler();
     onMouseDown?.(event);
+  };
+
+  const handlePortalSelect = () => {
+    portalSelectHandler();
+    (refs.domReference.current as HTMLButtonElement)?.focus();
   };
 
   return (
@@ -196,11 +198,12 @@ export const DropdownNext = forwardRef(function DropdownNext(
       <button
         id={dropdownId}
         disabled={disabled}
-        onFocus={handleFocus}
-        onKeyDown={handleKeyDown}
-        onMouseOver={handleMouseOver}
-        onMouseDown={handleMouseDown}
-        onBlur={handleBlur}
+        {...getReferenceProps({
+          onFocus: handleFocus,
+          onMouseOver: handleMouseOver,
+          onMouseDown: handleMouseDown,
+          onKeyDown: handleKeyDown,
+        })}
         value={selectedItem}
         className={clsx(
           withBaseName("button"),
@@ -227,7 +230,7 @@ export const DropdownNext = forwardRef(function DropdownNext(
       </button>
       <FloatingComponent
         open={open && !disabled}
-        ref={floating}
+        ref={portalRef}
         {...getDropdownNextProps()}
         {...getPosition()}
       >
@@ -235,11 +238,12 @@ export const DropdownNext = forwardRef(function DropdownNext(
           id={listId}
           className={clsx(withBaseName("list"), ListProps?.className)}
           disableFocus
-          disabled={disabled || ListProps?.disabled}
+          disabled={disabled ?? ListProps?.disabled}
           selected={selectedItem}
           highlightedItem={highlightedItem}
           {...ListProps}
           ref={setListRef}
+          onSelect={handlePortalSelect}
         >
           {getListItems(source)}
         </ListNext>

--- a/packages/lab/src/dropdown-next/useDropdownNext.tsx
+++ b/packages/lab/src/dropdown-next/useDropdownNext.tsx
@@ -43,7 +43,6 @@ export const useDropdownNext = ({
   const {
     focusHandler: listFocusHandler,
     keyDownHandler: listKeyDownHandler,
-    blurHandler: listBlurHandler,
     mouseOverHandler: listMouseOverHandler,
     activeDescendant,
     selectedItem,
@@ -51,7 +50,6 @@ export const useDropdownNext = ({
     highlightedItem,
     setHighlightedItem,
     contextValue: listContextValue,
-    focusVisibleRef,
   } = useList({
     ...listProps,
   });
@@ -86,29 +84,37 @@ export const useDropdownNext = ({
     onOpenChangeProp?.(open);
   };
 
-  const { floating, reference, x, y, strategy, placement, context, elements } =
-    useFloatingUI({
-      open,
-      onOpenChange,
-      placement: placementProp,
-      middleware: [
-        offset(0),
-        size({
-          apply({ rects, elements }) {
-            Object.assign(elements.floating.style, {
-              width: `${rects.reference.width}px`,
-            });
-          },
-        }),
-        flip(),
-        shift({ limiter: limitShift() }),
-      ],
-    });
+  const {
+    floating,
+    reference,
+    x,
+    y,
+    strategy,
+    placement,
+    context,
+    elements,
+    refs,
+  } = useFloatingUI({
+    open,
+    onOpenChange,
+    placement: placementProp,
+    middleware: [
+      offset(0),
+      size({
+        apply({ rects, elements }) {
+          Object.assign(elements.floating.style, {
+            width: `${rects.reference.width}px`,
+          });
+        },
+      }),
+      flip(),
+      shift({ limiter: limitShift() }),
+    ],
+  });
 
-  const { getFloatingProps } = useInteractions([
-    useDismiss(context),
-    useRole(context, { role: "listbox" }),
-  ]);
+  const { getReferenceProps, getFloatingProps, getItemProps } = useInteractions(
+    [useDismiss(context), useRole(context, { role: "listbox" })]
+  );
 
   const getDropdownNextProps = (): HTMLProps<HTMLDivElement> => {
     return getFloatingProps({
@@ -126,12 +132,6 @@ export const useDropdownNext = ({
     height: elements.floating?.clientHeight,
   });
 
-  // HANDLERS
-  const blurHandler = () => {
-    listBlurHandler();
-    setOpen(false);
-  };
-
   // handles focus on mouse and keyboard
   const focusHandler = (event: FocusEvent<HTMLElement>) => {
     if (selectedItem) {
@@ -147,6 +147,10 @@ export const useDropdownNext = ({
   // handles mouse hover on dropdown button
   const mouseOverHandler = () => {
     listMouseOverHandler();
+  };
+
+  const portalSelectHandler = () => {
+    setOpen(false);
   };
 
   const keyDownHandler = (event: KeyboardEvent<HTMLElement>) => {
@@ -174,6 +178,9 @@ export const useDropdownNext = ({
       case "Escape":
         setOpen(false);
         break;
+      case "Tab":
+        setOpen(false);
+        break;
       case "PageUp":
       case "PageDown":
       case "Home":
@@ -190,24 +197,28 @@ export const useDropdownNext = ({
 
   return {
     handlers: {
-      focusHandler,
       keyDownHandler,
-      blurHandler,
+      focusHandler,
       mouseOverHandler,
       mouseDownHandler,
+      portalSelectHandler,
     },
+    refs,
+    open,
+    getReferenceProps,
+    getItemProps,
     activeDescendant,
     selectedItem,
     setSelectedItem,
     highlightedItem,
     setHighlightedItem,
-    focusVisibleRef,
     getListItems,
     portalProps: {
       open,
       setOpen,
       floating,
       reference,
+      getFloatingProps,
       getDropdownNextProps,
       getPosition,
     },


### PR DESCRIPTION
DropDown + Combobox: use floating ui use dismiss in favour of on blur - fixes list blurring on click of scroll bar 
DropDown: on list selection return focus to dropdown
ComboBox: Keyboard nav, open on tab--> enter instead of just focus using tab
https://github.com/jpmorganchase/salt-ds/issues/2487

This PR does not fix:
- Combobox return focus after selection:
Logic currently works so that on focus of the tigger element the portal element opens
If Focus is returned to trigger after selection the user has to blur trigger element to re-focus
- Focus doesn't persist on dropdown or combobox on selection of Chevron Icon