### PR TITLE
fix dashboard pattern link

### DIFF
--- a/site/docs/patterns/dashboards/index.mdx
+++ b/site/docs/patterns/dashboards/index.mdx
@@ -7,6 +7,6 @@ sidebar:
 
 ## Available dashboard patterns
 
-| Pattern                                        |
-| ---------------------------------------------- |
-| [Analytical Dashboard](./analytical-dashboard) |
+| Pattern                                                                |
+| ---------------------------------------------------------------------- |
+| [Analytical Dashboard](/salt/patterns/dashboards/analytical-dashboard) |


### PR DESCRIPTION
Update nav link to `/salt/patterns/dashboards/analytical-dashboard`