### PR TITLE
Fix Tooltip breaking when used inside a Form Field with an invalid value passed to the `validationStatus` prop

### DIFF
--- a/.changeset/plenty-hotels-obey.md
+++ b/.changeset/plenty-hotels-obey.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Changes to fix tooltip UI breaks inside formfield

--- a/.changeset/plenty-hotels-obey.md
+++ b/.changeset/plenty-hotels-obey.md
@@ -2,4 +2,4 @@
 "@salt-ds/core": patch
 ---
 
-Changes to fix tooltip UI breaks inside formfield
+Changes for fixing tooltip UI breaks inside formfield

--- a/.changeset/plenty-hotels-obey.md
+++ b/.changeset/plenty-hotels-obey.md
@@ -2,4 +2,4 @@
 "@salt-ds/core": patch
 ---
 
-Changes for fixing tooltip UI breaks inside formfield
+Fixed Tooltip breaking when used inside a Form Field with an invalid value passed to the `validationStatus` prop.

--- a/packages/core/src/__tests__/__e2e__/form-field/FormField.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/form-field/FormField.cy.tsx
@@ -263,6 +263,22 @@ describe("GIVEN a FormField", () => {
           cy.findByRole("tooltip").should("have.class", "saltTooltip-error");
         });
       });
+      
+      describe("AND has empty validation status", () => {
+        it("THEN tooltip should reflect status", () => {
+          cy.mount(
+            <FormField validationStatus="">
+              <FormFieldLabel>Label</FormFieldLabel>
+              <Tooltip content="Helper text">
+                <Input defaultValue="Value" data-testid="test-id-2" />
+              </Tooltip>
+            </FormField>
+          );
+          cy.findByLabelText("Label").realHover();
+
+          cy.findByRole("tooltip").should("have.class", "saltTooltip-info");
+        });
+      });
     });
 
     describe("AND Input has an button adornment", () => {

--- a/packages/core/src/__tests__/__e2e__/form-field/FormField.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/form-field/FormField.cy.tsx
@@ -263,10 +263,12 @@ describe("GIVEN a FormField", () => {
           cy.findByRole("tooltip").should("have.class", "saltTooltip-error");
         });
       });
-      
+
       describe("AND has empty validation status", () => {
         it("THEN tooltip should reflect status", () => {
           cy.mount(
+            //check for falsy value not included in validationstatus
+            //@ts-expect-error
             <FormField validationStatus="">
               <FormFieldLabel>Label</FormFieldLabel>
               <Tooltip content="Helper text">

--- a/packages/core/src/__tests__/__e2e__/form-field/FormField.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/form-field/FormField.cy.tsx
@@ -264,11 +264,10 @@ describe("GIVEN a FormField", () => {
         });
       });
 
-      describe("AND has empty validation status", () => {
-        it("THEN tooltip should reflect status", () => {
+      describe("AND has an invalid validation status", () => {
+        it("THEN tooltip should default to the info status", () => {
           cy.mount(
-            //check for falsy value not included in validationstatus
-            //@ts-expect-error
+            //@ts-expect-error - intentionally invalid validationStatus
             <FormField validationStatus="">
               <FormFieldLabel>Label</FormFieldLabel>
               <Tooltip content="Helper text">

--- a/packages/core/src/tooltip/Tooltip.tsx
+++ b/packages/core/src/tooltip/Tooltip.tsx
@@ -7,7 +7,7 @@ import {
   ReactNode,
 } from "react";
 
-import { ValidationStatus } from "../status-indicator";
+import { ValidationStatus, VALIDATION_NAMED_STATUS } from "../status-indicator";
 import {
   makePrefixer,
   mergeProps,
@@ -90,8 +90,11 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     } = useFormFieldProps();
 
     const disabled = formFieldDisabled ?? disabledProp;
-    const status = formFieldValidationStatus ?? statusProp;
-
+    const status = VALIDATION_NAMED_STATUS.some(
+      (validStatus) => validStatus === formFieldValidationStatus
+    )
+      ? formFieldValidationStatus ?? statusProp
+      : statusProp;
     const { Component: FloatingComponent } = useFloatingComponent();
 
     const hookProps: UseTooltipProps = {

--- a/packages/core/src/tooltip/Tooltip.tsx
+++ b/packages/core/src/tooltip/Tooltip.tsx
@@ -90,11 +90,11 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     } = useFormFieldProps();
 
     const disabled = formFieldDisabled ?? disabledProp;
-    const status = VALIDATION_NAMED_STATUS.some(
-      (validStatus) => validStatus === formFieldValidationStatus
-    )
-      ? formFieldValidationStatus ?? statusProp
-      : statusProp;
+    const status =
+      formFieldValidationStatus !== undefined &&
+      VALIDATION_NAMED_STATUS.includes(formFieldValidationStatus)
+        ? formFieldValidationStatus
+        : statusProp;
     const { Component: FloatingComponent } = useFloatingComponent();
 
     const hookProps: UseTooltipProps = {


### PR DESCRIPTION
Fixes #2752 