### PR TITLE
Remove unprefixed classnames from ColorPicker

### DIFF
--- a/.changeset/old-weeks-travel.md
+++ b/.changeset/old-weeks-travel.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/lab": patch
+---
+
+Fix global css clashing issues by replacing un-prefixed classes .root and .rootDisabledAlpha in ColorPicker with prefixed (.saltColorChooserPicker-root and .saltColorChooserPicker-rootDisabledAlpha)

--- a/packages/lab/src/color-chooser/ColorPicker.css
+++ b/packages/lab/src/color-chooser/ColorPicker.css
@@ -34,21 +34,21 @@
  **/
 
 /* Entire container for react-color component */
-.root,
-.rootDisabledAlpha {
+.saltColorChooserPicker-root,
+.saltColorChooserPicker-rootDisabledAlpha {
   box-shadow: none !important;
   padding: 8px 8px 0px 0px !important;
   background: transparent !important;
   width: calc(9 * var(--salt-size-stackable)) !important;
 }
 /* Color sliders container */
-.root .flexbox-fix,
-.rootDisabledAlpha .flexbox-fix {
+.saltColorChooserPicker-root .flexbox-fix,
+.saltColorChooserPicker-rootDisabledAlpha .flexbox-fix {
   padding-top: 8px !important;
 }
 /* RGB Inputs provided by react-color */
-.rootDisabledAlpha .flexbox-fix ~ .flexbox-fix,
-.root .flexbox-fix ~ .flexbox-fix {
+.saltColorChooserPicker-rootDisabledAlpha .flexbox-fix ~ .flexbox-fix,
+.saltColorChooserPicker-root .flexbox-fix ~ .flexbox-fix {
   display: none !important;
 }
 /* Height of hue and saturation boxes */
@@ -81,7 +81,7 @@
   height: calc(var(--salt-size-base) / 4) !important;
 }
 /* Cursor on hue slider */
-.rootDisabledAlpha .hue-horizontal > div > div {
+.saltColorChooserPicker-rootDisabledAlpha .hue-horizontal > div > div {
   position: relative;
   margin-top: 0px !important;
   width: 4px !important;

--- a/packages/lab/src/color-chooser/ColorPicker.tsx
+++ b/packages/lab/src/color-chooser/ColorPicker.tsx
@@ -87,8 +87,8 @@ export const ColorPicker = ({
       {/** @ts-ignore react-color has incorrect types **/}
       <SketchPicker
         className={clsx(withBaseName("swatchPickerStyles"), {
-          ["rootDisabledAlpha"]: disableAlphaChooser,
-          ["root"]: !disableAlphaChooser,
+          [withBaseName("rootDisabledAlpha")]: disableAlphaChooser,
+          [withBaseName("root")]: !disableAlphaChooser,
         })}
         color={rgbaValue}
         onChange={onSketchPickerChange}


### PR DESCRIPTION
When using Salt with static css, including the entire labs css package surfaced an issue where ColorPicker adds two unprefixed classes .root and .rootDisabledAlpha which are causing global css clashes.