### PR TITLE
Fix FloatingComponent types

### DIFF
--- a/.changeset/hot-teachers-know.md
+++ b/.changeset/hot-teachers-know.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Fixed FloatingComponent types

--- a/packages/core/src/__tests__/__e2e__/common/CustomFloatingComponentProvider.tsx
+++ b/packages/core/src/__tests__/__e2e__/common/CustomFloatingComponentProvider.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, forwardRef, ReactNode, Ref } from "react";
+import { forwardRef, ReactNode } from "react";
 import {
   FloatingComponentProps,
   SaltProvider,
@@ -6,49 +6,45 @@ import {
 } from "@salt-ds/core";
 import { FloatingPortal } from "@floating-ui/react";
 
-type RootComponentProps = FloatingComponentProps &
-  ComponentPropsWithoutRef<"div">;
-
 export const FLOATING_TEST_ID = "FLOATING_TEST_ID";
 
-const TestCustomFloatingComponent = forwardRef<HTMLElement, RootComponentProps>(
-  (props, ref) => {
-    const { open, top, left, width, height, position, ...rest } = props;
-    const style = {
-      top,
-      left,
-      position,
-    };
+const TestCustomFloatingComponent = forwardRef<
+  HTMLDivElement,
+  FloatingComponentProps
+>(function TestCustomFloatingComponent(props, ref) {
+  const { open, top, left, width, height, position, ...rest } = props;
+  const style = {
+    top,
+    left,
+    position,
+  };
 
-    return open ? (
-      <FloatingPortal>
-        <SaltProvider>
-          <div
-            data-testid={FLOATING_TEST_ID}
-            data-top={typeof top === "number" ? Math.floor(top) : undefined}
-            data-left={typeof left === "number" ? Math.floor(left) : undefined}
-            data-width={
-              typeof width === "number" ? Math.floor(width) : undefined
-            }
-            data-height={
-              typeof height === "number" ? Math.floor(height) : undefined
-            }
-            data-position={position}
-            {...rest}
-            style={style}
-            ref={ref as Ref<HTMLDivElement>}
-          />
-        </SaltProvider>
-      </FloatingPortal>
-    ) : null;
-  }
-);
+  return open ? (
+    <FloatingPortal>
+      <SaltProvider>
+        <div
+          data-testid={FLOATING_TEST_ID}
+          data-top={typeof top === "number" ? Math.floor(top) : undefined}
+          data-left={typeof left === "number" ? Math.floor(left) : undefined}
+          data-width={typeof width === "number" ? Math.floor(width) : undefined}
+          data-height={
+            typeof height === "number" ? Math.floor(height) : undefined
+          }
+          data-position={position}
+          {...rest}
+          style={style}
+          ref={ref}
+        />
+      </SaltProvider>
+    </FloatingPortal>
+  ) : null;
+});
 
-type Props = {
-  children: ReactNode;
-};
-
-export const CustomFloatingComponentProvider = ({ children }: Props) => {
+export const CustomFloatingComponentProvider = ({
+  children,
+}: {
+  children?: ReactNode;
+}) => {
   return (
     <FloatingComponentProvider Component={TestCustomFloatingComponent}>
       {children}

--- a/packages/core/src/tooltip/Tooltip.tsx
+++ b/packages/core/src/tooltip/Tooltip.tsx
@@ -116,12 +116,12 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     } = useTooltip(hookProps);
 
     const triggerRef = useForkRef(
-      // @ts-ignore
+      // @ts-expect-error children.ref cannot currently be typed.
       isValidElement(children) ? children.ref : null,
       reference
     );
 
-    const floatingRef = useForkRef(floating, ref);
+    const floatingRef = useForkRef<HTMLDivElement>(floating, ref);
 
     return (
       <>
@@ -134,8 +134,8 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
         <FloatingComponent
           className={clsx(withBaseName(), withBaseName(status), className)}
           open={open && !disabled}
-          ref={floatingRef}
           {...getTooltipProps()}
+          ref={floatingRef}
           {...getTooltipPosition()}
         >
           <TooltipBase

--- a/packages/core/src/utils/useFloatingUI/useFloatingUI.tsx
+++ b/packages/core/src/utils/useFloatingUI/useFloatingUI.tsx
@@ -18,15 +18,13 @@ import {
   useContext,
   useMemo,
   forwardRef,
-  PropsWithChildren,
-  Ref,
-  ForwardRefExoticComponent,
+  ComponentPropsWithoutRef,
 } from "react";
 
 import { SaltProvider } from "../../salt-provider";
 
-type CombinedFloatingComponentProps = PropsWithChildren<FloatingComponentProps>;
-export interface FloatingComponentProps {
+export interface FloatingComponentProps
+  extends ComponentPropsWithoutRef<"div"> {
   /**
    * Whether the floating component is open (used for determinig whether to show the component)
    * We pass this as a prop rather than not rendering the component to allow more advanced use-cases e.g.
@@ -44,10 +42,20 @@ export interface FloatingComponentProps {
 }
 
 const DefaultFloatingComponent = forwardRef<
-  HTMLElement,
-  CombinedFloatingComponentProps
+  HTMLDivElement,
+  FloatingComponentProps
 >(function DefaultFloatingComponent(props, ref) {
-  const { open, top, left, position, ...rest } = props;
+  const {
+    open,
+    top,
+    left,
+    position,
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    width,
+    height,
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+    ...rest
+  } = props;
   const style = {
     top,
     left,
@@ -56,14 +64,14 @@ const DefaultFloatingComponent = forwardRef<
   return open ? (
     <FloatingPortal>
       <SaltProvider>
-        <div style={style} {...rest} ref={ref as Ref<HTMLDivElement>} />
+        <div style={style} {...rest} ref={ref} />
       </SaltProvider>
     </FloatingPortal>
   ) : null;
 });
 
 export interface FloatingComponentContextType {
-  Component: ForwardRefExoticComponent<CombinedFloatingComponentProps>;
+  Component: typeof DefaultFloatingComponent;
 }
 
 const FloatingComponentContext = createContext<FloatingComponentContextType>({

--- a/packages/core/stories/floating-platform/custom-floating-ui-platform.stories.tsx
+++ b/packages/core/stories/floating-platform/custom-floating-ui-platform.stories.tsx
@@ -1,6 +1,5 @@
-import { ComponentMeta, Story } from "@storybook/react";
+import { Meta, StoryFn } from "@storybook/react";
 import React, {
-  ForwardedRef,
   forwardRef,
   useMemo,
   ComponentPropsWithoutRef,
@@ -33,7 +32,7 @@ import { NewWindow, FloatingComponentWindow } from "./NewWindow";
 export default {
   title: "Core/Floating Platform",
   component: Tooltip,
-} as ComponentMeta<typeof Tooltip>;
+} as Meta<typeof Tooltip>;
 
 const defaultArgs: Omit<TooltipProps, "children"> = {
   content:
@@ -113,8 +112,8 @@ const NewWindowTest = (props: NewWindowTestProps) => {
 
   const FloatingUIComponent = useMemo(
     () =>
-      forwardRef(
-        (
+      forwardRef<HTMLDivElement, RootComponentProps>(
+        function FloatingUIComponent(
           {
             style,
             open,
@@ -122,11 +121,12 @@ const NewWindowTest = (props: NewWindowTestProps) => {
             left,
             width,
             height,
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             position,
             ...rest
-          }: RootComponentProps,
-          ref: ForwardedRef<HTMLElement>
-        ) => {
+          },
+          ref
+        ) {
           const FloatingRoot = (
             /* In thise case to avoid Flash of Unstyled Text (FOUT) in the tooltip, due to being in an iframe, we are always rendering the tooltip.
              * We are visually hiding it until it is open to 'eagerly load' the font
@@ -190,9 +190,7 @@ const NewWindowTest = (props: NewWindowTestProps) => {
   );
 };
 
-export const CustomFloatingUiPlatform: Story<TooltipProps> = (
-  props: TooltipProps
-) => {
+export const CustomFloatingUiPlatform: StoryFn<typeof Tooltip> = (args) => {
   return (
     <NewWindow style={{ width: "600px", height: "550px", border: "none" }}>
       <StackLayout gap={2}>
@@ -201,7 +199,7 @@ export const CustomFloatingUiPlatform: Story<TooltipProps> = (
           It represents a global coordinate space (e.g. a users screen)
         </Text>
         <StackLayout gap={10} direction="row">
-          <NewWindowTest {...props} />
+          <NewWindowTest {...args} />
         </StackLayout>
       </StackLayout>
     </NewWindow>
@@ -209,7 +207,7 @@ export const CustomFloatingUiPlatform: Story<TooltipProps> = (
 };
 CustomFloatingUiPlatform.args = defaultArgs;
 
-export const AnimationFrame: Story<TooltipProps> = (props: TooltipProps) => {
+export const AnimationFrame: StoryFn = () => {
   const targetWindow = useWindow();
   useComponentCssInjection({ css: floatingCss, window: targetWindow });
 
@@ -232,9 +230,8 @@ export const AnimationFrame: Story<TooltipProps> = (props: TooltipProps) => {
     </div>
   );
 };
-CustomFloatingUiPlatform.args = defaultArgs;
 
-export const CustomMiddleware: Story<TooltipProps> = (props: TooltipProps) => {
+export const CustomMiddleware: StoryFn = () => {
   const targetWindow = useWindow();
   useComponentCssInjection({ css: floatingCss, window: targetWindow });
 
@@ -254,4 +251,3 @@ export const CustomMiddleware: Story<TooltipProps> = (props: TooltipProps) => {
     </FloatingPlatformProvider>
   );
 };
-CustomFloatingUiPlatform.args = defaultArgs;

--- a/packages/lab/src/__tests__/__e2e__/common/CustomFloatingComponentProvider.tsx
+++ b/packages/lab/src/__tests__/__e2e__/common/CustomFloatingComponentProvider.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, forwardRef, ReactNode, Ref } from "react";
+import { forwardRef, ReactNode } from "react";
 import {
   FloatingComponentProps,
   SaltProvider,
@@ -6,49 +6,45 @@ import {
 } from "@salt-ds/core";
 import { FloatingPortal } from "@floating-ui/react";
 
-type RootComponentProps = FloatingComponentProps &
-  ComponentPropsWithoutRef<"div">;
-
 export const FLOATING_TEST_ID = "FLOATING_TEST_ID";
 
-const TestCustomFloatingComponent = forwardRef<HTMLElement, RootComponentProps>(
-  (props, ref) => {
-    const { open, top, left, width, height, position, ...rest } = props;
-    const style = {
-      top,
-      left,
-      position,
-    };
+const TestCustomFloatingComponent = forwardRef<
+  HTMLDivElement,
+  FloatingComponentProps
+>(function TestCustomFloatingComponent(props, ref) {
+  const { open, top, left, width, height, position, ...rest } = props;
+  const style = {
+    top,
+    left,
+    position,
+  };
 
-    return open ? (
-      <FloatingPortal>
-        <SaltProvider>
-          <div
-            data-testid={FLOATING_TEST_ID}
-            data-top={typeof top === "number" ? Math.floor(top) : undefined}
-            data-left={typeof left === "number" ? Math.floor(left) : undefined}
-            data-width={
-              typeof width === "number" ? Math.floor(width) : undefined
-            }
-            data-height={
-              typeof height === "number" ? Math.floor(height) : undefined
-            }
-            data-position={position}
-            {...rest}
-            style={style}
-            ref={ref as Ref<HTMLDivElement>}
-          />
-        </SaltProvider>
-      </FloatingPortal>
-    ) : null;
-  }
-);
+  return open ? (
+    <FloatingPortal>
+      <SaltProvider>
+        <div
+          data-testid={FLOATING_TEST_ID}
+          data-top={typeof top === "number" ? Math.floor(top) : undefined}
+          data-left={typeof left === "number" ? Math.floor(left) : undefined}
+          data-width={typeof width === "number" ? Math.floor(width) : undefined}
+          data-height={
+            typeof height === "number" ? Math.floor(height) : undefined
+          }
+          data-position={position}
+          {...rest}
+          style={style}
+          ref={ref}
+        />
+      </SaltProvider>
+    </FloatingPortal>
+  ) : null;
+});
 
-type Props = {
-  children: ReactNode;
-};
-
-export const CustomFloatingComponentProvider = ({ children }: Props) => {
+export const CustomFloatingComponentProvider = ({
+  children,
+}: {
+  children?: ReactNode;
+}) => {
   return (
     <FloatingComponentProvider Component={TestCustomFloatingComponent}>
       {children}

--- a/packages/lab/src/combo-box-next/ComboBoxNext.tsx
+++ b/packages/lab/src/combo-box-next/ComboBoxNext.tsx
@@ -252,9 +252,9 @@ export const ComboBoxNext = forwardRef(function ComboBoxNext<T>(
 
       <FloatingComponent
         open={Boolean(open && !disabled && filteredSource)}
-        ref={floating}
         {...getPortalProps()}
         {...getPosition()}
+        ref={floating}
       >
         <ListNext
           className={clsx(withBaseName("list"), listClassName)}

--- a/packages/lab/src/dropdown-next/DropdownNext.tsx
+++ b/packages/lab/src/dropdown-next/DropdownNext.tsx
@@ -149,7 +149,6 @@ export const DropdownNext = forwardRef(function DropdownNext(
   } = handlers;
 
   const triggerRef = useForkRef<HTMLButtonElement>(ref, reference);
-  const portalRef = useForkRef<HTMLButtonElement>(ref, floating);
 
   const getIcon = () => {
     if (readOnly) return;
@@ -230,9 +229,9 @@ export const DropdownNext = forwardRef(function DropdownNext(
       </button>
       <FloatingComponent
         open={open && !disabled}
-        ref={portalRef}
         {...getDropdownNextProps()}
         {...getPosition()}
+        ref={floating}
       >
         <ListNext
           data-test-id={"list-container"}


### PR DESCRIPTION
FloatingComponent was typed with:

```ts
type CombinedFloatingComponentProps = PropsWithChildren<FloatingComponentProps>;

forwardRef<
  HTMLElement,
  CombinedFloatingComponentProps
>

Component: ForwardRefExoticComponent<CombinedFloatingComponentProps>;
```
Which allowed for incorrect refs to be passed and ignored that there is an assumption that the floating component will always be a `div`, making typing harder to do than necessary.

This PR tidies that up and fixes the code where FloatingComponent is already used.
