### PR TITLE
Fix accessibility issues raised during the review.

### DIFF
--- a/.changeset/tender-baboons-walk.md
+++ b/.changeset/tender-baboons-walk.md
@@ -1,0 +1,10 @@
+---
+"@salt-ds/core": patch
+---
+
+- Updated indeterminate Checkboxes and Radio Buttons to use the native indeterminate attribute. This ensures screenreaders correctly announce the control.
+- Fixed Checkboxes and Radio Buttons not being announced as read-only.
+- Updated external Link's accessible text to remove the redundant text ("Link").
+- Fixed Switch's thumb being announced when the switch receives focus.
+- Changed standalone ToggleButton's role from checkbox to button and updated the neccessary aria attributes.
+- Fixed Tooltip's being announced as clickable and focusable.

--- a/.changeset/tender-baboons-walk.md
+++ b/.changeset/tender-baboons-walk.md
@@ -2,9 +2,9 @@
 "@salt-ds/core": patch
 ---
 
-- Updated indeterminate Checkboxes and Radio Buttons to use the native indeterminate attribute. This ensures screenreaders correctly announce the control.
-- Fixed Checkboxes and Radio Buttons not being announced as read-only.
-- Updated external Link's accessible text to remove the redundant text ("Link").
-- Fixed Switch's thumb being announced when the switch receives focus.
-- Changed standalone ToggleButton's role from checkbox to button and updated the neccessary aria attributes.
-- Fixed Tooltip's being announced as clickable and focusable.
+- Updated indeterminate `Checkbox` and `RadioButton` to use the native indeterminate attribute. This ensures screen readers correctly announce the control.
+- Fixed `Checkbox` and `RadioButton` not being announced as read-only.
+- Updated external `Link`'s accessible text to remove the redundant text ("Link").
+- Fixed `Switch`'s thumb being announced when the switch receives focus.
+- Changed standalone `ToggleButton`'s role from checkbox to button and updated the necessary aria attributes.
+- Fixed `Tooltip` being announced as clickable and focusable.

--- a/.changeset/tender-baboons-walk.md
+++ b/.changeset/tender-baboons-walk.md
@@ -3,7 +3,7 @@
 ---
 
 - Updated indeterminate `Checkbox` and `RadioButton` to use the native indeterminate attribute. This ensures screen readers correctly announce the control.
-- Fixed `Checkbox` and `RadioButton` not being announced as read-only.
+- Fixed `Checkbox` as `RadioButtonGroup` not being announced as read-only by setting `aria-readonly`.
 - Updated external `Link`'s accessible text to remove the redundant text ("Link").
 - Fixed `Switch`'s thumb being announced when the switch receives focus.
 - Changed standalone `ToggleButton`'s role from checkbox to button and updated the necessary aria attributes.

