### PR TITLE
Disable prefer nullish coalescing for expressions containing booleans

### DIFF
--- a/.changeset/fresh-jars-attack.md
+++ b/.changeset/fresh-jars-attack.md
@@ -3,4 +3,4 @@
 "@salt-ds/lab": patch
 ---
 
-Replace incorrect usage of nullish operators
+Replaced incorrect usage of nullish operators.

--- a/.changeset/fresh-jars-attack.md
+++ b/.changeset/fresh-jars-attack.md
@@ -3,4 +3,4 @@
 "@salt-ds/lab": patch
 ---
 
-Replace incorrect usage of nullish operator
+Replace incorrect usage of nullish operators

--- a/.changeset/fresh-jars-attack.md
+++ b/.changeset/fresh-jars-attack.md
@@ -3,4 +3,4 @@
 "@salt-ds/lab": patch
 ---
 
-Replace incorrect usaing of nullish operator
+Replace incorrect usage of nullish operator

--- a/.changeset/fresh-jars-attack.md
+++ b/.changeset/fresh-jars-attack.md
@@ -1,0 +1,6 @@
+---
+"@salt-ds/core": patch
+"@salt-ds/lab": patch
+---
+
+Replace incorrect usaing of nullish operator

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,6 +44,12 @@ module.exports = {
         ],
         "@typescript-eslint/no-misused-promises": "off",
         "@typescript-eslint/no-unsafe-assignment ": "off",
+        "@typescript-eslint/prefer-nullish-coalescing": [
+          "error",
+          {
+            ignorePrimitives: { boolean: true },
+          },
+        ],
         // TypeScript provides the same checks as part of standard type checking.
         "import/named": "off",
         "import/namespace": "off",

--- a/packages/core/src/checkbox/Checkbox.tsx
+++ b/packages/core/src/checkbox/Checkbox.tsx
@@ -141,9 +141,9 @@ export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
     } = useFormFieldProps();
 
     const disabled =
-      checkboxGroup.disabled ?? formFieldDisabled ?? disabledProp;
+      checkboxGroup.disabled || formFieldDisabled || disabledProp;
     const readOnly =
-      checkboxGroup.readOnly ?? formFieldReadOnly ?? readOnlyProp;
+      checkboxGroup.readOnly || formFieldReadOnly || readOnlyProp;
     const validationStatus = !disabled
       ? checkboxGroup.validationStatus ??
         formFieldValidationStatus ??

--- a/packages/core/src/checkbox/CheckboxGroup.tsx
+++ b/packages/core/src/checkbox/CheckboxGroup.tsx
@@ -90,8 +90,8 @@ export const CheckboxGroup = forwardRef<
     validationStatus: formFieldValidationStatus,
   } = useFormFieldProps();
 
