### PR TITLE
Fix Salt / UITK text property compatibility

### DIFF
--- a/.changeset/orange-bulldogs-glow.md
+++ b/.changeset/orange-bulldogs-glow.md
@@ -1,0 +1,16 @@
+---
+"@salt-ds/core": patch
+---
+
+Fixed component text properties (`font-weight`, `font-family`, `font-size`, `line-height`) incorrectly impacted by external global styles, which should follow text characteristic from Salt theme.
+
+- Avatar
+- Badge
+- Banner
+- Card
+- Form Field
+- Panel
+- Switch
+- Text
+- Toast
+- Tooltip

--- a/.changeset/orange-bulldogs-glow.md
+++ b/.changeset/orange-bulldogs-glow.md
@@ -2,7 +2,7 @@
 "@salt-ds/core": patch
 ---
 
-Fixed component text properties (`font-weight`, `font-family`, `font-size`, `line-height`) incorrectly impacted by external global styles, which should follow text characteristic from Salt theme.
+Fixed component text properties (`font-weight`, `font-family`, `font-size`, `line-height`) incorrectly inheriting external global styles, which should follow the text characteristic from the Salt theme.
 
 - Avatar
 - Badge

--- a/.changeset/young-pets-exist.md
+++ b/.changeset/young-pets-exist.md
@@ -1,0 +1,14 @@
+---
+"@salt-ds/lab": patch
+---
+
+Fixed component text properties (`font-weight`, `font-family`, `font-size`, `line-height`) incorrectly impacted by external global styles, which should follow text characteristic from Salt theme.
+
+- Content Status
+- Dialog
+- Form Field Legacy
+- List
+- List Next
+- Tab
+- Tab Next
+- Toolbar

--- a/.changeset/young-pets-exist.md
+++ b/.changeset/young-pets-exist.md
@@ -2,7 +2,7 @@
 "@salt-ds/lab": patch
 ---
 
-Fixed component text properties (`font-weight`, `font-family`, `font-size`, `line-height`) incorrectly impacted by external global styles, which should follow text characteristic from Salt theme.
+Fixed component text properties (`font-weight`, `font-family`, `font-size`, `line-height`) incorrectly inheriting external global styles, which should follow the text characteristic from the Salt theme.
 
 - Content Status
 - Dialog

--- a/.storybook/styles.css
+++ b/.storybook/styles.css
@@ -58,3 +58,14 @@
 .salt-theme .sbdocs table tr:nth-of-type(2n) {
   background: var(--salt-color-gray-20);
 }
+
+/* 
+ * This is to make sure Salt components will work ok with UITK
+ * https://github.com/jpmorganchase/salt-ds/issues/2671
+ */
+body {
+  font-weight: 400;
+  font-family: Roboto;
+  font-size: 14px;
+  line-height: 1.85714286em;
+}

--- a/docs/components/QAContainer.css
+++ b/docs/components/QAContainer.css
@@ -47,6 +47,15 @@
   padding: var(--qaContainer-item-padding, 0);
   vertical-align: top;
   width: var(--qaContainer-item-width, var(--itemWrapper-calculated-item-width));