--- a/packages/core/src/__tests__/__e2e__/checkbox/Checkbox.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/checkbox/Checkbox.cy.tsx
@@ -2,9 +2,10 @@ import { Checkbox } from "@salt-ds/core";
 
 describe("GIVEN a Checkbox", () => {
   describe("WHEN in an indeterminate state", () => {
-    it("THEN should have aria-checked set to `mixed`", () => {
+    it("THEN should have indeterminate set to true", () => {
       cy.mount(<Checkbox indeterminate />);
-      cy.findByRole("checkbox").should("have.attr", "aria-checked", "mixed");
+      // Since indeterminate is not exposed as an attribute you have to check the property of the component.
+      cy.findByRole("checkbox").should("have.prop", "indeterminate", true);
     });
   });
 

--- a/packages/core/src/__tests__/__e2e__/toggle-button/ToggleButton.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/toggle-button/ToggleButton.cy.tsx
@@ -21,17 +21,17 @@ describe("GIVEN a ToggleButton with Icon and Text", () => {
 
     cy.mount(<ControlledToggleButtonExample />);
 
-    cy.findByRole("checkbox").should("have.text", "Home");
-    cy.findByRole("checkbox").should("have.attr", "aria-checked", "true");
+    cy.findByRole("button").should("have.text", "Home");
+    cy.findByRole("button").should("have.attr", "aria-pressed", "true");
 
     // untoggle
-    cy.findByRole("checkbox").realClick();
-    cy.findByRole("checkbox").should("have.attr", "aria-checked", "false");
+    cy.findByRole("button").realClick();
+    cy.findByRole("button").should("have.attr", "aria-pressed", "false");
     cy.get("@selectionChangeSpy").should("have.been.calledOnce");
 
     // toggle
-    cy.findByRole("checkbox").realClick();
-    cy.findByRole("checkbox").should("have.attr", "aria-checked", "true");
+    cy.findByRole("button").realClick();
+    cy.findByRole("button").should("have.attr", "aria-pressed", "true");
     cy.get("@selectionChangeSpy").should("have.been.calledTwice");
   });
 });
@@ -47,12 +47,12 @@ describe("GIVEN a disabled ToggleButton with Icon and Text", () => {
       </ToggleButton>
     );
 
-    cy.findByRole("checkbox").should("have.text", "Home");
-    cy.findByRole("checkbox").should("have.attr", "aria-checked", "false");
-    cy.findByRole("checkbox").should("be.disabled");
+    cy.findByRole("button").should("have.text", "Home");
+    cy.findByRole("button").should("have.attr", "aria-pressed", "false");
+    cy.findByRole("button").should("be.disabled");
 
     // try to toggle
-    cy.findByRole("checkbox").realClick();
+    cy.findByRole("button").realClick();
     cy.get("@selectionChangeSpy").should("not.have.been.called");
   });
 });

--- a/packages/core/src/checkbox/Checkbox.tsx
+++ b/packages/core/src/checkbox/Checkbox.tsx
@@ -5,10 +5,15 @@ import {
   forwardRef,
   InputHTMLAttributes,
   ReactNode,
+  useRef,
 } from "react";
 import { useComponentCssInjection } from "@salt-ds/styles";
 import { useWindow } from "@salt-ds/window";
-import { makePrefixer, useControlled } from "../utils";
+import {
+  makePrefixer,
+  useControlled,
+  useIsomorphicLayoutEffect,
+} from "../utils";
 import { CheckboxIcon } from "./CheckboxIcon";
 import { useFormFieldProps } from "../form-field-context";
 import { AdornmentValidationStatus } from "../status-adornment";
