### PR TITLE
Expand Sidebar to Current Page

### DIFF
--- a/site/src/components/PageNavigation.tsx
+++ b/site/src/components/PageNavigation.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { SidebarItem, useRoute, useStore } from "@jpmorganchase/mosaic-store";
+import { VerticalNavigation } from "@jpmorganchase/mosaic-site-components";
+
+export const PageNavigation = () => {
+  const menu = useStore((state) => state.sidebarData) || [];
+  let { route } = useRoute();
+
+  if (!route) {
+    route = "";
+  }
+
+  // This function evaluates the active route against the data of the sidebar menu, and determines which menu nodes need to be expanded for the current page as per the route.
+  function getExpandedNodeIds(route: string, menu: SidebarItem[]): Set<string> {
+    const expandedNodeIds = new Set<string>();
+
+    const traverse = (node: SidebarItem) => {
+      if (route.startsWith(node.id.replace("/index", ""))) {
+        expandedNodeIds.add(node.id);
+      }
+
+      if (node.childNodes) {
+        for (const childNode of node.childNodes) {
+          traverse(childNode);
+        }
+      }
+    };
+
+    menu.forEach((node) => {
+      traverse(node);
+    });
+
+    return expandedNodeIds;
+  }
+  return (
+    <VerticalNavigation
+      menu={menu}
+      selectedNodeId={route}
+      expandedNodeIds={getExpandedNodeIds(route, menu)}
+    />
+  );
+};

--- a/site/src/components/index.ts
+++ b/site/src/components/index.ts
@@ -19,3 +19,5 @@ export * from "./keyboard-controls";
 export * from "./mdx";
 export * from "./support-and-contributions";
 export * from "./css-display";
+
+export * from "./PageNavigation";

--- a/site/src/layouts/DetailBase/DetailBase.tsx
+++ b/site/src/layouts/DetailBase/DetailBase.tsx
@@ -5,11 +5,11 @@ import {
   DocPaginator,
   BackLink,
   Breadcrumbs,
-  PageNavigation,
 } from "@jpmorganchase/mosaic-site-components";
 import { useStore, SiteState } from "@jpmorganchase/mosaic-store";
 import { Footer } from "../../components/footer";
 import { AppHeader } from "../../components/app-header";
+import { PageNavigation } from "../../components";
 import { LayoutBase } from "@jpmorganchase/mosaic-layouts";
 import { StatusPill } from "../../components/status-pill";
 import { LayoutColumns } from "../LayoutColumns/LayoutColumns";


### PR DESCRIPTION
This PR adds logic to expand sidebar to whatever page is selected. This behaviour doesn't work by default as Mosaic uses breadcrumbs data to determine which page to expand, but we have disabled the Breadcrumbs plugin.

It is just a draft to try and diagnose a problem with nested pages collapsing in the Sidebar.