### PR TITLE
Add Markdown support to component descriptions, use PillNext for tags and fix code element font family

### DIFF
--- a/site/src/components/components/PropsTable.tsx
+++ b/site/src/components/components/PropsTable.tsx
@@ -1,6 +1,9 @@
 import { FC, useEffect } from "react";
 import ReactMarkdown from "react-markdown";
 import { Table } from "../mdx/table";
+import { code, p, ul } from "../mdx";
+
+const components = { code, ul, p };
 
 type PropsTableType = {
   /**
@@ -65,7 +68,9 @@ export const PropsTable: FC<PropsTableType> = ({
                   <code>{type.name}</code>
                 </td>
                 <td>
-                  <ReactMarkdown>{description}</ReactMarkdown>
+                  <ReactMarkdown components={components}>
+                    {description}
+                  </ReactMarkdown>
                 </td>
                 <td>
                   <code>{defaultValue ? defaultValue.value : "-"}</code>

--- a/site/src/components/mdx/code/Code.module.css
+++ b/site/src/components/mdx/code/Code.module.css
@@ -4,7 +4,7 @@
 }
 
 .code {
-  font-family: SFMono-Regular, Menlo;
+  font-family: var(--salt-text-code-fontFamily);
   overflow-wrap: anywhere;
   vertical-align: text-bottom;
   white-space: pre-wrap;

--- a/site/src/layouts/DetailComponent/DetailComponent.tsx
+++ b/site/src/layouts/DetailComponent/DetailComponent.tsx
@@ -11,6 +11,7 @@ import {
   useMeta,
 } from "@jpmorganchase/mosaic-store";
 import { TabPanel, Tabs } from "@salt-ds/lab";
+import ReactMarkdown from "react-markdown";
 import { LayoutProps } from "../types/index";
 import { DetailBase } from "../DetailBase";
 import SecondarySidebar from "./SecondarySidebar";
@@ -19,6 +20,9 @@ import MobileDrawer from "./MobileDrawer";
 import useIsMobileView from "../../utils/useIsMobileView";
 import { AllExamplesViewContext } from "../../utils/useAllExamplesView";
 import styles from "./DetailComponent.module.css";
+import { code, p, ul } from "../../components";
+
+const components = { code, ul, p };
 
 const tabs = [
   { id: 0, name: "examples", label: "Examples" },
@@ -134,8 +138,9 @@ export const DetailComponent: FC<LayoutProps> = ({ children }) => {
             drawerContent={<SecondarySidebar additionalData={useData} />}
           />
         )}
-
-        <p>{description}</p>
+        <ReactMarkdown components={components}>
+          {description ?? ""}
+        </ReactMarkdown>
         <Tabs
           activeTabIndex={currentTabIndex}
           onActiveChange={updateRouteWhenTabChanges}

--- a/site/src/layouts/DetailComponent/SecondarySidebar.tsx
+++ b/site/src/layouts/DetailComponent/SecondarySidebar.tsx
@@ -1,6 +1,6 @@
 import React, { FC, ReactNode } from "react";
 import { Image } from "@jpmorganchase/mosaic-site-components";
-import { Pill } from "@salt-ds/lab";
+import { PillNext } from "@salt-ds/lab";
 import { Link } from "@salt-ds/core";
 import { Heading4 } from "../../components/mdx/h4";
 import { Data, Relationship } from "./DetailComponent";
@@ -53,7 +53,7 @@ const SecondarySidebar: FC<SecondarySidebarProps> = ({
       <Heading4>Also known as</Heading4>
       <div className={styles.pills}>
         {alsoKnownAs.map((name) => (
-          <Pill key={name} label={name} />
+          <PillNext key={name}>{name}</PillNext>
         ))}
       </div>
     </>
@@ -76,7 +76,7 @@ const SecondarySidebar: FC<SecondarySidebarProps> = ({
           <Heading4>{heading}</Heading4>
           <div className={styles.pills}>
             {components.map(({ name }) => (
-              <Pill key={name} label={name} />
+              <PillNext key={name}>{name}</PillNext>
             ))}
           </div>
         </>


### PR DESCRIPTION
Fix code element font family:

Before:
![image](https://github.com/jpmorganchase/salt-ds/assets/12938082/a66d22f8-f9d8-4391-9eb0-2baa406fcc87)
![image](https://github.com/jpmorganchase/salt-ds/assets/12938082/2b19ca98-dd17-4d55-a28c-ff8b13196f1f)


After:
![image](https://github.com/jpmorganchase/salt-ds/assets/12938082/64218d9d-aff4-462e-ac0d-95d3927fcbfa)
![image](https://github.com/jpmorganchase/salt-ds/assets/12938082/8853c3a9-9387-4e53-8f0e-9174f92de043)


Use PillNext:

Before:
![image](https://github.com/jpmorganchase/salt-ds/assets/12938082/55ef4930-16e9-4df3-b100-588b6baa0cb1)

After:
![image](https://github.com/jpmorganchase/salt-ds/assets/12938082/f996f69f-5b88-4d2a-b347-dc3eac9df8fd)