@@ -41,9 +46,7 @@ export interface CheckboxProps
    */
   error?: boolean;
   /**
-   * If true, the checkbox appears indeterminate. This does not set the native
-   * input element to indeterminate due to the inconsistent behaviour across browsers
-   * However, a data-indeterminate attribute is set on the input.
+   * If true, the checkbox appears indeterminate. A data-indeterminate attribute is set on the input.
    */
   indeterminate?: boolean;
   /**
@@ -150,6 +153,8 @@ export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
         validationStatusProp
       : undefined;
 
+    const inputRef = useRef<HTMLInputElement>(null);
+
     const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
       // Workaround for https://github.com/facebook/react/issues/9023
       if (event.nativeEvent.defaultPrevented || readOnly) {
@@ -162,6 +167,12 @@ export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
       inputOnChange?.(event);
       checkboxGroup?.onChange?.(event);
     };
+
+    useIsomorphicLayoutEffect(() => {
+      if (inputRef.current != null) {
+        inputRef.current.indeterminate = indeterminate ?? false;
+      }
+    }, [indeterminate]);
 
     return (
       <label
@@ -179,8 +190,7 @@ export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
         {...rest}
       >
         <input
-          // aria-checked only needed when indeterminate since native indeterminate behaviour is not used
-          aria-checked={indeterminate ? "mixed" : undefined}
+          aria-readonly={readOnly || undefined}
           aria-describedby={clsx(
             checkboxGroup === undefined
               ? formFieldA11yProps?.["aria-describedby"]
@@ -205,6 +215,7 @@ export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
           onChange={handleChange}
           onFocus={onFocus}
           type="checkbox"
+          ref={inputRef}
           {...restInputProps}
         />
         <CheckboxIcon

--- a/packages/core/src/link/Link.tsx
+++ b/packages/core/src/link/Link.tsx
@@ -55,7 +55,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
           {IconComponent && (
             <IconComponent className={withBaseName("icon")} aria-hidden />
           )}
-          <span className={withBaseName("externalLinkADA")}>External Link</span>
+          <span className={withBaseName("externalLinkADA")}>External</span>
         </>
       )}
     </Text>

--- a/packages/core/src/radio-button/RadioButton.tsx
+++ b/packages/core/src/radio-button/RadioButton.tsx
@@ -63,6 +63,7 @@ export interface RadioButtonProps
   onFocus?: FocusEventHandler<HTMLInputElement>;
   /**
    * Set the read only state.
+   * **Note**: Setting a standalone radio button as read-only is not accessible. The whole radio buttton group should be set as read-only instead.
    */
   readOnly?: boolean;
   /**
@@ -169,7 +170,6 @@ export const RadioButton = forwardRef<HTMLLabelElement, RadioButtonProps>(
         {...rest}
       >
         <input
-          aria-readonly={readOnly || undefined}
           aria-describedby={
             clsx(
               radioGroup == undefined

--- a/packages/core/src/radio-button/RadioButton.tsx
+++ b/packages/core/src/radio-button/RadioButton.tsx
@@ -169,6 +169,7 @@ export const RadioButton = forwardRef<HTMLLabelElement, RadioButtonProps>(
         {...rest}
       >
         <input
+          aria-readonly={readOnly || undefined}
           aria-describedby={
             clsx(
               radioGroup == undefined

--- a/packages/core/src/radio-button/RadioButtonGroup.tsx
+++ b/packages/core/src/radio-button/RadioButtonGroup.tsx
@@ -109,6 +109,8 @@ export const RadioButtonGroup = forwardRef<
 
   return (
     <fieldset
+      role="radiogroup"
+      aria-readonly={readOnly}
       aria-labelledby={
         clsx(a11yProps?.["aria-labelledby"], ariaLabelledBy) || undefined
       }

--- a/packages/core/src/switch/Switch.tsx
+++ b/packages/core/src/switch/Switch.tsx
@@ -172,7 +172,9 @@ export const Switch = forwardRef<HTMLLabelElement, SwitchProps>(function Switch(
       />
       <span className={withBaseName("track")}>
         <span className={withBaseName("thumb")}>
-          {checked && <CheckedIcon className={withBaseName("icon")} />}
+          {checked && (
+            <CheckedIcon aria-hidden className={withBaseName("icon")} />
+          )}
         </span>
       </span>
       <span className={withBaseName("label")}>{label}</span>

--- a/packages/core/src/toggle-button/ToggleButton.css
+++ b/packages/core/src/toggle-button/ToggleButton.css
@@ -34,13 +34,15 @@
   cursor: var(--salt-actionable-cursor-hover);
 }
 
-.saltToggleButton[aria-checked="true"]:focus-visible {
+.saltToggleButton[aria-checked="true"]:focus-visible,
+.saltToggleButton[aria-pressed="true"]:focus-visible {
   background: var(--salt-actionable-secondary-background-active);
   color: var(--salt-actionable-secondary-foreground-active);
   cursor: var(--salt-actionable-cursor-active);
 }
 
-.saltToggleButton[aria-checked="true"] {
+.saltToggleButton[aria-checked="true"],
+.saltToggleButton[aria-pressed="true"] {
   background: var(--salt-actionable-secondary-background-active);
   color: var(--salt-actionable-secondary-foreground-active);
   cursor: var(--salt-actionable-cursor-active);

--- a/packages/core/src/toggle-button/ToggleButton.tsx
+++ b/packages/core/src/toggle-button/ToggleButton.tsx
@@ -78,10 +78,11 @@ export const ToggleButton = forwardRef<HTMLButtonElement, ToggleButtonProps>(
 
     return (
       <button
-        aria-checked={ariaChecked}
+        aria-pressed={!toggleButtonGroup ? ariaChecked : undefined}
+        aria-checked={toggleButtonGroup ? ariaChecked : undefined}
+        role={toggleButtonGroup ? "radio" : undefined}
         className={clsx(withBaseName(), className)}
         disabled={disabled}
-        role={toggleButtonGroup ? "radio" : "checkbox"}
         ref={handleRef}
         onClick={handleClick}
         onFocus={handleFocus}

--- a/packages/core/src/tooltip/useTooltip.ts
+++ b/packages/core/src/tooltip/useTooltip.ts
@@ -63,27 +63,18 @@ export function useTooltip(props?: UseTooltipProps) {
     onOpenChange?.(open);
   };
 
-  const {
-    floating,
-    reference,
-    x,
-    y,
-    strategy,
-    middlewareData: { arrow: { x: arrowX, y: arrowY } = {} },
-    placement,
-    context,
-    elements,
-  } = useFloatingUI({
-    open,
-    onOpenChange: handleOpenChange,
-    placement: placementProp,
-    middleware: [
-      offset(8),
-      flip(),
-      shift({ limiter: limitShift() }),
-      arrow({ element: arrowRef }),
-    ],
-  });
+  const { floating, reference, x, y, strategy, placement, context, elements } =
+    useFloatingUI({
+      open,
+      onOpenChange: handleOpenChange,
+      placement: placementProp,
+      middleware: [
+        offset(8),
+        flip(),
+        shift({ limiter: limitShift() }),
+        arrow({ element: arrowRef }),
+      ],
+    });
 
   const { getReferenceProps, getFloatingProps } = useInteractions([
     useHover(context, {
@@ -111,11 +102,14 @@ export function useTooltip(props?: UseTooltipProps) {
   };
 
   const getTooltipProps = (): HTMLProps<HTMLDivElement> => {
-    return getFloatingProps({
-      // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- tabIndex raises false positives because it is set to "-1".
+    const { tabIndex, ...tooltipProps } = getFloatingProps({
+      // @ts-expect-error - `data-*` props need extra typing when not used on a DOM element.
       "data-placement": placement,
       ref: floating,
     });
+
+    return tooltipProps;
   };
 
   const getTriggerProps = () =>

--- a/site/docs/components/badge/accessibility.mdx
+++ b/site/docs/components/badge/accessibility.mdx
@@ -9,5 +9,5 @@ data:
 
 ### Best practices
 
-- When using a `Badge` that is attached to a child component that receives focus, the focusable element should have an `aria-label` or `aria-labelledby` attribute that describes the badge e.g. "9 Notifications".
-- When using a `Badge`, that is inline the badge is automatically announced by the screen reader when the user navigates to the element.
+- When a badge is attached to a child component and that component receives focus, the focusable element should have an `aria-label` or `aria-labelledby` attribute that describes the badge, such as "9 notifications."
+- When the user navigates to an inline badge, the screen reader automatically announces the contents of the badge. Use `aria-label` to provide more context to the badge contents if needed.

--- a/site/docs/components/badge/accessibility.mdx
+++ b/site/docs/components/badge/accessibility.mdx
@@ -9,4 +9,5 @@ data:
 
 ### Best practices
 
-We recommend only using the accent color for `Badge`. Align to the minimum contrast guidance outlined in [WCAG 2.1](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) for any color overrides.
+- When using a `Badge` that is attached to a child component that receives focus, the focusable element should have an `aria-label` or `aria-labelledby` attribute that describes the badge e.g. "9 Notifications".
+- When using a `Badge`, that is inline the badge is automatically announced by the screen reader when the user navigates to the element.

--- a/site/docs/components/badge/examples.mdx
+++ b/site/docs/components/badge/examples.mdx
@@ -8,8 +8,8 @@ data:
 ---
 
 <LivePreviewControls>
-  <LivePreview componentName="badge" exampleName="Default">
-  ### Default (top-right)
+<LivePreview componentName="badge" exampleName="Default">
+### Default (top-right)
 
 By default, `Badge` is in the top-right corner when attached to a child component such as an icon. Badges visually anchor to the attached component. As the number of alphanumeric characters increases, the badge width expands, but stays in the same place.
 
@@ -17,8 +17,8 @@ By default, `Badge` is in the top-right corner when attached to a child componen
 
 Use a badge in the top-right corner to summarize the overall state of the content the badge is anchored to. For example, you may want to provide a quick overview of the number of new or unread items, using numeric values.
 
-  </LivePreview>
-  <LivePreview componentName="badge" exampleName="InlineBadge">
+</LivePreview>
+<LivePreview componentName="badge" exampleName="InlineBadge">
 
 ### Inline badge
 
@@ -28,8 +28,8 @@ To place a badge inline instead of in the top-right corner of an element, don't 
 
 Using a badge inline with text clarifies which part of the content the badge relates to and allows specific details to be highlighted within the content to draw the user’s attention. For example, you may use a badge within `TabNext`, inline with the text.
 
-  </LivePreview>
-  <LivePreview componentName="badge" exampleName="BadgeWithMaximumDigits">
+</LivePreview>
+<LivePreview componentName="badge" exampleName="BadgeWithMaximumDigits">
 
 ### Badge with maximum digits
 
@@ -37,12 +37,12 @@ Specify the maximum displayed number with the `max` prop. If `value` exceeds `ma
 
 When you don't pass a max value to the component, the value will have a limitation of three digits by default, displaying 999+ for any values over 999.
 
-  </LivePreview>
-  <LivePreview componentName="badge" exampleName="BadgeWithString">
+</LivePreview>
+<LivePreview componentName="badge" exampleName="BadgeWithString">
     
-  ### Badge with string
+### Badge with string
 
 The `value` property can accept both a `number` and a `string`.
 
-  </LivePreview>
+</LivePreview>
 </LivePreviewControls>

--- a/site/src/examples/badge/BadgeWithMaximumDigits.tsx
+++ b/site/src/examples/badge/BadgeWithMaximumDigits.tsx
@@ -4,8 +4,8 @@ import { NotificationSolidIcon } from "@salt-ds/icons";
 
 export const BadgeWithMaximumDigits = (): ReactElement => (
   <Badge value={200} max={99}>
-    <Button>
-      <NotificationSolidIcon />
+    <Button aria-label="200 Notifications">
+      <NotificationSolidIcon aria-hidden />
     </Button>
   </Badge>
 );

--- a/site/src/examples/badge/BadgeWithString.tsx
+++ b/site/src/examples/badge/BadgeWithString.tsx
@@ -4,8 +4,8 @@ import { MessageIcon } from "@salt-ds/icons";
 
 export const BadgeWithString = (): ReactElement => (
   <Badge value={"NEW"}>
-    <Button>
-      <MessageIcon />
+    <Button aria-label="New messages">
+      <MessageIcon aria-hidden />
     </Button>
   </Badge>
 );

--- a/site/src/examples/badge/Default.tsx
+++ b/site/src/examples/badge/Default.tsx
@@ -4,8 +4,8 @@ import { NotificationSolidIcon } from "@salt-ds/icons";
 
 export const Default = (): ReactElement => (
   <Badge value={9}>
-    <Button>
-      <NotificationSolidIcon />
+    <Button aria-label="9 Notifications">
+      <NotificationSolidIcon aria-hidden />
     </Button>
   </Badge>
 );


### PR DESCRIPTION
Fixes the following:

- Tooltip's being announced as focusable/clickable due to floating-ui adding tabIndex -1
- External link's having redundant screen reader text that announces Link.
- Read-only checkboxes/radio button's not being announced as such.
- Standalone ToggleButton group's being announced as checkboxes (not ideal but not that wrong).
- Checkbox and radio button not being announced as indeterminate.
- Switch's thumb being announced.
- Badge's not being announced in all of the examples.