### PR TITLE
[WIP] - make muti-line input scrollable and resizeable

### DIFF
--- a/packages/core/src/multiline-input/MultilineInput.css
+++ b/packages/core/src/multiline-input/MultilineInput.css
@@ -109,8 +109,7 @@
   letter-spacing: 0;
   margin: var(--salt-spacing-75) 0;
   min-width: 0;
-  overflow: hidden;
-  resize: none;
+  overflow: auto;
   padding: 0;
 }
 


### PR DESCRIPTION
Multi-line Input is not scrollable when content overflows.
1. Make Input Scrollable when content overflows in the y direction 
2. Make Input Resizeable
