### PR TITLE
Undeprecate --salt-track-borderColor

### DIFF
--- a/.changeset/chilly-dragons-unite.md
+++ b/.changeset/chilly-dragons-unite.md
@@ -1,0 +1,6 @@
+---
+"@salt-ds/lab": patch
+"@salt-ds/theme": patch
+---
+
+Undeprecated `--salt-track-borderColor`, which was incorrectly deprecated in feb80146.

--- a/packages/lab/src/progress/CircularProgress/CircularProgress.css
+++ b/packages/lab/src/progress/CircularProgress/CircularProgress.css
@@ -21,7 +21,7 @@
   border-style: var(--salt-track-borderStyle);
   border-width: var(--salt-size-bar-small);
   border-radius: calc(var(--salt-size-base) * 3);
-  border-color: var(--salt-palette-neutral-secondary-border);
+  border-color: var(--salt-track-borderColor);
 }
 
 .saltCircularProgress-bar {

--- a/packages/lab/src/progress/LinearProgress/LinearProgress.css
+++ b/packages/lab/src/progress/LinearProgress/LinearProgress.css
@@ -27,7 +27,7 @@
 }
 
 .saltLinearProgress-track {
-  background: var(--salt-palette-neutral-secondary-border);
+  background: var(--salt-track-borderColor);
   width: 100%;
   height: var(--salt-size-bar-small);
   position: absolute;

--- a/packages/lab/src/slider/Slider.css
+++ b/packages/lab/src/slider/Slider.css
@@ -28,7 +28,7 @@
 
 .saltSlider {
   --slider-rail-height: var(--saltSlider-rail-height, 8px);
-  --slider-rail-color: var(--saltSlider-rail-color, var(--salt-palette-neutral-secondary-border));
+  --slider-rail-color: var(--saltSlider-rail-color, var(--salt-track-borderColor));
 
   --slider-rail-mark-height: var(--saltSlider-rail-mark-height, 7px);
   --slider-rail-mark-color: var(--saltSlider-rail-mark-color, var(--slider-rail-color));

--- a/packages/lab/src/stepped-tracker/TrackerConnector/TrackerConnector.css
+++ b/packages/lab/src/stepped-tracker/TrackerConnector/TrackerConnector.css
@@ -1,7 +1,7 @@
 .saltTrackerConnector {
   --trackerConnector-style-default: var(--saltTrackerConnector-style-default, var(--salt-track-borderStyle-incomplete));
   --trackerConnector-style-active: var(--saltTrackerConnector-style-active, var(--salt-track-borderStyle-active));
-  --trackerConnector-color: var(--saltTrackerConnector-color, var(--salt-palette-neutral-secondary-border));
+  --trackerConnector-color: var(--saltTrackerConnector-color, var(--salt-track-borderColor));
   --trackerConnector-thickness: var(--saltTrackerConnector-thickness, var(--salt-size-border-strong));
   --trackerConnector-margin: var(--saltTrackerConnector-margin, var(--salt-spacing-100));
   --trackerConnector-style-border: var(--trackerConnector-style-default);

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -126,9 +126,6 @@
   - --salt-track-borderWidth-complete
   - --salt-track-borderWidth-incomplete
   + --salt-size-border-strong
-
-  - --salt-track-borderColor
-  + --salt-palette-neutral-secondary-border
   ```
 
   #### Miscellaneous

--- a/packages/theme/css/characteristics/track.css
+++ b/packages/theme/css/characteristics/track.css
@@ -3,4 +3,6 @@
   --salt-track-borderStyle-active: solid;
   --salt-track-borderStyle-complete: solid;
   --salt-track-borderStyle-incomplete: dotted;
+
+  --salt-track-borderColor: var(--salt-palette-neutral-secondary-border);
 }

--- a/packages/theme/css/deprecated/characteristics.css
+++ b/packages/theme/css/deprecated/characteristics.css
@@ -144,7 +144,6 @@
   --salt-track-textAlign: center;
   --salt-track-background: var(--salt-palette-track-background);
   --salt-track-background-disabled: var(--salt-palette-track-background-disabled);
-  --salt-track-borderColor: var(--salt-palette-track-border); /* Use --salt-palette-neutral-secondary-border */
   --salt-track-borderColor-disabled: var(--salt-palette-track-border-disabled);
 
   /* Taggable */


### PR DESCRIPTION
During the theme changes --salt-track-borderColor was incorrectly marked as deprecated. This PR reverts that.