### PR TITLE
Update backdrop CSS tokens

### DIFF
--- a/.changeset/chilled-wombats-marry.md
+++ b/.changeset/chilled-wombats-marry.md
@@ -1,0 +1,6 @@
+---
+"@salt-ds/theme": minor
+---
+
+Added `--salt-color-white-fade-backdrop` token with value `rgba(255, 255, 255, var(--salt-palette-opacity-backdrop))`
+Updated `--salt-color-black-fade-backdrop` token to value `rgba(0, 0, 0, var(--salt-palette-opacity-backdrop))`

--- a/packages/theme/css/foundations/fade.css
+++ b/packages/theme/css/foundations/fade.css
@@ -50,7 +50,7 @@
   --salt-color-gray-800-fade-background-readonly: rgba(36, 37, 38, var(--salt-palette-opacity-background-readonly));
 
   --salt-color-white-fade-backdrop: rgba(255, 255, 255, var(--salt-palette-opacity-backdrop));
-  --salt-color-black-fade-backdrop: rgba(36, 37, 38, var(--salt-palette-opacity-backdrop));
+  --salt-color-black-fade-backdrop: rgba(0, 0, 0, var(--salt-palette-opacity-backdrop));
 
   --salt-color-blue-100-fade-fill: rgba(100, 177, 228, var(--salt-palette-opacity-disabled));
   --salt-color-blue-600-fade-fill: rgba(21, 92, 147, var(--salt-palette-opacity-disabled));

--- a/packages/theme/css/foundations/fade.css
+++ b/packages/theme/css/foundations/fade.css
@@ -49,6 +49,7 @@
   --salt-color-gray-600-fade-background-readonly: rgba(47, 49, 54, var(--salt-palette-opacity-background-readonly));
   --salt-color-gray-800-fade-background-readonly: rgba(36, 37, 38, var(--salt-palette-opacity-background-readonly));
 
+  --salt-color-white-fade-backdrop: rgba(255, 255, 255, var(--salt-palette-opacity-backdrop));
   --salt-color-black-fade-backdrop: rgba(36, 37, 38, var(--salt-palette-opacity-backdrop));
 
   --salt-color-blue-100-fade-fill: rgba(100, 177, 228, var(--salt-palette-opacity-disabled));


### PR DESCRIPTION
This PR adds a definition for `--salt-color-white-fade-backdrop` which is currently not defined.

Noticed this issue when looking at [Scrim](https://storybook.saltdesignsystem.com/?path=/story/lab-scrim--default). As you can see, it has no background colour when opened.