### PR TITLE
Remove text properties from Card and Panel

### DIFF
--- a/.changeset/lucky-yaks-shop.md
+++ b/.changeset/lucky-yaks-shop.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Fixed Card and Panel setting text properties by mistake, impacting content within inheriting wrong values.

--- a/packages/core/src/card/Card.css
+++ b/packages/core/src/card/Card.css
@@ -4,11 +4,6 @@
   border-width: var(--salt-size-border);
   border-style: var(--salt-container-borderStyle);
   padding: var(--saltCard-padding, var(--salt-spacing-300));
-
-  font-family: var(--salt-text-fontFamily);
-  font-size: var(--salt-text-fontSize);
-  font-weight: var(--salt-text-fontWeight);
-  line-height: var(--salt-text-lineHeight);
 }
 
 .saltCard-primary {

--- a/packages/core/src/panel/Panel.css
+++ b/packages/core/src/panel/Panel.css
@@ -16,9 +16,4 @@
   overflow: auto;
   padding: var(--saltPanel-padding, var(--salt-size-container-spacing));
   width: var(--saltPanel-width, 100%);
-
-  font-family: var(--salt-text-fontFamily);
-  font-size: var(--salt-text-fontSize);
-  font-weight: var(--salt-text-fontWeight);
-  line-height: var(--salt-text-lineHeight);
 }


### PR DESCRIPTION
Fix issues introduced from #2671 #2679.

When Salt container component is used during UITK app migration, most content within containers will inherit text properties from `body` or `:root`. With the text properties set at container level, content will be reset to use Salt properties instead. In most cases, this is not the intended effect of these container components would behave.