### PR TITLE
Style Keys in Keyboard Accessibility Table

### DIFF
--- a/site/src/components/keyboard-controls/KeyboardControls.module.css
+++ b/site/src/components/keyboard-controls/KeyboardControls.module.css
@@ -3,12 +3,21 @@
   margin-bottom: calc(2 * var(--salt-size-unit));
 }
 
-.table td {
-  vertical-align: top;
-}
-
 .table td > :last-child {
   margin-bottom: 0;
+}
+
+.table kbd {
+  display: inline-block;
+  background-color: var(--salt-container-primary-background);
+  border: var(--salt-size-border) var(--salt-container-borderStyle) var(--salt-container-primary-borderColor);
+  border-radius: 3px;
+  font-family: var(--salt-text-label-fontFamily);
+  font-size: var(--salt-text-label-fontSize);
+  font-weight: var(--salt-text-label-fontWeight-strong);
+  margin: var(--salt-spacing-25);
+  padding: var(--salt-spacing-25) var(--salt-spacing-75);
+  box-shadow: var(--salt-shadow-200-color) 0px 2px;
 }
 
 .keyCol {


### PR DESCRIPTION
This PR adds styling to the keys in the keyboard controls table (used on the component docs pages), so they look like keys. 

I added it while working on App Header pattern it's not really needed as part of that, so raising a separate PR since I've done it anyways and (I think) it looks nice.

<img width="1026" alt="Screenshot 2023-11-23 at 16 51 13" src="https://github.com/jpmorganchase/salt-ds/assets/45168453/83d3c6eb-8ee7-4581-8454-8c7ec881e321">
