### PR TITLE
Fix nested Salt Providers not inheriting a parent provider's `enableStyleInjection` value

### DIFF
--- a/.changeset/thin-yaks-rush.md
+++ b/.changeset/thin-yaks-rush.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Fixed nested Salt Providers not inheriting a parent provider's `enableStyleInjection` value.

--- a/packages/core/src/salt-provider/SaltProvider.tsx
+++ b/packages/core/src/salt-provider/SaltProvider.tsx
@@ -209,7 +209,7 @@ function InternalSaltProvider({
 }
 
 export function SaltProvider({
-  enableStyleInjection = true,
+  enableStyleInjection,
   ...restProps
 }: SaltProviderProps) {
   return (

--- a/packages/core/stories/style-injection/style-injection.default.stories.tsx
+++ b/packages/core/stories/style-injection/style-injection.default.stories.tsx
@@ -1,6 +1,5 @@
-import { Button } from "@salt-ds/core";
+import { Button, SaltProvider } from "@salt-ds/core";
 import { StoryFn } from "@storybook/react";
-import { SaltProvider } from "@salt-ds/core";
 
 export default {
   title: "Core/Style Injection",

--- a/packages/core/stories/style-injection/style-injection.default.stories.tsx
+++ b/packages/core/stories/style-injection/style-injection.default.stories.tsx
@@ -1,0 +1,21 @@
+import { Button } from "@salt-ds/core";
+import { StoryFn } from "@storybook/react";
+import { SaltProvider } from "@salt-ds/core";
+
+export default {
+  title: "Core/Style Injection",
+  component: SaltProvider,
+};
+
+export const RootDefault: StoryFn = () => (
+  <SaltProvider>
+    <Button variant="primary">style injection enabled</Button>
+    <SaltProvider>
+      <Button variant="primary">Nested - style injection enabled</Button>
+    </SaltProvider>
+  </SaltProvider>
+);
+
+RootDefault.parameters = {
+  chromatic: { disableSnapshot: false },
+};

--- a/packages/core/stories/style-injection/style-injection.disabled.stories.tsx
+++ b/packages/core/stories/style-injection/style-injection.disabled.stories.tsx
@@ -1,0 +1,23 @@
+import { Button } from "@salt-ds/core";
+import { StoryFn } from "@storybook/react";
+import { SaltProvider } from "@salt-ds/core";
+
+export default {
+  title: "Core/Style Injection",
+  component: SaltProvider,
+};
+
+export const RootDisabled: StoryFn = () => (
+  <SaltProvider enableStyleInjection={false}>
+    <Button variant="primary">Root - style injection disabled</Button>
+    <SaltProvider>
+      <Button variant="primary">
+        Nested - style injection enabled (but should inherit from root)
+      </Button>
+    </SaltProvider>
+  </SaltProvider>
+);
+
+RootDisabled.parameters = {
+  chromatic: { disableSnapshot: false },
+};

--- a/packages/core/stories/style-injection/style-injection.disabled.stories.tsx
+++ b/packages/core/stories/style-injection/style-injection.disabled.stories.tsx
@@ -1,6 +1,5 @@
-import { Button } from "@salt-ds/core";
+import { Button, SaltProvider } from "@salt-ds/core";
 import { StoryFn } from "@storybook/react";
-import { SaltProvider } from "@salt-ds/core";
 
 export default {
   title: "Core/Style Injection",

--- a/packages/core/stories/style-injection/style-injection.enabled.stories.tsx
+++ b/packages/core/stories/style-injection/style-injection.enabled.stories.tsx
@@ -1,0 +1,21 @@
+import { Button } from "@salt-ds/core";
+import { StoryFn } from "@storybook/react";
+import { SaltProvider } from "@salt-ds/core";
+
+export default {
+  title: "Core/Style Injection",
+  component: SaltProvider,
+};
+
+export const RootEnabled: StoryFn = () => (
+  <SaltProvider enableStyleInjection={true}>
+    <Button variant="primary">Root - style injection enabled</Button>
+    <SaltProvider enableStyleInjection={false}>
+      <Button variant="primary">Nested - style injection disabled</Button>
+    </SaltProvider>
+  </SaltProvider>
+);
+
+RootEnabled.parameters = {
+  chromatic: { disableSnapshot: false },
+};

--- a/packages/core/stories/style-injection/style-injection.enabled.stories.tsx
+++ b/packages/core/stories/style-injection/style-injection.enabled.stories.tsx
@@ -1,6 +1,5 @@
-import { Button } from "@salt-ds/core";
+import { Button, SaltProvider } from "@salt-ds/core";
 import { StoryFn } from "@storybook/react";
-import { SaltProvider } from "@salt-ds/core";
 
 export default {
   title: "Core/Style Injection",

--- a/packages/styles/src/style-injection-provider/index.tsx
+++ b/packages/styles/src/style-injection-provider/index.tsx
@@ -1,6 +1,26 @@
-import { createContext, useContext } from "react";
+import React, { type ReactNode, createContext, useContext } from "react";
+export interface StyleInjectionContextType {
+  value?: boolean;
+}
 
 const StyleInjectionContext = createContext(true);
 
-export const useStyleInjection = () => useContext(StyleInjectionContext);
-export const StyleInjectionProvider = StyleInjectionContext.Provider;
+export function useStyleInjection(enableStyleInjection?: boolean): boolean {
+  const enableStyleInjectionFromContext = useContext(StyleInjectionContext);
+  return enableStyleInjection ?? enableStyleInjectionFromContext;
+}
+
+export interface StyleInjectionProviderProps extends StyleInjectionContextType {
+  children: ReactNode;
+}
+
+export function StyleInjectionProvider(props: StyleInjectionProviderProps) {
+  const { value: enableStyleInjectionProp, children } = props;
+  const value = useStyleInjection(enableStyleInjectionProp);
+
+  return (
+    <StyleInjectionContext.Provider value={value}>
+      {children}
+    </StyleInjectionContext.Provider>
+  );
+}


### PR DESCRIPTION
Root `StyleInjectionProvider` overrides nested `StyleInjectionProvider` 