### PR TITLE
Viewport provider fix

### DIFF
--- a/.changeset/olive-laws-vanish.md
+++ b/.changeset/olive-laws-vanish.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Viewport provider sets initial viewport

--- a/packages/core/src/__tests__/__e2e__/viewport-provider/ViewportProvider.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/viewport-provider/ViewportProvider.cy.tsx
@@ -75,4 +75,16 @@ describe("Given a ViewportProvider", () => {
       cy.get("@resizeObserver").should("have.been.calledOnce");
     });
   });
+
+  describe("WHEN ViewportProvider is initially mounted", () => {
+    it("THEN the viewport width should be set to the body width", () => {
+      cy.stub(document.body, "getBoundingClientRect").returns({ width: 1000 });
+      mount(
+        <ViewportProvider>
+          <TestComponent />
+        </ViewportProvider>
+      );
+      cy.findByText("1000");
+    });
+  });
 });

--- a/packages/core/src/viewport/ViewportProvider.tsx
+++ b/packages/core/src/viewport/ViewportProvider.tsx
@@ -26,6 +26,7 @@ const ViewportProvider = ({ children }: ViewportProviderProps) => {
       );
 
       observer.observe(document.body);
+      setViewport(document.body.getBoundingClientRect().width);
     }
 
     return () => {


### PR DESCRIPTION
This PR ensures Viewport is read and set immediately. Previously, Viewport was sometimes 0 initially causing a flash of layouts.