### PR TITLE
Fix RadioButton and Checkbox not using default Salt text properties

### DIFF
--- a/.changeset/rich-bats-breathe.md
+++ b/.changeset/rich-bats-breathe.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Fix RadioButton and Checkbox not using default Salt text properties

--- a/packages/core/src/checkbox/Checkbox.css
+++ b/packages/core/src/checkbox/Checkbox.css
@@ -4,6 +4,11 @@
   gap: var(--salt-spacing-100);
   position: relative;
   cursor: var(--salt-selectable-cursor-hover);
+
+  font-size: var(--salt-text-fontSize);
+  line-height: var(--salt-text-lineHeight);
+  font-family: var(--salt-text-fontFamily);
+  font-weight: var(--salt-text-fontWeight);
 }
 
 /* Styles applied to root component if `disabled={true}` */

--- a/packages/core/src/radio-button/RadioButton.css
+++ b/packages/core/src/radio-button/RadioButton.css
@@ -4,6 +4,11 @@
   gap: var(--salt-spacing-100);
   cursor: var(--salt-selectable-cursor-hover);
   position: relative;
+
+  font-size: var(--salt-text-fontSize);
+  line-height: var(--salt-text-lineHeight);
+  font-family: var(--salt-text-fontFamily);
+  font-weight: var(--salt-text-fontWeight);
 }
 
 /* Styles applied when RadioButton is disabled */


### PR DESCRIPTION
Should solve immediate issue for radio button #2671

Still need better way to test across all components. Maybe add this to our storybook, to make sure things still work

```
body {
    font-weight: 400;
    font-family: some-other-font;
    font-size: 14px;
    line-height: 1.85714286em;
}
```