### PR TITLE
Data grid uses text properties from theme and move doc to lab

### DIFF
--- a/.changeset/five-goats-joke.md
+++ b/.changeset/five-goats-joke.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/data-grid": patch
+---
+
+Fixed text properties not set to use values from Salt theme

--- a/packages/data-grid/src/Grid.css
+++ b/packages/data-grid/src/Grid.css
@@ -123,6 +123,11 @@
   outline: none;
   user-select: none;
   background: var(--grid-background);
+
+  font-family: var(--salt-text-fontFamily);
+  font-size: var(--grid-fontSize);
+  font-weight: var(--salt-text-fontWeight);
+  line-height: var(--salt-text-lineHeight);
 }
 
 /* Styles applied to the root element if zebra is enabled */

--- a/packages/data-grid/stories/grid-cellCustomization.stories.tsx
+++ b/packages/data-grid/stories/grid-cellCustomization.stories.tsx
@@ -10,7 +10,7 @@ import "./grid.stories.css";
 import { StoryFn } from "@storybook/react";
 
 export default {
-  title: "Data Grid/Data Grid",
+  title: "Lab/Data Grid",
   component: Grid,
   argTypes: {},
 };

--- a/packages/data-grid/stories/grid-cellValidation.stories.tsx
+++ b/packages/data-grid/stories/grid-cellValidation.stories.tsx
@@ -18,7 +18,7 @@ import "./grid.stories.css";
 import { RowValidationStatusColumn } from "../src/RowValidationStatus";
 
 export default {
-  title: "Data Grid/Data Grid",
+  title: "Lab/Data Grid",
   component: GridColumn,
   argTypes: {},
 };

--- a/packages/data-grid/stories/grid-columnGroups.stories.tsx
+++ b/packages/data-grid/stories/grid-columnGroups.stories.tsx
@@ -4,7 +4,7 @@ import "./grid.stories.css";
 import { StoryFn } from "@storybook/react";
 
 export default {
-  title: "Data Grid/Data Grid",
+  title: "Lab/Data Grid",
   component: Grid,
   argTypes: {},
 };

--- a/packages/data-grid/stories/grid-cssVariables.stories.tsx
+++ b/packages/data-grid/stories/grid-cssVariables.stories.tsx
@@ -22,7 +22,7 @@ import { StoryFn } from "@storybook/react";
 type Variant = "primary" | "secondary" | "zebra";
 
 export default {
-  title: "Data Grid/Data Grid",
+  title: "Lab/Data Grid",
   component: Grid,
   argTypes: {},
 };

--- a/packages/data-grid/stories/grid-editableCells.stories.tsx
+++ b/packages/data-grid/stories/grid-editableCells.stories.tsx
@@ -13,7 +13,7 @@ import { useCallback, useState } from "react";
 import "./grid.stories.css";
 
 export default {
-  title: "Data Grid/Data Grid",
+  title: "Lab/Data Grid",
   component: Grid,
   argTypes: {},
 };

--- a/packages/data-grid/stories/grid-headerCustomization.stories.tsx
+++ b/packages/data-grid/stories/grid-headerCustomization.stories.tsx
@@ -28,7 +28,7 @@ import "./grid.stories.css";
 import { StoryFn } from "@storybook/react";
 
 export default {
-  title: "Data Grid/Data Grid",
+  title: "Lab/Data Grid",
   component: Grid,
   argTypes: {},
 };

--- a/packages/data-grid/stories/grid-pagination.stories.tsx
+++ b/packages/data-grid/stories/grid-pagination.stories.tsx
@@ -6,7 +6,7 @@ import { createDummyInvestors, investorKeyGetter } from "./dummyData";
 import "./grid.stories.css";
 
 export default {
-  title: "Data Grid/Data Grid",
+  title: "Lab/Data Grid",
   component: Grid,
   argTypes: {},
 };

--- a/packages/data-grid/stories/grid-rowSelectionControlled.stories.tsx
+++ b/packages/data-grid/stories/grid-rowSelectionControlled.stories.tsx
@@ -11,7 +11,7 @@ import "./grid.stories.css";
 import { StoryFn } from "@storybook/react";
 
 export default {
-  title: "Data Grid/Data Grid",
+  title: "Lab/Data Grid",
   component: Grid,
   argTypes: {},
 };

--- a/packages/data-grid/stories/grid-rowSelectionModes.stories.tsx
+++ b/packages/data-grid/stories/grid-rowSelectionModes.stories.tsx
@@ -18,7 +18,7 @@ import {
 import "./grid.stories.css";
 
 export default {
-  title: "Data Grid/Data Grid",
+  title: "Lab/Data Grid",
   component: Grid,
   argTypes: {},
 };

--- a/packages/data-grid/stories/grid-serverSideData.stories.tsx
+++ b/packages/data-grid/stories/grid-serverSideData.stories.tsx
@@ -11,7 +11,7 @@ import { Grid, GridColumn, RowSelectionCheckboxColumn } from "../src";
 import "./grid.stories.css";
 
 export default {
-  title: "Data Grid/Data Grid",
+  title: "Lab/Data Grid",
   component: Grid,
   parameters: {
     msw: {

--- a/packages/data-grid/stories/grid-sortColumns.stories.tsx
+++ b/packages/data-grid/stories/grid-sortColumns.stories.tsx
@@ -18,7 +18,7 @@ import { rest } from "msw";
 import "./grid.stories.css";
 
 export default {
-  title: "Data Grid/Data Grid",
+  title: "Lab/Data Grid",
   component: Grid,
   parameters: {
     msw: {

--- a/packages/data-grid/stories/grid-variants.stories.tsx
+++ b/packages/data-grid/stories/grid-variants.stories.tsx
@@ -19,7 +19,7 @@ import { DummyRow, dummyRowKeyGetter, rowData } from "./dummyData";
 import { clsx } from "clsx";
 
 export default {
-  title: "Data Grid/Data Grid",
+  title: "Lab/Data Grid",
   component: Grid,
   argTypes: {},
 };

--- a/packages/data-grid/stories/grid.doc.stories.mdx
+++ b/packages/data-grid/stories/grid.doc.stories.mdx
@@ -10,7 +10,7 @@ import {
 import HelpAndSupport from "docs/blocks/help-and-support.doc.mdx";
 
 <Meta
-  title="Documentation/Data Grid/Data Grid"
+  title="Documentation/Lab/Data Grid"
   component={Grid}
   parameters={{
     viewMode: "docs",

--- a/packages/data-grid/stories/grid.stories.tsx
+++ b/packages/data-grid/stories/grid.stories.tsx
@@ -40,7 +40,7 @@ import {
 import "./grid.stories.css";
 
 export default {
-  title: "Data Grid/Data Grid",
+  title: "Lab/Data Grid",
   component: Grid,
   argTypes: {},
 };


### PR DESCRIPTION
Data grid examples are not showing correct text properties (e.g. https://storybook.saltdesignsystem.com/?path=/story/data-grid-data-grid--cell-customization). Applying similar treatment from #2671 #2679.

Data gird is not receiving active development, so moving it away from ag grid theme in storybook to avoid confusion, although it's not documented on site.