### PR TITLE
Turn off prefer-nullish-coalescing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,8 +44,12 @@ module.exports = {
         ],
         "@typescript-eslint/no-misused-promises": "off",
         "@typescript-eslint/no-unsafe-assignment ": "off",
-        // nullish coalescing introduces a lot false negative
-        "@typescript-eslint/prefer-nullish-coalescing": "off",
+        "@typescript-eslint/prefer-nullish-coalescing": [
+          "error",
+          {
+            ignoreConditionalTests: true,
+          },
+        ],
         // TypeScript provides the same checks as part of standard type checking.
         "import/named": "off",
         "import/namespace": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,6 +44,8 @@ module.exports = {
         ],
         "@typescript-eslint/no-misused-promises": "off",
         "@typescript-eslint/no-unsafe-assignment ": "off",
+        // nullish coalescing introduces a lot false negative
+        "@typescript-eslint/prefer-nullish-coalescing": "off",
         // TypeScript provides the same checks as part of standard type checking.
         "import/named": "off",
         "import/namespace": "off",


### PR DESCRIPTION
A lot of false negative between `??` and `||`

Only 13 errors reduced