### PR TITLE
Add resizing support to MultilineInput

### DIFF
--- a/.changeset/tiny-radios-exercise.md
+++ b/.changeset/tiny-radios-exercise.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": minor
+---
+
+Added resizing support to `MutilineInput`. `MultilineInput`s will now resize when typing and can be resized manually.

--- a/packages/core/src/__tests__/__e2e__/multiline-input/MultilineInput.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/multiline-input/MultilineInput.cy.tsx
@@ -1,5 +1,6 @@
 import { composeStories } from "@storybook/react";
 import * as multilineInputStories from "@stories/multiline-input/multiline-input.stories";
+import { ChangeEvent } from "react";
 
 const { Default, Controlled, Readonly, WithFormField } = composeStories(
   multilineInputStories
@@ -8,7 +9,12 @@ const { Default, Controlled, Readonly, WithFormField } = composeStories(
 describe("GIVEN an MultilineInput", () => {
   it("should allow a default value to be set", () => {
     const changeSpy = cy.stub().as("changeSpy");
-    cy.mount(<Default onChange={changeSpy} />);
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+      // React 16 backwards compatibility
+      event.persist();
+      changeSpy(event);
+    };
+    cy.mount(<Default onChange={handleChange} />);
     cy.findByRole("textbox").should("have.value", "Value");
     cy.findByRole("textbox").clear();
     cy.findByRole("textbox").realClick();
@@ -112,7 +118,7 @@ describe("GIVEN an MultilineInput", () => {
         cy.findByRole("textbox")
           .invoke("height")
           .then((newHeight) => {
-            expect(newHeight).to.be.greaterThan(defaultHeight);
+            expect(newHeight ?? 0).to.be.greaterThan(defaultHeight ?? 0);
           });
       });
   });

--- a/packages/core/src/__tests__/__e2e__/multiline-input/MultilineInput.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/multiline-input/MultilineInput.cy.tsx
@@ -99,4 +99,21 @@ describe("GIVEN an MultilineInput", () => {
     cy.mount(<WithFormField readOnly />);
     cy.findByLabelText("Comments").should("have.attr", "readonly");
   });
+
+  it("should expand to fit its content", () => {
+    cy.mount(<Default />);
+    cy.findByRole("textbox")
+      .invoke("height")
+      .then((defaultHeight) => {
+        cy.findByRole("textbox").realClick();
+        cy.realPress("Enter");
+        cy.realPress("Enter");
+        cy.realPress("Enter");
+        cy.findByRole("textbox")
+          .invoke("height")
+          .then((newHeight) => {
+            expect(newHeight).to.be.greaterThan(defaultHeight);
+          });
+      });
+  });
 });

--- a/packages/core/src/__tests__/__e2e__/multiline-input/MultilineInput.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/multiline-input/MultilineInput.cy.tsx
@@ -1,240 +1,102 @@
-import { ChangeEvent, useState } from "react";
-import {
-  Button,
-  FormField,
-  FormFieldLabel,
-  MultilineInput,
-} from "@salt-ds/core";
+import { composeStories } from "@storybook/react";
+import * as multilineInputStories from "@stories/multiline-input/multiline-input.stories";
+
+const { Default, Controlled, Readonly, WithFormField } = composeStories(
+  multilineInputStories
+);
 
 describe("GIVEN an MultilineInput", () => {
-  it("SHOULD have no a11y violations on load", () => {
-    cy.mount(<MultilineInput defaultValue="The default value" />);
-    cy.checkAxeComponent();
+  it("should allow a default value to be set", () => {
+    const changeSpy = cy.stub().as("changeSpy");
+    cy.mount(<Default onChange={changeSpy} />);
+    cy.findByRole("textbox").should("have.value", "Value");
+    cy.findByRole("textbox").clear();
+    cy.findByRole("textbox").realClick();
+    cy.realType("New Value");
+    cy.get("@changeSpy").should("have.been.calledWithMatch", {
+      target: { value: "New Value" },
+    });
+    cy.findByRole("textbox").should("have.value", "New Value");
   });
 
-  describe("WHEN mounted as an uncontrolled component", () => {
-    it("SHOULD have the given default value", () => {
-      cy.mount(<MultilineInput defaultValue="The default value" />);
-      cy.findByRole("textbox").should("have.value", "The default value");
+  it("should support a controlled value", () => {
+    const changeSpy = cy.stub().as("changeSpy");
+    cy.mount(<Controlled onChange={changeSpy} />);
+    cy.findByRole("textbox").should("have.value", "Value");
+    cy.findByRole("textbox").clear();
+    cy.findByRole("textbox").realClick();
+    cy.realType("New Value");
+    cy.get("@changeSpy").should("have.been.calledWithMatch", {
+      target: { value: "New Value" },
     });
-
-    describe("THEN the input is updated", () => {
-      it("SHOULD call onChange with the new value", () => {
-        const changeSpy = cy.stub().as("changeSpy");
-        const onChange = (event: ChangeEvent<HTMLInputElement>) => {
-          // React 16 backwards compatibility
-          event.persist();
-          changeSpy(event);
-        };
-        cy.mount(
-          <MultilineInput
-            defaultValue="The default value"
-            onChange={onChange}
-          />
-        );
-        cy.findByRole("textbox").click().clear().type("new value");
-        cy.get("@changeSpy").should("have.been.calledWithMatch", {
-          target: { value: "new value" },
-        });
-      });
-    });
+    cy.findByRole("textbox").should("have.value", "New Value");
   });
 
-  describe("WHEN mounted as an controlled component", () => {
-    it("THEN have the specified value", () => {
-      cy.mount(<MultilineInput value="text value" />);
-      cy.findByRole("textbox").should("have.value", "text value");
-    });
-
-    describe("THEN the user input is updated", () => {
-      it("SHOULD call onChange with the new value", () => {
-        const changeSpy = cy.stub().as("changeSpy");
-
-        function ControlledMultilineInput() {
-          const [value, setValue] = useState("text value");
-          const onChange = (event: ChangeEvent<HTMLInputElement>) => {
-            // React 16 backwards compatibility
-            event.persist();
-            setValue(event.target.value);
-            changeSpy(event);
-          };
-
-          return <MultilineInput value={value} onChange={onChange} />;
-        }
-
-        cy.mount(<ControlledMultilineInput />);
-        cy.findByRole("textbox").click().clear().type("new value");
-        cy.get("@changeSpy").should("have.been.calledWithMatch", {
-          target: { value: "new value" },
-        });
-      });
-    });
+  it("should allow the value to be set as required", () => {
+    cy.mount(<Default textAreaProps={{ required: true }} />);
+    cy.findByRole("textbox").should("have.attr", "required");
   });
 
-  describe("WHEN an adornment is given", () => {
-    it("THEN should mount with adornment", () => {
-      cy.mount(
-        <MultilineInput startAdornment={<>%</>} defaultValue={"Value"} />
-      );
-      cy.findByText("%").should("be.visible");
-    });
-
-    describe("AND adornment is a Button", () => {
-      it("SHOULD mount with the button", () => {
-        cy.mount(
-          <MultilineInput
-            startAdornment={<Button>Test</Button>}
-            defaultValue={"Value"}
-          />
-        );
-        cy.findByRole("button").should("be.visible");
-        cy.findByRole("button").should("have.class", "saltButton");
-      });
-
-      it("SHOULD have the correct tab order on startAdornment", () => {
-        cy.mount(
-          <FormField>
-            <FormFieldLabel>Label</FormFieldLabel>
-            <MultilineInput
-              startAdornment={<Button>Test</Button>}
-              defaultValue="Value"
-              data-testid="test-id-3"
-            />
-          </FormField>
-        );
-
-        cy.realPress("Tab");
-        cy.findByRole("button").should("be.focused");
-        cy.realPress("Tab");
-        cy.findByRole("textbox").should("be.focused");
-      });
-
-      it("SHOULD have the correct tab order on endAdornment", () => {
-        cy.mount(
-          <FormField>
-            <FormFieldLabel>Label</FormFieldLabel>
-            <MultilineInput
-              defaultValue="Value"
-              endAdornment={<Button>Test</Button>}
-              data-testid="test-id-3"
-            />
-          </FormField>
-        );
-
-        cy.realPress("Tab");
-        cy.findByRole("textbox").should("be.focused");
-        cy.realPress("Tab");
-        cy.findByRole("button").should("be.focused");
-      });
-    });
+  it("should not receive focus when disabled", () => {
+    cy.mount(
+      <div>
+        <button>start</button>
+        <Default disabled />
+        <button>end</button>
+      </div>
+    );
+    cy.findByRole("textbox").should("be.disabled");
+    cy.realPress("Tab");
+    cy.findByRole("button", { name: "start" }).should("be.focused");
+    cy.realPress("Tab");
+    cy.findByRole("textbox").should("not.be.focused");
+    cy.findByRole("button", { name: "end" }).should("be.focused");
   });
 
-  describe("WHEN the input is required", () => {
-    it("SHOULD have required attr", () => {
-      cy.mount(
-        <MultilineInput
-          defaultValue="The default value"
-          textAreaProps={{ required: true }}
-        />
-      );
-      cy.findByRole("textbox").should("have.attr", "required");
-    });
+  it("should not allow the value to be changed when it is read-only", () => {
+    cy.mount(<Readonly />);
+    cy.findAllByRole("textbox").eq(0).should("have.attr", "readonly");
+    cy.findAllByRole("textbox").eq(0).should("have.value", "Value");
+    cy.findAllByRole("textbox").eq(0).realClick();
+    cy.findAllByRole("textbox").eq(0).should("be.focused");
+    cy.realType("Update");
+    cy.findAllByRole("textbox").eq(0).should("have.value", "Value");
   });
 
-  describe("WHEN disabled", () => {
-    it("SHOULD mount as disabled", () => {
-      cy.mount(<MultilineInput defaultValue="The default value" disabled />);
-      cy.findByRole("textbox").should("be.disabled");
-    });
-    it("SHOULD have no a11y violations on load", () => {
-      cy.mount(<MultilineInput defaultValue="The default value" disabled />);
-      cy.checkAxeComponent();
-    });
+  it("should have form field support", () => {
+    cy.mount(<WithFormField />);
+    cy.findByRole("textbox").should("have.accessibleName", "Comments");
+    cy.findByRole("textbox").should(
+      "have.accessibleDescription",
+      "Please leave feedback about your experience."
+    );
   });
 
-  describe("WHEN read only", () => {
-    it("SHOULD mount as read only", () => {
-      cy.mount(<MultilineInput defaultValue="The default value" readOnly />);
-      cy.findByRole("textbox").should("have.attr", "readonly");
-    });
-
-    it("SHOULD have no a11y violations on load", () => {
-      cy.mount(<MultilineInput defaultValue="The default value" readOnly />);
-      cy.checkAxeComponent();
-    });
+  it("should be disabled when it's FormField is disabled", () => {
+    cy.mount(<WithFormField disabled />);
+    cy.findByRole("textbox").should("be.disabled");
   });
 
-  describe("WHEN used in Formfield", () => {
-    describe("AND disabled", () => {
-      it("THEN MultilineInput within should be disabled", () => {
-        cy.mount(
-          <FormField disabled>
-            <FormFieldLabel>Disabled form field</FormFieldLabel>
-            <MultilineInput defaultValue="Value" />
-          </FormField>
-        );
-        cy.findByLabelText("Disabled form field").should(
-          "have.attr",
-          "disabled"
-        );
-      });
-    });
+  it("should be required when it's FormField is required", () => {
+    cy.mount(<WithFormField necessity="required" />);
+    cy.findByLabelText("Comments (Required)").should("have.attr", "required");
+  });
 
-    describe("AND is required", () => {
-      it("THEN MultilineInput within should be required", () => {
-        cy.mount(
-          <FormField necessity="required">
-            <FormFieldLabel>Form Field</FormFieldLabel>
-            <MultilineInput defaultValue="Value" />
-          </FormField>
-        );
-        cy.findByLabelText("Form Field (Required)").should(
-          "have.attr",
-          "required"
-        );
-      });
-    });
+  it("should be required when it's FormField is required with an asterisk", () => {
+    cy.mount(<WithFormField necessity="asterisk" />);
+    cy.findByLabelText("Comments *").should("have.attr", "required");
+  });
 
-    describe("AND is required with asterisk", () => {
-      it("THEN MultilineInput within should be required", () => {
-        cy.mount(
-          <FormField necessity="asterisk">
-            <FormFieldLabel>Form Field</FormFieldLabel>
-            <MultilineInput defaultValue="Value" />
-          </FormField>
-        );
-        cy.findByLabelText("Form Field *").should("have.attr", "required");
-      });
-    });
+  it("should not be required when it's FormField is optional", () => {
+    cy.mount(<WithFormField necessity="optional" />);
+    cy.findByLabelText("Comments (Optional)").should(
+      "not.have.attr",
+      "required"
+    );
+  });
 
-    describe("AND is optional", () => {
-      it("THEN MultilineInput within should not be required", () => {
-        cy.mount(
-          <FormField necessity="optional">
-            <FormFieldLabel>Form Field</FormFieldLabel>
-            <MultilineInput defaultValue="Value" />
-          </FormField>
-        );
-        cy.findByLabelText("Form Field (Optional)").should(
-          "not.have.attr",
-          "required"
-        );
-      });
-    });
-
-    describe("AND readonly", () => {
-      it("THEN MultilineInput within should be readonly", () => {
-        cy.mount(
-          <FormField readOnly>
-            <FormFieldLabel>Readonly form field</FormFieldLabel>
-            <MultilineInput defaultValue="Value" />
-          </FormField>
-        );
-        cy.findByLabelText("Readonly form field").should(
-          "have.attr",
-          "readonly"
-        );
-      });
-    });
+  it("should be read-only when it's FormField is read-only", () => {
+    cy.mount(<WithFormField readOnly />);
+    cy.findByLabelText("Comments").should("have.attr", "readonly");
   });
 });

--- a/packages/core/src/multiline-input/MultilineInput.css
+++ b/packages/core/src/multiline-input/MultilineInput.css
@@ -99,18 +99,17 @@
 .saltMultilineInput-textarea {
   background: none;
   border: none;
-  box-sizing: content-box;
+  box-sizing: border-box;
   color: inherit;
   cursor: inherit;
-  display: inline-flex;
-  height: calc(var(--saltMultilineInput-rows, 3) * var(--salt-text-lineHeight));
   flex-grow: 1;
   font: inherit;
   letter-spacing: 0;
+  line-height: var(--salt-text-lineHeight);
   margin: var(--salt-spacing-75) 0;
   min-width: 0;
-  overflow: hidden;
-  resize: none;
+  min-height: 0;
+  resize: vertical;
   padding: 0;
 }
 

--- a/packages/core/src/multiline-input/MultilineInput.tsx
+++ b/packages/core/src/multiline-input/MultilineInput.tsx
@@ -7,13 +7,14 @@ import {
   ReactNode,
   Ref,
   TextareaHTMLAttributes,
+  useRef,
   useState,
 } from "react";
 import { useComponentCssInjection } from "@salt-ds/styles";
 import { useWindow } from "@salt-ds/window";
 import { useFormFieldProps } from "../form-field-context";
 import { StatusAdornment } from "../status-adornment";
-import { makePrefixer, useControlled } from "../utils";
+import { makePrefixer, useControlled, useForkRef } from "../utils";
 
 import multilineInputCss from "./MultilineInput.css";
 
@@ -90,6 +91,9 @@ export const MultilineInput = forwardRef<HTMLDivElement, MultilineInputProps>(
     },
     ref
   ) {
+    const inputRef = useRef<HTMLTextAreaElement>(null);
+    const handleRef = useForkRef(inputRef, textAreaRef);
+
     const targetWindow = useWindow();
     useComponentCssInjection({
       testId: "salt-multiline-input",
@@ -140,10 +144,30 @@ export const MultilineInput = forwardRef<HTMLDivElement, MultilineInputProps>(
       state: "value",
     });
 
+    const previousHeight = useRef<string | undefined>(undefined);
+
     const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
       const value = event.target.value;
       setValue(value);
       onChange?.(event);
+      const input = event.target;
+
+      const hasBeenManuallyResized =
+        previousHeight.current !== undefined &&
+        input.style.height !== previousHeight.current;
+
+      if (!hasBeenManuallyResized) {
+        const previousOverflow = input.style.overflow;
+        input.style.overflow = "hidden";
+        input.style.height = "auto";
+        input.scrollHeight; // Needed to work around Firefox bug. https://bugzilla.mozilla.org/show_bug.cgi?id=1787062
+        const newHeight = `${
+          input.scrollHeight + (input.offsetHeight - input.clientHeight)
+        }px`;
+        input.style.height = newHeight;
+        previousHeight.current = newHeight;
+        input.style.overflow = previousOverflow;
+      }
     };
 
     const handleBlur = (event: FocusEvent<HTMLTextAreaElement>) => {
@@ -172,7 +196,7 @@ export const MultilineInput = forwardRef<HTMLDivElement, MultilineInputProps>(
             [withBaseName("focused")]: !isDisabled && focused,
             [withBaseName("disabled")]: isDisabled,
             [withBaseName("readOnly")]: isReadOnly,
-            [withBaseName(validationStatus || "")]: validationStatus,
+            [withBaseName(validationStatus ?? "")]: validationStatus,
           },
           classNameProp
         )}
@@ -192,7 +216,7 @@ export const MultilineInput = forwardRef<HTMLDivElement, MultilineInputProps>(
           disabled={isDisabled}
           id={id}
           readOnly={isReadOnly}
-          ref={textAreaRef}
+          ref={handleRef}
           required={isRequired}
           role={role}
           rows={rows}

--- a/packages/core/stories/multiline-input/multiline-input.stories.tsx
+++ b/packages/core/stories/multiline-input/multiline-input.stories.tsx
@@ -1,14 +1,21 @@
-import { Button, FlowLayout, Label, MultilineInput, Text } from "@salt-ds/core";
 import {
-  BankCheckSolidIcon,
+  FormField,
+  Button,
+  FlowLayout,
+  Label,
+  MultilineInput,
+  Text,
+  FormFieldLabel,
+  FormFieldHelperText,
+} from "@salt-ds/core";
+import {
   BookmarkSolidIcon,
-  EditSolidIcon,
   FilterClearIcon,
   FlagIcon,
-  HelpSolidIcon,
   PinSolidIcon,
+  RefreshIcon,
   SendIcon,
-  UserBadgeIcon,
+  CloseIcon,
 } from "@salt-ds/icons";
 import { Meta, StoryFn } from "@storybook/react";
 import { ChangeEvent, useState } from "react";
@@ -34,6 +41,7 @@ export const Controlled: StoryFn<typeof MultilineInput> = (args) => {
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
     setValue(value);
+    args.onChange?.(event);
   };
 
   return (
@@ -223,19 +231,14 @@ export const WithAdornments: StoryFn<typeof MultilineInput> = (args) => {
   return (
     <FlowLayout style={{ width: "366px" }}>
       <MultilineInput
-        startAdornment={
-          <Button variant="cta">
-            <EditSolidIcon />
-          </Button>
-        }
         endAdornment={
           <>
             <Text>GBP</Text>
-            <Button variant="secondary">
-              <HelpSolidIcon />
+            <Button variant="secondary" aria-label="Reset">
+              <RefreshIcon aria-hidden />
             </Button>
-            <Button variant="cta">
-              <SendIcon />
+            <Button variant="cta" aria-label="Submit">
+              <SendIcon aria-hidden />
             </Button>
           </>
         }
@@ -245,8 +248,8 @@ export const WithAdornments: StoryFn<typeof MultilineInput> = (args) => {
       <MultilineInput
         startAdornment={<Text>£</Text>}
         endAdornment={
-          <Button>
-            <BookmarkSolidIcon />
+          <Button aria-label="Bookmark">
+            <BookmarkSolidIcon aria-hidden />
           </Button>
         }
         defaultValue="Value"
@@ -255,8 +258,8 @@ export const WithAdornments: StoryFn<typeof MultilineInput> = (args) => {
       <MultilineInput
         disabled
         endAdornment={
-          <Button disabled>
-            <UserBadgeIcon />
+          <Button disabled aria-label="Clear input">
+            <CloseIcon aria-hidden />
           </Button>
         }
         defaultValue="Disabled value"
@@ -265,8 +268,8 @@ export const WithAdornments: StoryFn<typeof MultilineInput> = (args) => {
       <MultilineInput
         readOnly
         endAdornment={
-          <Button variant="secondary" disabled>
-            <BankCheckSolidIcon />
+          <Button variant="secondary" disabled aria-label="Clear input">
+            <CloseIcon aria-hidden />
           </Button>
         }
         defaultValue="Readonly value"
@@ -299,5 +302,17 @@ export const WithMultipleFeatures: StoryFn<typeof MultilineInput> = (args) => {
         {...args}
       />
     </FlowLayout>
+  );
+};
+
+export const WithFormField: StoryFn<typeof FormField> = (args) => {
+  return (
+    <FormField {...args}>
+      <FormFieldLabel>Comments</FormFieldLabel>
+      <MultilineInput defaultValue="Value" {...args} />
+      <FormFieldHelperText>
+        Please leave feedback about your experience.
+      </FormFieldHelperText>
+    </FormField>
   );
 };

--- a/packages/core/stories/multiline-input/multiline-input.stories.tsx
+++ b/packages/core/stories/multiline-input/multiline-input.stories.tsx
@@ -65,16 +65,6 @@ export const NumberOfRows: StoryFn<typeof MultilineInput> = (args) => {
   );
 };
 
-export const MaxRows: StoryFn<typeof MultilineInput> = (args) => {
-  return (
-    <MultilineInput
-      defaultValue="Value"
-      {...args}
-      style={{ maxWidth: "266px" }}
-    />
-  );
-};
-
 export const Bordered: StoryFn<typeof MultilineInput> = (args) => {
   return (
     <FlowLayout style={{ width: "366px" }}>

--- a/packages/core/stories/multiline-input/multiline-input.stories.tsx
+++ b/packages/core/stories/multiline-input/multiline-input.stories.tsx
@@ -57,6 +57,16 @@ export const NumberOfRows: StoryFn<typeof MultilineInput> = (args) => {
   );
 };
 
+export const MaxRows: StoryFn<typeof MultilineInput> = (args) => {
+  return (
+    <MultilineInput
+      defaultValue="Value"
+      {...args}
+      style={{ maxWidth: "266px" }}
+    />
+  );
+};
+
 export const Bordered: StoryFn<typeof MultilineInput> = (args) => {
   return (
     <FlowLayout style={{ width: "366px" }}>

--- a/packages/core/stories/multiline-input/multiline-input.stories.tsx
+++ b/packages/core/stories/multiline-input/multiline-input.stories.tsx
@@ -40,6 +40,8 @@ export const Controlled: StoryFn<typeof MultilineInput> = (args) => {
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
+    // React 16 backwards compatibility
+    event.persist();
     setValue(value);
     args.onChange?.(event);
   };

--- a/site/src/examples/multiline-input/Bordered.tsx
+++ b/site/src/examples/multiline-input/Bordered.tsx
@@ -2,5 +2,5 @@ import { ReactElement } from "react";
 import { MultilineInput } from "@salt-ds/core";
 
 export const Bordered = (): ReactElement => (
-  <MultilineInput bordered value="Value" style={{ maxWidth: "256px" }} />
+  <MultilineInput bordered defaultValue="Value" style={{ maxWidth: "256px" }} />
 );

--- a/site/src/examples/multiline-input/NumberOfRows.tsx
+++ b/site/src/examples/multiline-input/NumberOfRows.tsx
@@ -2,5 +2,5 @@ import { ReactElement } from "react";
 import { MultilineInput } from "@salt-ds/core";
 
 export const NumberOfRows = (): ReactElement => (
-  <MultilineInput value="Value" rows={4} style={{ maxWidth: "256px" }} />
+  <MultilineInput defaultValue="Value" rows={4} style={{ maxWidth: "256px" }} />
 );

--- a/site/src/examples/multiline-input/Primary.tsx
+++ b/site/src/examples/multiline-input/Primary.tsx
@@ -2,5 +2,5 @@ import { ReactElement } from "react";
 import { MultilineInput } from "@salt-ds/core";
 
 export const Primary = (): ReactElement => (
-  <MultilineInput value="Value" style={{ maxWidth: "256px" }} />
+  <MultilineInput defaultValue="Value" style={{ maxWidth: "256px" }} />
 );

--- a/site/src/examples/multiline-input/Secondary.tsx
+++ b/site/src/examples/multiline-input/Secondary.tsx
@@ -4,7 +4,7 @@ import { MultilineInput } from "@salt-ds/core";
 export const Secondary = (): ReactElement => (
   <MultilineInput
     variant="secondary"
-    value="Value"
+    defaultValue="Value"
     style={{ maxWidth: "256px" }}
   />
 );


### PR DESCRIPTION
Adds resizing to MultilineInput. Resizing can be done two ways:

- As new lines are entered, the field's height increases.
- An end-user can drag the resize handle to resize the field vertically. After doing this, the field no longer adjusts based on the content of the field.