### PR TITLE
Fix component doc lab badge and missing next / prev bottom navs

### DIFF
--- a/site/mosaic.config.js
+++ b/site/mosaic.config.js
@@ -33,6 +33,11 @@ const saltConfig = {
         icon: "🚧",
       },
     },
+    {
+      modulePath: require.resolve(
+        "./src/mosaic-plugins/ChildrenDocPaginatorPlugin.mjs"
+      ),
+    },
   ],
 };
 

--- a/site/mosaic.config.js
+++ b/site/mosaic.config.js
@@ -35,7 +35,7 @@ const saltConfig = {
     },
     {
       modulePath: require.resolve(
-        "./src/mosaic-plugins/ChildrenDocPaginatorPlugin.mjs"
+        "./src/mosaic-plugins/ComponentsDocPaginatorPlugin.mjs"
       ),
     },
   ],

--- a/site/package.json
+++ b/site/package.json
@@ -16,7 +16,8 @@
     "gen:snapshot": "yarn gen:props && yarn gen:css && yarn mosaic build --out snapshots --name latest --config mosaic.config.js && yarn copy:sitemap",
     "serve:snapshot:file": "yarn cross-env MOSAIC_MODE='snapshot-file' concurrently --kill-others 'yarn dev'",
     "serve:snapshot:s3": "yarn cross-env MOSAIC_MODE='snapshot-s3' concurrently --kill-others 'yarn dev'",
-    "serve": "yarn gen:props && yarn gen:css && concurrently --kill-others 'yarn dev' 'yarn mosaic serve -c ./mosaic.config.js' -p 8080",
+    "serve:mosaic": "yarn mosaic serve -c ./mosaic.config.js -p 8080",
+    "serve": "yarn gen:props && yarn gen:css && concurrently --kill-others 'yarn dev' 'yarn serve:mosaic'",
     "copy:sitemap": "yarn node copySitemap.js",
     "gen:props": "yarn node './propsGen.js'",
     "gen:css": "yarn node './cssGen.js'"