+
+  /* 
+   * This is to make sure Salt components will work ok with UITK
+   * https://github.com/jpmorganchase/salt-ds/issues/2671
+   */
+  font-weight: 400;
+  font-family: Roboto;
+  font-size: 14px;
+  line-height: 1.85714286em;
 }
 .saltFormFieldQA.saltQAContainer {
   height: unset !important;

--- a/packages/ag-grid-theme/stories/examples/StatusBar.tsx
+++ b/packages/ag-grid-theme/stories/examples/StatusBar.tsx
@@ -1,4 +1,4 @@
-import { StackLayout } from "@salt-ds/core";
+import { StackLayout, Text } from "@salt-ds/core";
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
 import dataGridExampleData from "../dependencies/dataGridExampleData";
 import dataGridExampleColumns from "../dependencies/dataGridExampleColumns";
@@ -27,7 +27,7 @@ const StatusBar = (props: AgGridReactProps) => {
     <StackLayout gap={4}>
       {switcher}
       <StackLayout gap={2}>
-        <p>Select rows to enable status bar display</p>
+        <Text>Select rows to enable status bar display</Text>
         <div {...containerProps}>
           <AgGridReact
             enableRangeSelection

--- a/packages/ag-grid-theme/stories/examples/StatusBarDark.tsx
+++ b/packages/ag-grid-theme/stories/examples/StatusBarDark.tsx
@@ -1,4 +1,4 @@
-import { SaltProvider, StackLayout } from "@salt-ds/core";
+import { SaltProvider, StackLayout, Text } from "@salt-ds/core";
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
 import dataGridExampleData from "../dependencies/dataGridExampleData";
 import dataGridExampleColumns from "../dependencies/dataGridExampleColumns";
@@ -30,7 +30,7 @@ const StatusBar = (props: AgGridReactProps) => {
       <StackLayout gap={4}>
         {switcher}
         <StackLayout gap={2}>
-          <p>Select rows to enable status bar display</p>
+          <Text>Select rows to enable status bar display</Text>
           <div {...containerProps}>
             <AgGridReact
               enableRangeSelection

--- a/packages/core/src/avatar/Avatar.css
+++ b/packages/core/src/avatar/Avatar.css
@@ -20,6 +20,8 @@
   background: var(--saltAvatar-background, var(--salt-accent-background));
   color: var(--avatar-foreground);
   font-size: var(--avatar-fontSize);
+  font-family: var(--salt-text-fontFamily);
+  font-weight: var(--salt-text-fontWeight);
   width: var(--avatar-container-size);
   min-width: var(--avatar-container-size);
   height: var(--avatar-container-size);

--- a/packages/core/src/badge/Badge.css
+++ b/packages/core/src/badge/Badge.css
@@ -10,7 +10,6 @@
   /* Should this vary according to touch size */
   padding-left: var(--salt-spacing-50);
   padding-right: var(--salt-spacing-50);
-  line-height: var(--salt-text-notation-lineHeight);
   height: var(--salt-text-notation-lineHeight);
   min-width: var(--salt-text-notation-lineHeight);
   border-radius: 9999px;
@@ -24,6 +23,8 @@
 
   font-size: var(--salt-text-notation-fontSize);
   font-weight: var(--salt-text-notation-fontWeight);
+  font-family: var(--salt-text-fontFamily);
+  line-height: var(--salt-text-notation-lineHeight);
   background: var(--salt-accent-background);
   color: var(--salt-accent-foreground);
 

--- a/packages/core/src/banner/Banner.css
+++ b/packages/core/src/banner/Banner.css
@@ -12,6 +12,11 @@
   padding: var(--saltBanner-padding, var(--salt-spacing-50) var(--salt-spacing-100));
   width: 100%;
   min-height: calc(var(--salt-size-base) + var(--salt-spacing-100));
+
+  font-family: var(--salt-text-fontFamily);
+  font-size: var(--salt-text-fontSize);
+  font-weight: var(--salt-text-fontWeight);
+  line-height: var(--salt-text-lineHeight);
 }
 
 /* Styles applied to icon */

--- a/packages/core/src/card/Card.css
+++ b/packages/core/src/card/Card.css
@@ -4,6 +4,11 @@
   border-width: var(--salt-size-border);
   border-style: var(--salt-container-borderStyle);
   padding: var(--saltCard-padding, var(--salt-spacing-300));
+
+  font-family: var(--salt-text-fontFamily);
+  font-size: var(--salt-text-fontSize);
+  font-weight: var(--salt-text-fontWeight);
+  line-height: var(--salt-text-lineHeight);
 }
 
 .saltCard-primary {

--- a/packages/core/src/form-field/FormField.css
+++ b/packages/core/src/form-field/FormField.css
@@ -4,6 +4,11 @@
   gap: var(--salt-spacing-100);
   text-align: left;
   width: var(--saltFormField-width, 100%);
+
+  font-family: var(--salt-text-fontFamily);
+  font-size: var(--salt-text-fontSize);
+  font-weight: var(--salt-text-fontWeight);
+  line-height: var(--salt-text-lineHeight);
 }
 
 .saltFormField-labelTop {

--- a/packages/core/src/panel/Panel.css
+++ b/packages/core/src/panel/Panel.css
@@ -16,4 +16,9 @@
   overflow: auto;
   padding: var(--saltPanel-padding, var(--salt-size-container-spacing));
   width: var(--saltPanel-width, 100%);
+
+  font-family: var(--salt-text-fontFamily);
+  font-size: var(--salt-text-fontSize);
+  font-weight: var(--salt-text-fontWeight);
+  line-height: var(--salt-text-lineHeight);
 }

--- a/packages/core/src/switch/Switch.css
+++ b/packages/core/src/switch/Switch.css
@@ -4,6 +4,11 @@
   position: relative;
   cursor: var(--salt-selectable-cursor-hover);
   color: var(--salt-content-primary-foreground);
+
+  font-family: var(--salt-text-fontFamily);
+  font-size: var(--salt-text-fontSize);
+  font-weight: var(--salt-text-fontWeight);
+  line-height: var(--salt-text-lineHeight);
 }
 
 .saltSwitch-disabled {

--- a/packages/core/src/text/Text.css
+++ b/packages/core/src/text/Text.css
@@ -2,6 +2,9 @@
 .saltText {
   color: var(--saltText-color, var(--text-color));
   font-family: var(--saltText-fontFamily, var(--salt-text-fontFamily));
+  font-size: var(--saltText-fontSize, var(--salt-text-fontSize));
+  line-height: var(--saltText-lineHeight, var(--salt-text-lineHeight));
+  font-weight: var(--saltText-fontWeight, var(--salt-text-fontWeight));
 }
 
 .saltText::selection {
@@ -41,6 +44,7 @@
 .saltText strong {
   font-weight: var(--salt-text-fontWeight-strong);
 }
+
 /* Body emphasis small */
 .saltText small {
   font-size: inherit;
@@ -85,6 +89,7 @@ h1.saltText strong,
 .saltText-h1.saltText strong {
   font-weight: var(--salt-text-h1-fontWeight-strong);
 }
+
 /* H1 emphasis small */
 h1.saltText small,
 .saltText-h1.saltText small {
@@ -106,6 +111,7 @@ h2.saltText strong,
 .saltText-h2.saltText strong {
   font-weight: var(--salt-text-h2-fontWeight-strong);
 }
+
 /* H2 emphasis small */
 h2.saltText small,
 .saltText-h2.saltText small {
@@ -127,6 +133,7 @@ h3.saltText strong,
 .saltText-h3.saltText strong {
   font-weight: var(--salt-text-h3-fontWeight-strong);
 }
+
 /* H3 emphasis small */
 h3.saltText small,
 .saltText-h3.saltText small {
@@ -148,6 +155,7 @@ h4.saltText strong,
 .saltText-h4.saltText strong {
   font-weight: var(--salt-text-h4-fontWeight-strong);
 }
+
 /* H4 emphasis small */
 h4.saltText small,
 .saltText-h4.saltText small {
@@ -169,6 +177,7 @@ label.saltText strong,
 .saltText-label.saltText strong {
   font-weight: var(--salt-text-label-fontWeight-strong);
 }
+
 /* Label emphasis small */
 label.saltText small,
 .saltText-label.saltText small {

--- a/packages/core/src/toast/Toast.css
+++ b/packages/core/src/toast/Toast.css
@@ -14,6 +14,11 @@
   padding: var(--saltToast-padding, var(--salt-spacing-100));
   min-height: calc(var(--salt-size-base) + var(--salt-spacing-100));
   margin: 0 var(--salt-spacing-100) var(--salt-spacing-100) var(--salt-spacing-100);
+
+  font-family: var(--salt-text-fontFamily);
+  font-size: var(--salt-text-fontSize);
+  font-weight: var(--salt-text-fontWeight);
+  line-height: var(--salt-text-lineHeight);
 }
 
 .saltToast:last-child {

--- a/packages/core/src/tooltip/Tooltip.css
+++ b/packages/core/src/tooltip/Tooltip.css
@@ -13,6 +13,7 @@
   border-width: var(--saltTooltip-borderWidth, var(--salt-size-border));
   box-shadow: var(--saltTooltip-shadow, var(--salt-overlayable-shadow-popout));
   color: var(--saltTooltip-text-color, var(--salt-content-primary-foreground));
+  font-family: var(--salt-text-fontFamily);
   font-size: var(--saltTooltip-fontSize, var(--salt-text-fontSize));
   font-weight: var(--saltTooltip-fontWeight, var(--salt-text-fontWeight));
   line-height: var(--saltTooltip-lineHeight, var(--salt-text-lineHeight));

--- a/packages/core/stories/badge/badge.qa.stories.tsx
+++ b/packages/core/stories/badge/badge.qa.stories.tsx
@@ -1,6 +1,11 @@
 import { Badge, Button, StackLayout } from "@salt-ds/core";
 import { Meta, StoryFn } from "@storybook/react";
-import { QAContainer, QAContainerProps } from "docs/components";
+import {
+  QAContainer,
+  QAContainerNoStyleInjection,
+  QAContainerNoStyleInjectionProps,
+  QAContainerProps,
+} from "docs/components";
 import { MessageIcon, NotificationSolidIcon } from "@salt-ds/icons";
 import { TabNext, TabstripNext } from "@salt-ds/lab";
 
@@ -38,5 +43,39 @@ export const AllExamples: StoryFn<QAContainerProps> = (props) => (
 );
 
 AllExamples.parameters = {
+  chromatic: { disableSnapshot: false },
+};
+
+export const NoStyleInjectionGrid: StoryFn<QAContainerNoStyleInjectionProps> = (
+  props
+) => (
+  <QAContainerNoStyleInjection height={500} width={1000} cols={4} {...props}>
+    <Badge value={9}>
+      <Button>
+        <NotificationSolidIcon />
+      </Button>
+    </Badge>
+    <Badge value={200} max={99}>
+      <Button>
+        <NotificationSolidIcon />
+      </Button>
+    </Badge>
+    <Badge value={"NEW"}>
+      <Button>
+        <MessageIcon />
+      </Button>
+    </Badge>
+    <TabstripNext defaultValue="Transactions">
+      <TabNext value="Transactions">
+        <StackLayout direction="row" gap={1}>
+          Transcations
+          <Badge value={30} />
+        </StackLayout>
+      </TabNext>
+    </TabstripNext>
+  </QAContainerNoStyleInjection>
+);
+
+NoStyleInjectionGrid.parameters = {
   chromatic: { disableSnapshot: false },
 };

--- a/packages/lab/src/content-status/ContentStatus.css
+++ b/packages/lab/src/content-status/ContentStatus.css
@@ -14,11 +14,17 @@
   display: flex;
   flex-direction: column;
   gap: var(--salt-size-unit);
+
+  font-size: var(--salt-text-fontSize);
+  line-height: var(--salt-text-lineHeight);
+  font-family: var(--salt-text-fontFamily);
+  font-weight: var(--salt-text-fontWeight);
 }
 
 /* Styles applied to status title */
-.saltContentStatus-title {
-  font-weight: var(--salt-text-display1-fontWeight); /* TODO: Use correct token */
+.saltContentStatus-title.saltText {
+  font-weight: var(--salt-text-display1-fontWeight);
+  /* TODO: Use correct token */
 }
 
 /* Styles applied to status message */

--- a/packages/lab/src/dialog/Dialog.css
+++ b/packages/lab/src/dialog/Dialog.css
@@ -11,6 +11,11 @@
   box-shadow: var(--salt-overlayable-shadow-modal);
   z-index: calc(var(--salt-zIndex-appHeader) - 1);
   overflow-y: auto;
+
+  font-family: var(--salt-text-fontFamily);
+  font-size: var(--salt-text-fontSize);
+  font-weight: var(--salt-text-fontWeight);
+  line-height: var(--salt-text-lineHeight);
 }
 
 .salt-density-high {

--- a/packages/lab/src/dialog/DialogContent.css
+++ b/packages/lab/src/dialog/DialogContent.css
@@ -4,7 +4,10 @@
   padding-right: var(--salt-spacing-300);
   flex: 1 1 auto;
   min-height: var(--salt-text-lineHeight);
-  font-size: var(--salt-text-fontSize);
-  line-height: var(--salt-text-lineHeight);
   overflow-y: auto;
+
+  font-family: var(--salt-text-fontFamily);
+  font-size: var(--salt-text-fontSize);
+  font-weight: var(--salt-text-fontWeight);
+  line-height: var(--salt-text-lineHeight);
 }

--- a/packages/lab/src/form-field-legacy/FormFieldLegacy.css
+++ b/packages/lab/src/form-field-legacy/FormFieldLegacy.css
@@ -29,13 +29,17 @@
 .saltFormFieldLegacy {
   border: 0;
   display: inline-grid;
-  font-size: var(--saltFormFieldLegacy-fontSize, var(--salt-text-fontSize));
   margin: var(--saltFormFieldLegacy-margin, 0);
   padding: 0;
   position: relative;
   min-width: 0;
   vertical-align: top;
   width: var(--saltFormFieldLegacy-width, auto);
+
+  font-family: var(--salt-text-fontFamily);
+  font-size: var(--saltFormFieldLegacy-fontSize, var(--salt-text-fontSize));
+  font-weight: var(--salt-text-fontWeight);
+  line-height: var(--salt-text-lineHeight);
 }
 
 /* Class applied to the root element on hover */

--- a/packages/lab/src/list-next/ListNext.css
+++ b/packages/lab/src/list-next/ListNext.css
@@ -12,4 +12,9 @@
   position: relative;
   padding-inline-start: 0;
   box-sizing: content-box;
+
+  font-family: var(--salt-text-fontFamily);
+  font-size: var(--salt-text-fontSize);
+  font-weight: var(--salt-text-fontWeight);
+  line-height: var(--salt-text-lineHeight);
 }

--- a/packages/lab/src/list/List.css
+++ b/packages/lab/src/list/List.css
@@ -18,6 +18,11 @@
   position: relative;
   user-select: none;
   width: var(--saltList-width, auto);
+
+  font-family: var(--salt-text-fontFamily);
+  font-size: var(--salt-text-fontSize);
+  font-weight: var(--salt-text-fontWeight);
+  line-height: var(--salt-text-lineHeight);
 }
 
 .saltList-borderless {

--- a/packages/lab/src/tabs-next/TabstripNext.css
+++ b/packages/lab/src/tabs-next/TabstripNext.css
@@ -9,6 +9,11 @@
   width: 100%;
   padding-left: var(--salt-spacing-300);
   padding-right: var(--salt-spacing-300);
+
+  font-family: var(--salt-text-fontFamily);
+  font-size: var(--salt-text-fontSize);
+  font-weight: var(--salt-text-fontWeight);
+  line-height: var(--salt-text-lineHeight);
 }
 
 .saltTabstripNext-main::before {

--- a/packages/lab/src/tabs/Tab.css
+++ b/packages/lab/src/tabs/Tab.css
@@ -25,6 +25,11 @@
   outline: none;
   position: var(--saltTabs-tab-position, var(--tabs-tab-position));
   user-select: none;
+
+  font-family: var(--salt-text-fontFamily);
+  font-size: var(--salt-text-fontSize);
+  font-weight: var(--salt-text-fontWeight);
+  /* Not specify line-height, otherwise tabs are misaligned */
 }
 
 /* Overrides characteristic used in saltFocusVisible */

--- a/packages/lab/src/toolbar/Toolbar.css
+++ b/packages/lab/src/toolbar/Toolbar.css
@@ -12,6 +12,11 @@
   justify-content: flex-start;
   overflow: hidden;
   position: relative;
+
+  font-family: var(--salt-text-fontFamily);
+  font-size: var(--salt-text-fontSize);
+  font-weight: var(--salt-text-fontWeight);
+  line-height: var(--salt-text-lineHeight);
 }
 
 /* .saltToolbarField:not([data-overflow-indicator]) > .saltButton {

--- a/packages/lab/stories/form-field-legacy/form-field.stories.tsx
+++ b/packages/lab/stories/form-field-legacy/form-field.stories.tsx
@@ -1,4 +1,4 @@
-import { SaltProvider } from "@salt-ds/core";
+import { SaltProvider, H3 } from "@salt-ds/core";
 import { Dropdown, FormField, FormFieldProps, Input } from "@salt-ds/lab";
 import { useState } from "react";
 import { Meta, StoryFn } from "@storybook/react";
@@ -38,7 +38,7 @@ export const Secondary: StoryFn<typeof FormField> = () => (
     }}
   >
     <div style={{ width: "200px" }}>
-      <h3>Secondary</h3>
+      <H3>Secondary</H3>
       <FormField
         label="Secondary form field"
         helperText="Helper text value"
@@ -48,7 +48,7 @@ export const Secondary: StoryFn<typeof FormField> = () => (
       </FormField>
     </div>
     <div style={{ width: "200px" }}>
-      <h3>Secondary with disabled outer ring</h3>
+      <H3>Secondary with disabled outer ring</H3>
       <FormField
         label="Secondary form field"
         helperText="Helper text value"
@@ -63,7 +63,7 @@ export const Secondary: StoryFn<typeof FormField> = () => (
 
 export const Tertiary: StoryFn<typeof FormField> = () => (
   <div style={{ width: "200px" }}>
-    <h3>Tertiary</h3>
+    <H3>Tertiary</H3>
     <FormField
       label="Tertiary form field"
       helperText="Helper text value"

--- a/site/src/examples/ag-grid-theme/StatusBar.tsx
+++ b/site/src/examples/ag-grid-theme/StatusBar.tsx
@@ -1,6 +1,7 @@
+import { Text } from "@salt-ds/core";
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
-import { useAgGridHelpers } from "./useAgGridHelpers";
 import { defaultColumns, defaultData } from "./data";
+import { useAgGridHelpers } from "./useAgGridHelpers";
 
 const statusBar = {
   statusPanels: [
@@ -19,7 +20,7 @@ export const StatusBar = (props: AgGridReactProps) => {
 
   return (
     <>
-      <p>Select rows to enable status bar display</p>
+      <Text>Select rows to enable status bar display</Text>
       <div {...containerProps}>
         <AgGridReact
           enableRangeSelection


### PR DESCRIPTION
Added text styles appearing in UITK's `body` to storybook (not website), so all subsequent components we're working on will have that checked out. 

Try to fix all core component's defect as well in this PR, mostly rely on Chromatic snapshot comparison.

Given Chromatic snapshot are rendered using `QAContainer`, which has `SaltProvider` wrapped inside, additional `body` styles will not be taken effect (unlike the order of`:root.salt-theme body`). So I also added additional text styles to `QAContainer` as well (`.background-item-wrapper`)

#2671

## Alternative Approaches A

Add default text styles to a fixed global className (similar to `.saltFocusVisible`), add apply that to components needed.

I didn't choose this with 2 reasons

1. Not all components needs the same default, e.g. for Button, which becomes an override of bold text on top of default value. It will either pollute relying more on CSS order, or increased CSS specificity 
1. A few components need to expose component CSS API for override, e.g. `--saltComponent-fontSize`, which this approach doesn't help

## Alternative Approaches B

Wrap every component with Text component which provides this.

1. I think most component we write should be atomic, i.e. less dependency between each other, just like we likely not use layout components ourselves. This helps isolated update and maintenance. 
1. User override will be harder, given additional nested DOM structure introduced

