### PR TITLE
Deprecate --formField-label-width and replace with --saltFormField-label-width

### DIFF
--- a/.changeset/tasty-poets-matter.md
+++ b/.changeset/tasty-poets-matter.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Added CSS API variable --saltFormField-label-width, deprecated --formField-label-width

--- a/.changeset/tasty-poets-matter.md
+++ b/.changeset/tasty-poets-matter.md
@@ -2,4 +2,11 @@
 "@salt-ds/core": patch
 ---
 
-Added CSS API variable --saltFormField-label-width, deprecated --formField-label-width
+Added CSS API variable `--saltFormField-label-width`, replacing deprecated `--formField-label-width`
+
+Usage should be changed:
+
+```diff
+- style={{ "--formField-label-width": "100px" } as CSSProperties}
++ style={{ "--saltFormField-label-width": "100px" } as CSSProperties}
+```

--- a/packages/core/src/form-field/FormField.css
+++ b/packages/core/src/form-field/FormField.css
@@ -23,13 +23,13 @@
 
 .saltFormField-labelLeft {
   align-self: center;
-  grid-template-columns: var(--formField-label-width, 40%) 1fr;
+  grid-template-columns: var(--saltFormField-label-width, var(--formField-label-width, 40%)) 1fr;
   grid-template-areas: "label controls";
 }
 
 .saltFormField-labelRight {
   align-self: center;
-  grid-template-columns: var(--formField-label-width, 40%) 1fr;
+  grid-template-columns: var(--saltFormField-label-width, var(--formField-label-width, 40%)) 1fr;
   grid-template-areas: "label controls";
 }
 

--- a/packages/core/stories/form-field/form-field.stories.tsx
+++ b/packages/core/stories/form-field/form-field.stories.tsx
@@ -181,10 +181,7 @@ export const LabelLeftWithControls: StoryFn<typeof FormField> = (props) => {
       <FormField labelPlacement="left" {...props}>
         <FormLabel>Assignment</FormLabel>
         <CheckboxGroup>
-          <Checkbox
-            aria-labelledby={"Private places"}
-            label="Private placement of equity or debt securities"
-          />
+          <Checkbox label="Private placement of equity or debt securities" />
           <Checkbox defaultChecked label="Syndicated credit facility or loan" />
           <Checkbox label="Interest rate, foreign exchange or commodity hedging or equity derivative" />
           <Checkbox label="Escrow arrangement" />

--- a/packages/core/stories/form-field/form-field.stories.tsx
+++ b/packages/core/stories/form-field/form-field.stories.tsx
@@ -181,7 +181,10 @@ export const LabelLeftWithControls: StoryFn<typeof FormField> = (props) => {
       <FormField labelPlacement="left" {...props}>
         <FormLabel>Assignment</FormLabel>
         <CheckboxGroup>
-          <Checkbox label="Private placement of equity or debt securities" />
+          <Checkbox
+            aria-labelledby={"Private places"}
+            label="Private placement of equity or debt securities"
+          />
           <Checkbox defaultChecked label="Syndicated credit facility or loan" />
           <Checkbox label="Interest rate, foreign exchange or commodity hedging or equity derivative" />
           <Checkbox label="Escrow arrangement" />
@@ -835,7 +838,7 @@ export const GroupedWithVariant: StoryFn<typeof FormField> = (props) => {
 export const MultiColumnLayout: StoryFn<typeof FormField> = (props) => {
   return (
     <StackLayout
-      style={{ "--formField-label-width": "100px" } as CSSProperties}
+      style={{ "--saltFormField-label-width": "100px" } as CSSProperties}
     >
       <FormField {...props}>
         <FormLabel>Form Field label left</FormLabel>
@@ -894,7 +897,7 @@ export const MultiColumnLayoutEmptySlot: StoryFn<typeof FormField> = (
 ) => {
   return (
     <StackLayout
-      style={{ "--formField-label-width": "100px" } as React.CSSProperties}
+      style={{ "--saltFormField-label-width": "100px" } as React.CSSProperties}
     >
       <FormField {...props}>
         <FormLabel>Form Field label left</FormLabel>

--- a/site/src/examples/form-field/GroupedWithEmptySlot.tsx
+++ b/site/src/examples/form-field/GroupedWithEmptySlot.tsx
@@ -11,7 +11,7 @@ import {
 
 export const GroupedWithEmptySlot = (): ReactElement => (
   <StackLayout
-    style={{ "--formField-label-width": "100px" } as React.CSSProperties}
+    style={{ "--saltFormField-label-width": "100px" } as React.CSSProperties}
     role={"group"}
   >
     <FormField>

--- a/site/src/examples/form-field/GroupedWithMultipleColumns.tsx
+++ b/site/src/examples/form-field/GroupedWithMultipleColumns.tsx
@@ -11,7 +11,7 @@ import {
 export const GroupedWithMultipleColumns = (): ReactElement => {
   return (
     <StackLayout
-      style={{ "--formField-label-width": "100px" } as CSSProperties}
+      style={{ "--saltFormField-label-width": "100px" } as CSSProperties}
     >
       <FormField>
         <FormFieldLabel>Form Field label left</FormFieldLabel>


### PR DESCRIPTION
The token should've followed the syntax used for CSS API variables as opposed to local tokens, creating an anomaly when trying to customize Form Field styling

--formField-label-width can be deprecated since we don't need it ourselves as a local token - I've kept it in to prevent breaking changes in case anyone used this token already. Usage should be replaced with the new API token