### PR TITLE
Fix Combobox input's `onChange` and `onKeyDown` not invoked

### DIFF
--- a/.changeset/empty-gorillas-lie.md
+++ b/.changeset/empty-gorillas-lie.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/lab": patch
+---
+
+Fix Combobox input's `onChange` and `onKeyDown` not invoked

--- a/packages/lab/src/__tests__/__e2e__/combo-box/ComboBox.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/combo-box/ComboBox.cy.tsx
@@ -8,6 +8,7 @@ const {
   // MultiSelect,
   ItemRenderer,
   WithCustomizedFilter,
+  Controlled,
 } = composeStories(comboBoxStories);
 
 describe("A combo box", () => {
@@ -101,7 +102,8 @@ describe("A combo box", () => {
 
   describe("when start typing in the input", () => {
     it("should filter items", () => {
-      cy.mount(<Default />);
+      const changeSpy = cy.stub().as("changeSpy");
+      cy.mount(<Default onChange={changeSpy} />);
 
       cy.findByRole("combobox").realClick();
 
@@ -116,6 +118,13 @@ describe("A combo box", () => {
         "have.length",
         Default.args!.source!.length
       );
+
+      // change callback invoked
+      cy.get("@changeSpy").should(
+        "have.been.calledWith",
+        Cypress.sinon.match.any,
+        "ska"
+      );
     });
 
     it("should highlight matching text", () => {
@@ -129,6 +138,16 @@ describe("A combo box", () => {
 
       cy.findByText("Connec").should("have.class", "saltHighlighter-highlight");
     });
+  });
+
+  it("should work when controlled", () => {
+    cy.mount(<Controlled />);
+
+    cy.realPress("Tab");
+    cy.realType("Baby bl");
+    cy.realPress("Enter");
+
+    cy.findByRole("combobox").should("have.value", "Baby blue");
   });
 });
 

--- a/packages/lab/src/__tests__/__e2e__/combo-box/ComboBox.keyboardNavigation.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/combo-box/ComboBox.keyboardNavigation.cy.tsx
@@ -136,7 +136,7 @@ describe("A combo box", () => {
     describe("when the 'Space' key is pressed", () => {
       it("should not select the highlighted item", () => {
         const changeSpy = cy.stub().as("changeSpy");
-        cy.mount(<Default onChange={changeSpy} />);
+        cy.mount(<Default onSelectionChange={changeSpy} />);
 
         cy.realPress("Tab");
 
@@ -229,7 +229,7 @@ describe("A combo box that allows free text", () => {
   describe("with nothing selected", () => {
     it("should not modify input value when blurred", () => {
       const changeSpy = cy.stub().as("changeSpy");
-      cy.mount(<WithFreeText onChange={changeSpy} />);
+      cy.mount(<WithFreeText onSelectionChange={changeSpy} />);
 
       cy.realPress("Tab");
 

--- a/packages/lab/src/combo-box/useCombobox.ts
+++ b/packages/lab/src/combo-box/useCombobox.ts
@@ -337,10 +337,18 @@ export const useCombobox = <
       const newValue = evt.target.value;
       setValue(newValue);
 
-      if (newValue && newValue.trim().length) {
+      if (newValue?.trim().length) {
         setFilterPattern(newValue);
       } else {
         setFilterPattern(undefined);
+        if (selectedRef.current !== null) {
+          onSelectionChange?.(
+            evt,
+            null as Selection extends SingleSelectionStrategy
+              ? Item | null
+              : Item[]
+          );
+        }
         selectedRef.current = null as selectedCollectionType;
       }
 

--- a/packages/lab/src/combo-box/useCombobox.ts
+++ b/packages/lab/src/combo-box/useCombobox.ts
@@ -232,6 +232,14 @@ export const useCombobox = <
     [allowFreeText, applySelection, indexPositions, quickSelection]
   );
 
+  const {
+    onKeyDown: inputOnKeyDown,
+    onFocus: inputOnFocus,
+    onChange: inputOnChange,
+    onBlur: inputOnBlur,
+    onSelect: inputOnSelect,
+  } = inputProps;
+
   const handleInputKeyDown = useCallback(
     (evt: KeyboardEvent) => {
       if ("Escape" === evt.key) {
@@ -248,11 +256,15 @@ export const useCombobox = <
 
       handleFirstItemSelection(evt);
 
-      // if (inputProps.onKeyDown) {
-      //   inputProps.onKeyDown(event as KeyboardEvent<HTMLInputElement>);
-      // }
+      inputOnKeyDown?.(evt as KeyboardEvent<HTMLInputElement>);
     },
-    [allowFreeText, handleFirstItemSelection, reconcileInput, setTextValue]
+    [
+      allowFreeText,
+      handleFirstItemSelection,
+      inputOnKeyDown,
+      reconcileInput,
+      setTextValue,
+    ]
   );
 
   const handleKeyboardNavigation = useCallback(() => {
@@ -330,26 +342,17 @@ export const useCombobox = <
       } else {
         setFilterPattern(undefined);
         selectedRef.current = null as selectedCollectionType;
-        onSelectionChange?.(
-          evt,
-          null as Selection extends SingleSelectionStrategy
-            ? Item | null
-            : Item[]
-        );
       }
 
       setIsOpen(true);
 
       setQuickSelection(newValue.length > 0 && !allowFreeText);
 
-      // if (inputProps.onChange) {
-      //   inputProps.onChange(event, "");
-      // }
+      inputOnChange?.(evt, newValue);
     },
-    [allowFreeText, onSelectionChange, setFilterPattern, setIsOpen, setValue]
+    [allowFreeText, inputOnChange, setFilterPattern, setIsOpen, setValue]
   );
 
-  const { onFocus: inputOnFocus } = inputProps;
   const { onFocus: listOnFocus } = listControlProps;
   const handleInputFocus = useCallback(
     (evt: FocusEvent<HTMLInputElement>) => {
@@ -402,7 +405,6 @@ export const useCombobox = <
     [onSelectionChange, selected, stringToItem, stringToCollectionItem, value]
   );
 
-  const { onBlur: inputOnBlur } = inputProps;
   const { onBlur: listOnBlur } = listControlProps;
   const handleInputBlur = useCallback(
     (evt: FocusEvent<HTMLInputElement>) => {
@@ -430,7 +432,6 @@ export const useCombobox = <
     ]
   );
 
-  const { onSelect: inputOnSelect } = inputProps;
   const handleInputSelect = useCallback(
     (event: SyntheticEvent<HTMLDivElement>) => {
       if (ignoreSelectOnFocus.current) {

--- a/packages/lab/stories/combobox/combobox.stories.tsx
+++ b/packages/lab/stories/combobox/combobox.stories.tsx
@@ -16,7 +16,6 @@ import {
   shortColorData,
   statesData,
 } from "../assets/exampleData";
-import { source } from "axe-core";
 
 export default {
   title: "Lab/Combo Box",
@@ -157,9 +156,9 @@ export const TestSourceDelay = () => {
   );
 };
 
-export const Controlled = (args) => {
+export const Controlled: StoryFn<ComboBoxProps> = (args) => {
   const [inputValue, setInputValue] = useState("");
-  const [selectedItem, setSelectedItem] = useState(null);
+  const [selectedItem, setSelectedItem] = useState<string | null>(null);
   return (
     <FormField label="Select a large city" style={{ maxWidth: 292 }}>
       <ComboBox
@@ -172,7 +171,7 @@ export const Controlled = (args) => {
         }}
         onSelectionChange={(e, item) => {
           setSelectedItem(item);
-          setInputValue(item);
+          setInputValue(item ?? "");
         }}
       />
     </FormField>

--- a/packages/lab/stories/combobox/combobox.stories.tsx
+++ b/packages/lab/stories/combobox/combobox.stories.tsx
@@ -16,6 +16,7 @@ import {
   shortColorData,
   statesData,
 } from "../assets/exampleData";
+import { source } from "axe-core";
 
 export default {
   title: "Lab/Combo Box",
@@ -152,6 +153,28 @@ export const TestSourceDelay = () => {
   return (
     <FormField label="Select something" style={{ maxWidth: 292 }}>
       <ComboBox source={source} />
+    </FormField>
+  );
+};
+
+export const Controlled = (args) => {
+  const [inputValue, setInputValue] = useState("");
+  const [selectedItem, setSelectedItem] = useState(null);
+  return (
+    <FormField label="Select a large city" style={{ maxWidth: 292 }}>
+      <ComboBox
+        {...args}
+        onChange={(e, value) => setInputValue(value)}
+        value={inputValue}
+        source={shortColorData}
+        ListProps={{
+          selected: selectedItem,
+        }}
+        onSelectionChange={(e, item) => {
+          setSelectedItem(item);
+          setInputValue(item);
+        }}
+      />
     </FormField>
   );
 };


### PR DESCRIPTION
Adds minimal change to old combobox, so it can be a stop gap solution for controlled usage