--- a/site/src/layouts/DetailBase/DetailBase.module.css
+++ b/site/src/layouts/DetailBase/DetailBase.module.css
@@ -138,16 +138,7 @@
 }
 
 .headingContainer {
-  display: flex;
-  align-items: center;
-  gap: var(--salt-size-unit);
-  /*
-    Mosaic's still using Salt 1.1, so --salt-spacing-100 etc is not available yet.
-
-    TODO: Replace line below with the commented-out one underneath once we upgrade Mosaic
-  */
-  margin: calc(var(--salt-size-unit) * 8) calc(3 * var(--salt-size-unit)) calc(var(--salt-size-unit) * 2) calc(3 * var(--salt-size-unit));
-  /* margin: var(--salt-spacing-800) var(--salt-spacing-300) var(--salt-spacing-200) var(--salt-spacing-300); */
+  margin: calc(var(--salt-spacing-100) * 8) var(--salt-spacing-300) var(--salt-spacing-200) var(--salt-spacing-300);
 }
 
 .headingContainer h1 {

--- a/site/src/layouts/DetailBase/DetailBase.tsx
+++ b/site/src/layouts/DetailBase/DetailBase.tsx
@@ -1,43 +1,49 @@
-import React, { FC, ReactElement } from "react";
-import clsx from "clsx";
 import { HelpLinks } from "@jpmorganchase/mosaic-components";
+import { LayoutBase } from "@jpmorganchase/mosaic-layouts";
 import {
-  DocPaginator,
   BackLink,
   Breadcrumbs,
+  DocPaginator,
   PageNavigation,
 } from "@jpmorganchase/mosaic-site-components";
-import { useStore, SiteState } from "@jpmorganchase/mosaic-store";
-import { Footer } from "../../components/footer";
+import { SiteState, useMeta, useStore } from "@jpmorganchase/mosaic-store";
+import { SaltProvider, FlexLayout } from "@salt-ds/core";
+import clsx from "clsx";
+import { FC, ReactElement } from "react";
 import { AppHeader } from "../../components/app-header";
-import { LayoutBase } from "@jpmorganchase/mosaic-layouts";
+import { Footer } from "../../components/footer";
 import { StatusPill } from "../../components/status-pill";
 import { LayoutColumns } from "../LayoutColumns/LayoutColumns";
-import { SaltProvider } from "@salt-ds/core";
-import { useMeta } from "@jpmorganchase/mosaic-store";
-import { LayoutProps } from "../types/index";
 import layoutStyles from "../index.module.css";
+import { LayoutProps } from "../types/index";
 import styles from "./DetailBase.module.css";
 
-type Data = {
+interface Data {
   status: string;
-};
+}
 
 type CustomSiteState = SiteState & { data?: Data };
 
-type PageHeadingWithPillProps = {
+interface PageHeadingWithPillProps {
   title?: string | ReactElement;
   pageStatus: string;
-};
+  isMobileView?: boolean;
+}
 
 const PageHeadingWithPill: FC<PageHeadingWithPillProps> = ({
   title,
   pageStatus,
+  isMobileView,
 }) => (
-  <div className={styles.headingContainer}>
+  <FlexLayout
+    className={styles.headingContainer}
+    direction={isMobileView ? "column" : "row"}
+    align={isMobileView ? "start" : "center"}
+    gap={isMobileView ? 0 : 1}
+  >
     <h1>{title}</h1>
     {pageStatus && <StatusPill label={pageStatus} />}
-  </div>
+  </FlexLayout>
 );
 
 export const DetailBase: FC<LayoutProps> = ({
@@ -47,6 +53,7 @@ export const DetailBase: FC<LayoutProps> = ({
   children,
   sidebar,
   pageTitle: titleProp,
+  isMobileView,
 }) => {
   const Header = <AppHeader />;
 
@@ -80,7 +87,11 @@ export const DetailBase: FC<LayoutProps> = ({
         <LayoutColumns PrimarySidebar={PrimarySidebar}>
           <Breadcrumbs />
           {pageStatus ? (
-            <PageHeadingWithPill title={pageTitle} pageStatus={pageStatus} />
+            <PageHeadingWithPill
+              title={pageTitle}
+              pageStatus={pageStatus}
+              isMobileView={isMobileView}
+            />
           ) : (
             <h1 className={layoutStyles.title}>{pageTitle}</h1>
           )}

--- a/site/src/layouts/DetailComponent/DetailComponent.tsx
+++ b/site/src/layouts/DetailComponent/DetailComponent.tsx
@@ -55,7 +55,7 @@ type CustomSiteState = SiteState & { data?: Data };
 export const DetailComponent: FC<LayoutProps> = ({ children }) => {
   const [openDrawer, setOpenDrawer] = useState(false);
 
-  const { push } = useRouter();
+  const { replace, push } = useRouter();
   const { route } = useRoute();
 
   const [allExamplesView, setAllExamplesView] = useState(false);
@@ -80,9 +80,9 @@ export const DetailComponent: FC<LayoutProps> = ({ children }) => {
   useEffect(() => {
     // Default to first tab, "Examples"
     if (!currentTab) {
-      push(`${newRoute}${tabs[0].name}`);
+      replace(`${newRoute}${tabs[0].name}`);
     }
-  }, [route]);
+  }, [currentTab, newRoute, replace, route]);
 
   const isMobileView = useIsMobileView();
 

--- a/site/src/layouts/DetailComponent/DetailComponent.tsx
+++ b/site/src/layouts/DetailComponent/DetailComponent.tsx
@@ -28,17 +28,17 @@ const tabs = [
 
 export type Relationship = "similarTo" | "contains";
 
-type RelatedComponent = {
+interface RelatedComponent {
   name: string;
   relationship: Relationship;
-};
+}
 
-type ComponentNpmInfo = {
+interface ComponentNpmInfo {
   name: string;
   initialRelease?: string;
-};
+}
 
-export type Data = {
+export interface Data {
   description: string;
   alsoKnownAs: string[];
   relatedComponents: RelatedComponent[];
@@ -48,7 +48,7 @@ export type Data = {
   bugReport?: string;
   featureRequest?: string;
   askQuestion?: string;
-};
+}
 
 type CustomSiteState = SiteState & { data?: Data };
 
@@ -73,11 +73,12 @@ export const DetailComponent: FC<LayoutProps> = ({ children }) => {
     return state.data ? { ...defaultData, ...state.data } : undefined;
   });
 
-  const { description } = useData || {};
+  const { description } = useData ?? {};
 
   const currentTab = tabs.find(({ name }) => route?.includes(name));
 
   useEffect(() => {
+    // Default to first tab, "Examples"
     if (!currentTab) {
       push(`${newRoute}${tabs[0].name}`);
     }
@@ -125,6 +126,7 @@ export const DetailComponent: FC<LayoutProps> = ({ children }) => {
             />
           ) : undefined
         }
+        isMobileView={isMobileView}
       >
         {isMobileView && (
           <MobileDrawer

--- a/site/src/layouts/types/index.ts
+++ b/site/src/layouts/types/index.ts
@@ -29,4 +29,5 @@ export type LayoutProps = {
   frontmatter?: {
     [key: string]: any;
   };
+  isMobileView?: boolean;
 };

--- a/site/src/mosaic-plugins/ChildrenDocPaginatorPlugin.mjs
+++ b/site/src/mosaic-plugins/ChildrenDocPaginatorPlugin.mjs
@@ -1,0 +1,63 @@
+const COMPONENT_OVERVIEW = {
+  title: "Overview",
+  route: "/salt/components/index",
+};
+
+function buildRouteNavigationData(pages) {
+  const allComponentIndexPages = pages
+    .filter((p) => new RegExp("components/[\\w-]+/index").test(p.route))
+    .sort((a, b) => a.route.localeCompare(b.route));
+
+  const pageIndexToNavigation = {};
+  for (let index = 0; index < allComponentIndexPages.length; index++) {
+    const page = allComponentIndexPages[index];
+    const prev =
+      index === 0
+        ? COMPONENT_OVERVIEW
+        : {
+            title: allComponentIndexPages[index - 1].title,
+            route: allComponentIndexPages[index - 1].route,
+          };
+
+    const next =
+      index === allComponentIndexPages.length - 1
+        ? undefined
+        : {
+            title: allComponentIndexPages[index + 1].title,
+            route: allComponentIndexPages[index + 1].route,
+          };
+
+    pageIndexToNavigation[page.route] = {
+      prev,
+      ...(next ? { next } : {}), // Don't want undefined or Mosaic will throw
+    };
+  }
+  return pageIndexToNavigation;
+}
+
+const ChildrenDocPaginatorPlugin = {
+  async $afterSource(pages) {
+    const componentRouteToName = buildRouteNavigationData(pages);
+
+    for (const page of pages) {
+      // Only work with components route
+      if (!new RegExp(`/components/`).test(page.route)) {
+        continue;
+      }
+
+      if (page.route.endsWith("/index")) {
+        // Don't care about index page, they are not displayed
+      } else {
+        const indexPageRoute =
+          page.route.substring(0, page.route.lastIndexOf("/")) + "/index";
+
+        if (componentRouteToName[indexPageRoute]) {
+          page.navigation = componentRouteToName[indexPageRoute];
+        }
+      }
+    }
+    return pages;
+  },
+};
+
+export default ChildrenDocPaginatorPlugin;

--- a/site/src/mosaic-plugins/ComponentsDocPaginatorPlugin.mjs
+++ b/site/src/mosaic-plugins/ComponentsDocPaginatorPlugin.mjs
@@ -35,7 +35,7 @@ function buildRouteNavigationData(pages) {
   return pageIndexToNavigation;
 }
 
-const ChildrenDocPaginatorPlugin = {
+const ComponentsDocPaginatorPlugin = {
   async $afterSource(pages) {
     const componentRouteToName = buildRouteNavigationData(pages);
 
@@ -60,4 +60,4 @@ const ChildrenDocPaginatorPlugin = {
   },
 };
 
-export default ChildrenDocPaginatorPlugin;
+export default ComponentsDocPaginatorPlugin;


### PR DESCRIPTION
- Stack "Lab Component" badge on mobile. To test, go to dropdown component page on mobile viewport.
- Add missing footer prev/next navigation links on component pages, so it's navigable on mobile.
- Use `replace` instead of `push` to redirect from `<Component>/index` to `<Component>/examples`, so that browser back button will not always circulate back to index.

closes #2712