### PR TITLE
Make ViewportProvider test more stable

### DIFF
--- a/packages/core/src/__tests__/__e2e__/viewport-provider/ViewportProvider.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/viewport-provider/ViewportProvider.cy.tsx
@@ -1,9 +1,16 @@
 import { useViewport, ViewportContext, ViewportProvider } from "@salt-ds/core";
 import { mount } from "cypress/react18";
+import { useEffect } from "react";
 
-const TestComponent = () => {
+const TestComponent = ({
+  onViewPortWidthChange,
+}: {
+  onViewPortWidthChange?: (width: number) => void;
+}) => {
   const width = useViewport();
-
+  useEffect(() => {
+    onViewPortWidthChange?.(width);
+  }, [width, onViewPortWidthChange]);
   return <div>{width}</div>;
 };
 
@@ -78,13 +85,16 @@ describe("Given a ViewportProvider", () => {
 
   describe("WHEN ViewportProvider is initially mounted", () => {
     it("THEN the viewport width should be set to the body width", () => {
+      const widthChangeSpy = cy.spy().as("widthChange");
+
       cy.stub(document.body, "getBoundingClientRect").returns({ width: 1000 });
       mount(
         <ViewportProvider>
-          <TestComponent />
+          <TestComponent onViewPortWidthChange={widthChangeSpy} />
         </ViewportProvider>
       );
-      cy.findByText("1000");
+
+      cy.get("@widthChange").should("have.been.calledWith", 1000);
     });
   });
 });


### PR DESCRIPTION
Previous test fails in almost all the runs (1 in 3 react versions)