-  const disabled = formFieldDisabled ?? disabledProp;
-  const readOnly = formFieldReadOnly ?? readOnlyProp;
+  const disabled = formFieldDisabled || disabledProp;
+  const readOnly = formFieldReadOnly || readOnlyProp;
   const validationStatus = formFieldValidationStatus ?? validationStatusProp;
 
   const [checkedValues, setCheckedValues] = useControlled({

--- a/packages/core/src/input/Input.tsx
+++ b/packages/core/src/input/Input.tsx
@@ -135,7 +135,7 @@ export const Input = forwardRef<HTMLDivElement, InputProps>(function Input(
 
   const isRequired = formFieldRequired
     ? ["required", "asterisk"].includes(formFieldRequired)
-    : undefined ?? inputPropsRequired;
+    : inputPropsRequired;
 
   const [value, setValue] = useControlled({
     controlled: valueProp,

--- a/packages/core/src/multiline-input/MultilineInput.tsx
+++ b/packages/core/src/multiline-input/MultilineInput.tsx
@@ -131,7 +131,7 @@ export const MultilineInput = forwardRef<HTMLDivElement, MultilineInputProps>(
     const validationStatus = formFieldValidationStatus ?? validationStatusProp;
     const isRequired = formFieldRequired
       ? ["required", "asterisk"].includes(formFieldRequired)
-      : undefined ?? textAreaRequired;
+      : textAreaRequired;
 
     const [value, setValue] = useControlled({
       controlled: valueProp,

--- a/packages/core/src/radio-button/RadioButton.tsx
+++ b/packages/core/src/radio-button/RadioButton.tsx
@@ -121,8 +121,8 @@ export const RadioButton = forwardRef<HTMLLabelElement, RadioButtonProps>(
       ...restInputProps
     } = inputProps;
 
-    const disabled = radioGroup.disabled ?? formFieldDisabled ?? disabledProp;
-    const readOnly = radioGroup.readOnly ?? formFieldReadOnly ?? readOnlyProp;
+    const disabled = radioGroup.disabled || formFieldDisabled || disabledProp;
+    const readOnly = radioGroup.readOnly || formFieldReadOnly || readOnlyProp;
     const validationStatus = !disabled
       ? radioGroup.validationStatus ??
         formFieldValidationStatus ??

--- a/packages/core/src/radio-button/RadioButtonGroup.tsx
+++ b/packages/core/src/radio-button/RadioButtonGroup.tsx
@@ -87,8 +87,8 @@ export const RadioButtonGroup = forwardRef<
     validationStatus: formFieldValidationStatus,
   } = useFormFieldProps();
 
-  const disabled = formFieldDisabled ?? disabledProp;
-  const readOnly = formFieldReadOnly ?? readOnlyProp;
+  const disabled = formFieldDisabled || disabledProp;
+  const readOnly = formFieldReadOnly || readOnlyProp;
   const validationStatus = formFieldValidationStatus ?? validationStatusProp;
 
   const [value, setStateValue] = useControlled({

--- a/packages/core/src/switch/Switch.tsx
+++ b/packages/core/src/switch/Switch.tsx
@@ -122,7 +122,7 @@ export const Switch = forwardRef<HTMLLabelElement, SwitchProps>(function Switch(
   const { a11yProps: formFieldA11yProps, disabled: formFieldDisabled } =
     useFormFieldProps();
 
-  const disabled = formFieldDisabled ?? disabledProp;
+  const disabled = formFieldDisabled || disabledProp;
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
     // Workaround for https://github.com/facebook/react/issues/9023

--- a/packages/core/src/tooltip/Tooltip.tsx
+++ b/packages/core/src/tooltip/Tooltip.tsx
@@ -90,7 +90,6 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     } = useFormFieldProps();
 
     const disabled = disabledProp || formFieldDisabled;
-
     const status =
       formFieldValidationStatus !== undefined &&
       VALIDATION_NAMED_STATUS.includes(formFieldValidationStatus)

--- a/packages/core/src/utils/useFloatingUI/useFloatingUI.tsx
+++ b/packages/core/src/utils/useFloatingUI/useFloatingUI.tsx
@@ -164,7 +164,7 @@ export function FloatingPlatformProvider(props: FloatingPlatformProviderProps) {
     () => ({
       platform: platformProp ?? platform,
       middleware: middleware ?? defaultGetMiddleware,
-      animationFrame: animationFrame ?? false,
+      animationFrame: animationFrame || false,
     }),
     [platformProp, middleware, animationFrame]
   );

--- a/packages/lab/src/dropdown/DropdownBase.tsx
+++ b/packages/lab/src/dropdown/DropdownBase.tsx
@@ -176,7 +176,7 @@ export const DropdownBase = forwardRef<HTMLDivElement, DropdownBaseProps>(
                 top: y ?? 0,
                 left: x ?? 0,
                 position: strategy,
-                maxHeight: maxPopupHeight ?? undefined,
+                maxHeight: maxPopupHeight,
               }}
               ref={handleFloatingRef}
             >

--- a/packages/lab/src/editable-label/EditableLabel.tsx
+++ b/packages/lab/src/editable-label/EditableLabel.tsx
@@ -65,7 +65,7 @@ export const EditableLabel = forwardRef(function EditableLabel(
 
   const [editing, setEditing] = useControlled({
     controlled: editingProp,
-    default: defaultEditing ?? false,
+    default: defaultEditing || false,
     name: "EditableLabel",
     state: "editing",
   });

--- a/packages/lab/src/toolbar/overflow-panel/OverflowPanel.tsx
+++ b/packages/lab/src/toolbar/overflow-panel/OverflowPanel.tsx
@@ -70,7 +70,7 @@ export const OverflowPanel = forwardRef(function DropdownPanel(
   const triggerRef = useRef<HTMLButtonElement>(null);
   const [isOpen, setIsOpen] = useControlled<boolean>({
     controlled: isOpenProp,
-    default: defaultIsOpen ?? false,
+    default: defaultIsOpen || false,
     name: "DropdownPanel",
   });
 

--- a/packages/lab/src/tree/Tree.tsx
+++ b/packages/lab/src/tree/Tree.tsx
@@ -103,7 +103,7 @@ export const Tree = forwardRef(function Tree<
     options: {
       noChildrenLabel: "No children available",
       revealSelected: revealSelected
-        ? selectedProp ?? defaultSelected ?? false
+        ? Boolean(selectedProp) || Boolean(defaultSelected) || false
         : undefined,
     },
   });

--- a/packages/lab/stories/pagination/pagination.qa.stories.tsx
+++ b/packages/lab/stories/pagination/pagination.qa.stories.tsx
@@ -36,7 +36,7 @@ const Template = (args: PaginationProps & PaginatorProps & StoryProps) => {
     <Pagination count={count}>
       <FlexLayout gap={1}>
         {goTo && <GoToInput />}
-        {compact ?? compactWithInput ? (
+        {compact || compactWithInput ? (
           <CompactPaginator>
             {compactWithInput && <CompactInput />}
           </CompactPaginator>

--- a/packages/lab/stories/pagination/pagination.stories.tsx
+++ b/packages/lab/stories/pagination/pagination.stories.tsx
@@ -39,7 +39,7 @@ const Template: StoryFn<PaginationProps & PaginatorProps & StoryProps> = (
     <Pagination count={count}>
       <FlexLayout gap={1}>
         {goTo && <GoToInput inputVariant={inputVariant} />}
-        {compact ?? compactWithInput ? (
+        {compact || compactWithInput ? (
           <CompactPaginator>
             {compactWithInput && <CompactInput variant={inputVariant} />}
           </CompactPaginator>


### PR DESCRIPTION
Reduces the likelihood of mistakes being made where using `??` would cause unwanted behaviour with booleans