### PR TITLE
Bump data grid version 

### DIFF
--- a/.changeset/chatty-houses-share.md
+++ b/.changeset/chatty-houses-share.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/data-grid": patch
+---
+
+Bump version so only 1 version of `@salt-ds/styles` will be installed


### PR DESCRIPTION
Bump version so only 1 version of `@salt-ds/styles` will be installed. 

Current version will cause both `0.1.1` and `0.2.1` be installed

```
"@salt-ds/data-grid@^1.0.4-alpha.7":
  version "1.0.4-alpha.7"
  resolved "https://artifacts.jpmchase.net/artifactory/api/npm/npm/@salt-ds/data-grid/-/data-grid-1.0.4-alpha.7.tgz#05d1ecaf6cdd18a4a5d709029352f09eab90886d"
  integrity sha1-BdHsr2zdGKSl1wkCk1LwnquQiG0=
  dependencies:
    "@salt-ds/core" "^1.8.2"
    "@salt-ds/icons" "^1.7.0"
    "@salt-ds/lab" "^1.0.0-alpha.17"
    "@salt-ds/styles" "^0.1.1"
    "@salt-ds/window" "^0.1.1"
    clsx "^2.0.0"
```