### PR TITLE
Fix Combo Box Next `onChange` using stale values

### DIFF
--- a/.changeset/ninety-queens-retire.md
+++ b/.changeset/ninety-queens-retire.md
@@ -2,4 +2,4 @@
 "@salt-ds/lab": patch
 ---
 
-Fix combobox onchange using stale value
+Fix Combo Box Next `onChange` using stale values

--- a/.changeset/ninety-queens-retire.md
+++ b/.changeset/ninety-queens-retire.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/lab": patch
+---
+
+Fix combobox onchange using stale value

--- a/packages/lab/src/combo-box-next/ComboBoxNext.tsx
+++ b/packages/lab/src/combo-box-next/ComboBoxNext.tsx
@@ -196,7 +196,7 @@ export const ComboBoxNext = forwardRef(function ComboBoxNext<T>(
   const getFilteredSource = () => {
     if (!source) return null;
     if (selectedItem && inputValue === selectedItem) return source;
-    return itemFilter && itemFilter(source, inputValue);
+    return itemFilter?.(source, inputValue);
   };
   const filteredSource = getFilteredSource();
 
@@ -214,7 +214,7 @@ export const ComboBoxNext = forwardRef(function ComboBoxNext<T>(
         setHighlightedItem(filteredSource[0] as unknown as string);
       }
     }
-    onInputChange?.(event, { value: inputValue ?? "" });
+    onInputChange?.(event, { value: value ?? "" });
   };
 
   const adornment = open ? (


### PR DESCRIPTION
Fix issue where combobox onChange was lagging behind the text typed into the combobox by one render. 

This was caused by sending inputValue to the onInputChange callback which had been set via setInputValue, but won't be updated till the next render.

Instead this change passes the value from event/target.value which will be the updated value.