### PR TITLE
Updated KeyboardControl site component to allow alternate keycombos to be separated by "or"

### DIFF
--- a/site/src/components/keyboard-controls/KeyboardControl.tsx
+++ b/site/src/components/keyboard-controls/KeyboardControl.tsx
@@ -9,8 +9,8 @@ export interface KeyboardControlProps {
    * Use "+" to indcate combos - i.e. when more than one key
    * need to pressed at the same time (e.g. "CTRL + A").
    *
-   * Use "/" to separate alternative keys or combos.
-   * E.g. "SPACE / ENTER"
+   * Use "/" or "or" to separate alternative keys or combos.
+   * E.g. "SPACE / ENTER" or "SPACE or ENTER"
    *
    * You can combine alternate combos too.
    * E.g.: "CTRL + A / CMD + A"
@@ -20,7 +20,7 @@ export interface KeyboardControlProps {
   className?: string;
 }
 
-const keyOrComboSeparator = /\s*([\+\/])\s*/;
+const keyOrComboSeparator = /\s*([\+\/]|or)\s*/i;
 
 function splitCombo(keyOrCombo: string): string[] {
   return keyOrCombo.split(keyOrComboSeparator);


### PR DESCRIPTION
Currently, alternate key combinations provided to the `<KeyboardControl>` component (which is used on the site's component pages in the accessibility tab) need to be separated by a slash (`/`). Based on a discussion with @mikearildbrown, we decided it would be more readable if we used the word "or" instead.

This PR allows you to use `/` or `or`, so that existing docs which all use `/` continue to work. However, they can now gradually be updated to use `or` instead.