### PR TITLE
Unstable SaltProviderNext with corner radius

### DIFF
--- a/.changeset/brave-cows-shave.md
+++ b/.changeset/brave-cows-shave.md
@@ -1,0 +1,6 @@
+---
+"@salt-ds/core": minor
+"@salt-ds/lab": minor
+---
+
+Implemented corner radius for relavent components in theme next

--- a/.changeset/brave-cows-shave.md
+++ b/.changeset/brave-cows-shave.md
@@ -1,6 +1,5 @@
 ---
-"@salt-ds/core": minor
 "@salt-ds/lab": minor
 ---
 
-Implemented corner radius for relavent components in theme next
+Implemented corner radius for relevant components when used with theme next. Refer to [documentation](https://storybook.saltdesignsystem.com/?path=/docs/experimental-theme-next--docs) for more information.

--- a/.changeset/five-candles-tie.md
+++ b/.changeset/five-candles-tie.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/theme": minor
+---
+
+Added `theme-next.css` which includes experimental theme implementation

--- a/.changeset/five-candles-tie.md
+++ b/.changeset/five-candles-tie.md
@@ -2,4 +2,4 @@
 "@salt-ds/theme": minor
 ---
 
-Added `theme-next.css` which includes experimental theme implementation
+Added `theme-next.css` which includes experimental theme implementation. Refer to [documentation](https://storybook.saltdesignsystem.com/?path=/docs/experimental-theme-next--docs) for more information.

--- a/.changeset/four-crabs-promise.md
+++ b/.changeset/four-crabs-promise.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": minor
+---
+
+Added `UNSTABLE_SaltProviderNext` for early adopters to test incoming theme next features

--- a/.changeset/four-crabs-promise.md
+++ b/.changeset/four-crabs-promise.md
@@ -2,4 +2,5 @@
 "@salt-ds/core": minor
 ---
 
-Added `UNSTABLE_SaltProviderNext` for early adopters to test incoming theme next features
+Added `UNSTABLE_SaltProviderNext` for early adopters to test incoming theme next features. Refer to [documentation](https://storybook.saltdesignsystem.com/?path=/docs/experimental-theme-next--docs) for more information.
+Implemented corner radius for relevant components when used with theme next.

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -126,15 +126,15 @@ export const globalTypes: GlobalTypes = {
       title: "Theme Next",
     },
   },
-  cornerRadius: {
-    name: "Experimental corner radius",
-    description: "Turn on/off theme next",
+  corner: {
+    name: "Experimental corner",
+    description: "Switch corner to sharp / rounded",
     defaultValue: "sharp",
-    // if: { global: "themeNext", eq: "enable" }, // if doesn't work?
+    // if: { global: "themeNext", eq: "enable" }, // todo: why if doesn't work?
     toolbar: {
       icon: "beaker",
       items: ["sharp", "rounded"],
-      title: "Corner radius",
+      title: "Corner",
     },
   },
 };

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 import type { ArgTypes, Parameters } from "@storybook/react";
 import type { GlobalTypes } from "@storybook/csf";
 import "@salt-ds/theme/index.css";
+import "@salt-ds/theme/css/theme-next.css";
 import "@fontsource/open-sans/300.css";
 import "@fontsource/open-sans/300-italic.css";
 import "@fontsource/open-sans/400.css";
@@ -113,6 +114,27 @@ export const globalTypes: GlobalTypes = {
     toolbar: {
       items: ["disable", "enable"],
       title: "Component Style Injection",
+    },
+  },
+  themeNext: {
+    name: "Experimental theme next",
+    description: "Turn on/off theme next",
+    defaultValue: "disable",
+    toolbar: {
+      icon: "beaker",
+      items: ["disable", "enable"],
+      title: "Theme Next",
+    },
+  },
+  cornerRadius: {
+    name: "Experimental corner radius",
+    description: "Turn on/off theme next",
+    defaultValue: "sharp",
+    // if: { global: "themeNext", eq: "enable" }, // if doesn't work?
+    toolbar: {
+      icon: "beaker",
+      items: ["sharp", "rounded"],
+      title: "Corner radius",
     },
   },
 };

--- a/docs/decorators/withTheme.tsx
+++ b/docs/decorators/withTheme.tsx
@@ -5,6 +5,7 @@ import {
   Panel,
   SaltProvider,
   useTheme,
+  UNSTABLE_SaltProviderNext,
 } from "@salt-ds/core";
 import { useEffect } from "react";
 
@@ -64,7 +65,11 @@ function SetBackground({ viewMode, id }: { viewMode: string; id: string }) {
 }
 
 export const withTheme: Decorator = (StoryFn, context) => {
-  const { density, mode, styleInjection } = context.globals;
+  const { density, mode, styleInjection, themeNext, cornerRadius } =
+    context.globals;
+
+  const Provider =
+    themeNext === "enable" ? UNSTABLE_SaltProviderNext : SaltProvider;
 
   if (mode === "side-by-side" || mode === "stacked") {
     const isStacked = mode === "stacked";
@@ -84,31 +89,33 @@ export const withTheme: Decorator = (StoryFn, context) => {
         }}
       >
         {ModeValues.map((mode) => (
-          <SaltProvider
+          <Provider
             applyClassesTo={"child"}
             density={density}
             mode={mode}
             key={`${mode}-${styleInjection}`}
             enableStyleInjection={styleInjection === "enable"}
+            cornerRadius={cornerRadius}
           >
             <Panel>
               <StoryFn />
             </Panel>
-          </SaltProvider>
+          </Provider>
         ))}
       </div>
     );
   }
 
   return (
-    <SaltProvider
+    <Provider
       density={density}
       mode={mode}
       key={`${mode}-${styleInjection}`}
       enableStyleInjection={styleInjection === "enable"}
+      cornerRadius={cornerRadius}
     >
       <SetBackground viewMode={context.viewMode} id={context.id} />
       <StoryFn />
-    </SaltProvider>
+    </Provider>
   );
 };

--- a/docs/decorators/withTheme.tsx
+++ b/docs/decorators/withTheme.tsx
@@ -65,8 +65,7 @@ function SetBackground({ viewMode, id }: { viewMode: string; id: string }) {
 }
 
 export const withTheme: Decorator = (StoryFn, context) => {
-  const { density, mode, styleInjection, themeNext, cornerRadius } =
-    context.globals;
+  const { density, mode, styleInjection, themeNext, corner } = context.globals;
 
   const Provider =
     themeNext === "enable" ? UNSTABLE_SaltProviderNext : SaltProvider;
@@ -95,7 +94,7 @@ export const withTheme: Decorator = (StoryFn, context) => {
             mode={mode}
             key={`${mode}-${styleInjection}`}
             enableStyleInjection={styleInjection === "enable"}
-            cornerRadius={cornerRadius}
+            corner={corner}
           >
             <Panel>
               <StoryFn />
@@ -112,7 +111,7 @@ export const withTheme: Decorator = (StoryFn, context) => {
       mode={mode}
       key={`${mode}-${styleInjection}`}
       enableStyleInjection={styleInjection === "enable"}
-      cornerRadius={cornerRadius}
+      corner={corner}
     >
       <SetBackground viewMode={context.viewMode} id={context.id} />
       <StoryFn />

--- a/packages/core/src/__tests__/__e2e__/salt-provider/SaltProvider.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/salt-provider/SaltProvider.cy.tsx
@@ -297,11 +297,7 @@ describe("Given a SaltProviderNext", () => {
   describe("when nested", () => {
     it("should inherit values not passed as props", () => {
       mount(
-        <UNSTABLE_SaltProviderNext
-          density="high"
-          mode="dark"
-          cornerRadius="rounded"
-        >
+        <UNSTABLE_SaltProviderNext density="high" mode="dark" corner="rounded">
           <TestComponent />
           <UNSTABLE_SaltProviderNext density="medium">
             <TestComponent id="test-2" />
@@ -328,13 +324,9 @@ describe("Given a SaltProviderNext", () => {
     });
     it("should take different values set as props", () => {
       mount(
-        <UNSTABLE_SaltProviderNext
-          density="high"
-          mode="dark"
-          cornerRadius="rounded"
-        >
+        <UNSTABLE_SaltProviderNext density="high" mode="dark" corner="rounded">
           <TestComponent />
-          <UNSTABLE_SaltProviderNext density="medium" cornerRadius="sharp">
+          <UNSTABLE_SaltProviderNext density="medium" corner="sharp">
             <TestComponent id="test-2" />
           </UNSTABLE_SaltProviderNext>
         </UNSTABLE_SaltProviderNext>

--- a/packages/core/src/__tests__/__e2e__/utils/useFloatingUI.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/utils/useFloatingUI.cy.tsx
@@ -1,0 +1,87 @@
+import { mount } from "cypress/react18";
+import {
+  useFloatingComponent,
+  SaltProvider,
+  UNSTABLE_SaltProviderNext,
+  useFloatingUI,
+} from "@salt-ds/core";
+
+const TestComponent = ({
+  id = "test-1",
+  contentId = "test-1-content",
+  focusManager,
+  open = true,
+}: {
+  id?: string;
+  contentId?: string;
+  focusManager?: boolean;
+  open?: boolean;
+}) => {
+  const { Component: FloatingComponent } = useFloatingComponent();
+  const { context } = useFloatingUI({
+    open,
+  });
+  return (
+    <div id={id}>
+      <FloatingComponent
+        open={Boolean(open)}
+        focusManagerProps={focusManager ? { context } : undefined}
+      >
+        <div id={contentId} />
+      </FloatingComponent>
+    </div>
+  );
+};
+
+describe("Use useFloatingComponent", () => {
+  describe("without focusManager", () => {
+    it("should render a nested SaltProvider by default", () => {
+      mount(
+        <SaltProvider>
+          <TestComponent focusManager={false} />
+        </SaltProvider>
+      );
+
+      cy.get("html.salt-theme").should("have.length", 1);
+      cy.get("div.salt-provider.salt-theme").should("have.length", 1);
+    });
+    it("should render a nested UNSTABLE_SaltProviderNext when used within another", () => {
+      mount(
+        <UNSTABLE_SaltProviderNext>
+          <TestComponent focusManager={false} />
+        </UNSTABLE_SaltProviderNext>
+      );
+
+      cy.get("html.salt-theme.salt-theme-next").should("have.length", 1);
+      cy.get("div.salt-provider.salt-theme.salt-theme-next").should(
+        "have.length",
+        1
+      );
+    });
+  });
+  describe("with focusManager", () => {
+    it("should render a nested SaltProvider by default", () => {
+      mount(
+        <SaltProvider>
+          <TestComponent focusManager={true} />
+        </SaltProvider>
+      );
+
+      cy.get("html.salt-theme").should("have.length", 1);
+      cy.get("div.salt-provider.salt-theme").should("have.length", 1);
+    });
+    it("should render a nested UNSTABLE_SaltProviderNext when used within another", () => {
+      mount(
+        <UNSTABLE_SaltProviderNext>
+          <TestComponent focusManager={true} />
+        </UNSTABLE_SaltProviderNext>
+      );
+
+      cy.get("html.salt-theme.salt-theme-next").should("have.length", 1);
+      cy.get("div.salt-provider.salt-theme.salt-theme-next").should(
+        "have.length",
+        1
+      );
+    });
+  });
+});

--- a/packages/core/src/avatar/Avatar.css
+++ b/packages/core/src/avatar/Avatar.css
@@ -27,7 +27,7 @@
   min-height: var(--avatar-container-size);
   overflow: hidden;
   user-select: none;
-  border-radius: 50%;
+  border-radius: var(--saltAvatar-borderRadius, var(--salt-palette-corner-strongest, 50%));
 }
 .saltAvatar:has(img),
 .saltAvatar-withImage {

--- a/packages/core/src/badge/Badge.css
+++ b/packages/core/src/badge/Badge.css
@@ -12,7 +12,8 @@
   padding-right: var(--salt-spacing-50);
   height: var(--salt-text-notation-lineHeight);
   min-width: var(--salt-text-notation-lineHeight);
-  border-radius: 9999px;
+  border-radius: var(--salt-palette-corner-strongest, 9999px);
+
   white-space: nowrap;
   z-index: var(--salt-zIndex-default);
   box-sizing: border-box;

--- a/packages/core/src/banner/Banner.css
+++ b/packages/core/src/banner/Banner.css
@@ -6,6 +6,7 @@
   border-color: var(--saltBanner-borderColor, var(--banner-borderColor));
   border-width: var(--saltBanner-borderWidth, var(--salt-size-border));
   border-style: var(--saltBanner-borderStyle, var(--salt-container-borderStyle));
+  border-radius: var(--saltBanner-borderRadius, var(--salt-palette-corner, 0));
   box-sizing: border-box;
   display: inline-flex;
   gap: var(--salt-spacing-75);

--- a/packages/core/src/button/Button.css
+++ b/packages/core/src/button/Button.css
@@ -41,7 +41,7 @@
   border-color: var(--saltButton-borderColor, transparent);
   border-style: var(--saltButton-borderStyle, solid);
   border-width: var(--saltButton-borderWidth, 0);
-  border-radius: var(--saltButton-borderRadius, 0);
+  border-radius: var(--saltButton-borderRadius, var(--salt-palette-corner-weak, 0));
   color: var(--saltButton-text-color, var(--button-text-color));
   cursor: var(--saltButton-cursor, pointer);
   display: inline-flex;

--- a/packages/core/src/card/Card.css
+++ b/packages/core/src/card/Card.css
@@ -5,6 +5,7 @@
   padding: var(--saltCard-padding, var(--salt-spacing-200));
   position: relative;
   box-sizing: border-box;
+  border-radius: var(--saltCard-borderRadius, var(--salt-palette-corner, 0));
 }
 
 .saltCard-primary {

--- a/packages/core/src/card/InteractableCard.css
+++ b/packages/core/src/card/InteractableCard.css
@@ -4,7 +4,7 @@
   border-width: var(--saltCard-borderWidth, var(--card-borderWidth));
   border-style: var(--saltCard-borderStyle, var(--salt-container-borderStyle));
   border-color: var(--saltCard-borderColor, var(--salt-accent-borderColor));
-  border-radius: var(--saltCard-borderRadius, 0);
+  border-radius: var(--saltCard-borderRadius, var(--salt-palette-corner, 0));
   display: block;
   transition: box-shadow var(--salt-duration-instant) cubic-bezier(0.4, 0, 0.2, 1);
   padding: var(--saltCard-padding, var(--salt-spacing-300));

--- a/packages/core/src/checkbox/CheckboxIcon.css
+++ b/packages/core/src/checkbox/CheckboxIcon.css
@@ -5,6 +5,7 @@
   height: var(--checkbox-size);
   min-height: var(--checkbox-size);
   border: var(--salt-size-border) var(--salt-selectable-borderStyle) var(--salt-selectable-borderColor);
+  border-radius: var(--salt-palette-corner-weaker, 0);
   color: var(--salt-selectable-foreground);
   background: var(--salt-container-primary-background);
   position: relative;

--- a/packages/core/src/file-drop-zone/FileDropZone.css
+++ b/packages/core/src/file-drop-zone/FileDropZone.css
@@ -6,6 +6,7 @@
   align-items: center;
   justify-content: center;
   border: var(--saltFileDropZone-border, var(--salt-size-border-strong) var(--salt-target-borderStyle) var(--salt-container-primary-borderColor));
+  border-radius: var(--saltFileDropZone-borderRadius, var(--salt-palette-corner, 0));
   flex-direction: column;
   padding: var(--salt-spacing-200);
   gap: var(--salt-spacing-200);

--- a/packages/core/src/panel/Panel.css
+++ b/packages/core/src/panel/Panel.css
@@ -16,4 +16,5 @@
   overflow: auto;
   padding: var(--saltPanel-padding, var(--salt-size-container-spacing));
   width: var(--saltPanel-width, 100%);
+  border-radius: var(--saltPanel-borderRadius, var(--salt-palette-corner, 0));
 }

--- a/packages/core/src/pill/Pill.css
+++ b/packages/core/src/pill/Pill.css
@@ -4,7 +4,7 @@
   display: inline-flex;
   align-items: center;
   background: var(--saltPill-background, var(--salt-actionable-primary-background));
-  border-radius: 0;
+  border-radius: var(--saltPill-borderRadius, var(--salt-palette-corner-weaker, 0));
   border: 0;
   height: calc(var(--salt-size-base) - var(--salt-spacing-100));
   min-height: var(--salt-text-minHeight);

--- a/packages/core/src/salt-provider/SaltProvider.tsx
+++ b/packages/core/src/salt-provider/SaltProvider.tsx
@@ -19,7 +19,7 @@ import {
   useComponentCssInjection,
   StyleInjectionProvider,
 } from "@salt-ds/styles";
-import { UNSTABLE_CornerRadius } from "../theme/CornerRadius";
+import { UNSTABLE_Corner } from "../theme/Corner";
 
 export const DEFAULT_DENSITY = "medium";
 
@@ -27,14 +27,14 @@ const DEFAULT_THEME_NAME = "salt-theme";
 const UNSTABLE_ADDITIONAL_THEME_NAME = "salt-theme-next";
 
 const DEFAULT_MODE = "light";
-const DEFAULT_CORNER: UNSTABLE_CornerRadius = "sharp";
+const DEFAULT_CORNER: UNSTABLE_Corner = "sharp";
 export interface ThemeContextProps {
   theme: ThemeName;
   mode: Mode;
   window?: WindowContextType;
   /** Only available when using SaltProviderNext. */
   themeNext: boolean;
-  UNSTABLE_corner: UNSTABLE_CornerRadius;
+  UNSTABLE_corner: UNSTABLE_Corner;
 }
 
 export const DensityContext = createContext<Density>(DEFAULT_DENSITY);
@@ -77,7 +77,7 @@ const createThemedChildren = ({
   mode,
   applyClassesTo,
   themeNext,
-  cornerRadius,
+  corner,
 }: {
   children: ReactNode;
   themeName: ThemeName;
@@ -88,7 +88,7 @@ const createThemedChildren = ({
   UNSTABLE_SaltProviderNextAdditionalProps) => {
   const themeNames = getThemeNames(themeName, themeNext);
   const themeNextProps = {
-    "data-corner": cornerRadius,
+    "data-corner": corner,
   };
   if (applyClassesTo === "root") {
     return children;
@@ -168,7 +168,7 @@ function InternalSaltProvider({
   mode: modeProp,
   breakpoints: breakpointsProp,
   themeNext,
-  cornerRadius: cornerRadiusProp,
+  corner: cornerProp,
 }: Omit<
   SaltProviderProps & ThemeNextProps & UNSTABLE_SaltProviderNextProps,
   "enableStyleInjection"
@@ -187,7 +187,7 @@ function InternalSaltProvider({
     themeProp ?? (inheritedTheme === "" ? DEFAULT_THEME_NAME : inheritedTheme);
   const mode = modeProp ?? inheritedMode;
   const breakpoints = breakpointsProp ?? DEFAULT_BREAKPOINTS;
-  const corner = cornerRadiusProp ?? inheritedCorner ?? DEFAULT_CORNER;
+  const corner = cornerProp ?? inheritedCorner ?? DEFAULT_CORNER;
 
   const applyClassesTo =
     applyClassesToProp ?? (isRootProvider ? "root" : "scope");
@@ -217,7 +217,7 @@ function InternalSaltProvider({
     mode,
     applyClassesTo,
     themeNext,
-    cornerRadius: corner,
+    corner: corner,
   });
 
   useIsomorphicLayoutEffect(() => {
@@ -293,7 +293,7 @@ export function SaltProvider({
 }
 
 interface UNSTABLE_SaltProviderNextAdditionalProps {
-  cornerRadius?: UNSTABLE_CornerRadius;
+  corner?: UNSTABLE_Corner;
 }
 
 export type UNSTABLE_SaltProviderNextProps = SaltProviderProps &

--- a/packages/core/src/salt-provider/SaltProvider.tsx
+++ b/packages/core/src/salt-provider/SaltProvider.tsx
@@ -303,7 +303,6 @@ export function UNSTABLE_SaltProviderNext({
   enableStyleInjection,
   ...restProps
 }: UNSTABLE_SaltProviderNextProps) {
-  console.log("UNSTABLE_SaltProviderNext");
   return (
     <StyleInjectionProvider value={enableStyleInjection}>
       {/* Leveraging InternalSaltProvider being not exported, so we can pass more props than previously supported */}

--- a/packages/core/src/switch/Switch.css
+++ b/packages/core/src/switch/Switch.css
@@ -19,6 +19,7 @@
 .saltSwitch-track {
   border: var(--salt-size-border) var(--salt-selectable-borderStyle) var(--salt-selectable-borderColor);
   --saltIcon-size: 100%;
+  border-radius: var(--salt-palette-corner-weak, 0);
   display: flex;
   flex-shrink: 0;
   height: calc(var(--salt-size-base) - var(--salt-spacing-100));
@@ -73,6 +74,7 @@
   margin: var(--salt-spacing-25);
   border: var(--salt-size-border) var(--salt-selectable-borderStyle) var(--salt-selectable-borderColor);
   box-sizing: border-box;
+  border-radius: var(--salt-palette-corner-weaker, 0);
 }
 
 .saltSwitch-input:focus-visible + .saltSwitch-track .saltSwitch-thumb,

--- a/packages/core/src/theme/Corner.ts
+++ b/packages/core/src/theme/Corner.ts
@@ -1,0 +1,3 @@
+export const UNSTABLE_CornerValues = ["sharp", "rounded"] as const;
+
+export type UNSTABLE_Corner = (typeof UNSTABLE_CornerValues)[number];

--- a/packages/core/src/theme/CornerRadius.ts
+++ b/packages/core/src/theme/CornerRadius.ts
@@ -1,4 +1,0 @@
-export const UNSTABLE_CornerRadiusValues = ["sharp", "rounded"] as const;
-
-export type UNSTABLE_CornerRadius =
-  (typeof UNSTABLE_CornerRadiusValues)[number];

--- a/packages/core/src/theme/CornerRadius.ts
+++ b/packages/core/src/theme/CornerRadius.ts
@@ -1,0 +1,4 @@
+export const UNSTABLE_CornerRadiusValues = ["sharp", "rounded"] as const;
+
+export type UNSTABLE_CornerRadius =
+  (typeof UNSTABLE_CornerRadiusValues)[number];

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -1,4 +1,4 @@
 export * from "./Density";
 export * from "./Theme";
 export * from "./Mode";
-export * from "./CornerRadius";
+export * from "./Corner";

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -1,3 +1,4 @@
 export * from "./Density";
 export * from "./Theme";
 export * from "./Mode";
+export * from "./CornerRadius";

--- a/packages/core/src/toast/Toast.css
+++ b/packages/core/src/toast/Toast.css
@@ -6,6 +6,7 @@
   border-color: var(--saltToast-borderColor, var(--toast-borderColor));
   border-width: var(--saltToast-borderWidth, var(--salt-size-border));
   border-style: var(--saltToast-borderStyle, var(--salt-container-borderStyle));
+  border-radius: var(--saltToast-borderRadius, var(--salt-palette-corner, 0));
 
   box-sizing: border-box;
   box-shadow: var(--salt-overlayable-shadow-popout);

--- a/packages/core/src/toggle-button-group/ToggleButtonGroup.css
+++ b/packages/core/src/toggle-button-group/ToggleButtonGroup.css
@@ -2,6 +2,7 @@
   display: flex;
   background: var(--salt-container-primary-background);
   border: var(--salt-size-border) var(--salt-container-borderStyle) var(--salt-container-primary-borderColor);
+  border-radius: var(--salt-palette-corner-weak, 0);
   width: fit-content;
   gap: var(--salt-spacing-50);
   padding: calc(var(--salt-spacing-50) - var(--salt-size-border));

--- a/packages/core/src/toggle-button/ToggleButton.css
+++ b/packages/core/src/toggle-button/ToggleButton.css
@@ -6,7 +6,7 @@
   display: inline-flex;
   background: var(--salt-actionable-secondary-background);
   border: 0 solid transparent;
-  border-radius: 0;
+  border-radius: var(--salt-palette-corner-weaker, 0);
   height: var(--salt-size-base);
   color: var(--salt-actionable-secondary-foreground);
   text-transform: var(--salt-text-action-textTransform);

--- a/packages/core/src/tooltip/Tooltip.css
+++ b/packages/core/src/tooltip/Tooltip.css
@@ -11,6 +11,7 @@
   border-color: var(--saltTooltip-borderColor, var(--tooltip-status-borderColor));
   border-style: var(--saltTooltip-borderStyle, var(--salt-container-borderStyle));
   border-width: var(--saltTooltip-borderWidth, var(--salt-size-border));
+  border-radius: var(--saltTooltip-borderRadius, var(--salt-palette-corner-weak, 0));
   box-shadow: var(--saltTooltip-shadow, var(--salt-overlayable-shadow-popout));
   color: var(--saltTooltip-text-color, var(--salt-content-primary-foreground));
   font-family: var(--salt-text-fontFamily);

--- a/packages/core/src/utils/useFloatingUI/useFloatingUI.tsx
+++ b/packages/core/src/utils/useFloatingUI/useFloatingUI.tsx
@@ -1,29 +1,31 @@
 import {
+  FloatingFocusManager,
+  FloatingFocusManagerProps,
+  FloatingPortal,
   Middleware,
   Platform,
   Strategy,
+  UseFloatingOptions,
   autoUpdate,
   flip,
   limitShift,
   platform,
   shift,
   useFloating,
-  FloatingPortal,
-  FloatingFocusManager,
-  FloatingFocusManagerProps,
 } from "@floating-ui/react";
-
 import {
-  createContext,
+  ComponentPropsWithoutRef,
   ReactNode,
+  createContext,
+  forwardRef,
   useContext,
   useMemo,
-  forwardRef,
-  ComponentPropsWithoutRef,
 } from "react";
-
-import { SaltProvider } from "../../salt-provider";
-import { UseFloatingOptions } from "@floating-ui/react/dist/floating-ui.react";
+import {
+  SaltProvider,
+  UNSTABLE_SaltProviderNext,
+  useTheme,
+} from "../../salt-provider";
 
 export interface FloatingComponentProps
   extends ComponentPropsWithoutRef<"div"> {
@@ -71,23 +73,29 @@ const DefaultFloatingComponent = forwardRef<
     position,
   };
 
+  const { themeNext } = useTheme();
+
+  const ChosenSaltProvider = themeNext
+    ? UNSTABLE_SaltProviderNext
+    : SaltProvider;
+
   if (focusManagerProps && open) {
     return (
       <FloatingPortal>
-        <SaltProvider>
+        <ChosenSaltProvider>
           <FloatingFocusManager {...focusManagerProps}>
             <div style={style} {...rest} ref={ref} />
           </FloatingFocusManager>
-        </SaltProvider>
+        </ChosenSaltProvider>
       </FloatingPortal>
     );
   }
 
   return open ? (
     <FloatingPortal>
-      <SaltProvider>
+      <ChosenSaltProvider>
         <div style={style} {...rest} ref={ref} />
-      </SaltProvider>
+      </ChosenSaltProvider>
     </FloatingPortal>
   ) : null;
 });

--- a/packages/core/stories/card/card.stories.tsx
+++ b/packages/core/stories/card/card.stories.tsx
@@ -159,7 +159,7 @@ export const Variants: StoryFn<typeof Card> = (args) => {
   );
 };
 
-export const Interactable: StoryFn<typeof Card> = (args) => (
+export const Interactable: StoryFn<typeof InteractableCard> = (args) => (
   <InteractableCard {...args} style={{ width: "260px" }}>
     <StackLayout gap={1}>
       <H3>Sustainable investing products</H3>
@@ -171,12 +171,15 @@ export const Interactable: StoryFn<typeof Card> = (args) => (
   </InteractableCard>
 );
 
-export const InteractableDisabled: StoryFn<typeof Card> = (args) => (
+export const InteractableDisabled: StoryFn<typeof InteractableCard> = (
+  args
+) => (
   <InteractableCard
     style={{ width: "260px" }}
     onClick={() => console.log("Clicked")}
     data-testid="card-disabled-example"
     disabled
+    {...args}
   >
     <StackLayout gap={1}>
       <H3 disabled>Sustainable investing products</H3>
@@ -188,7 +191,9 @@ export const InteractableDisabled: StoryFn<typeof Card> = (args) => (
   </InteractableCard>
 );
 
-export const InteractableAccentVariations: StoryFn<typeof Card> = (args) => {
+export const InteractableAccentVariations: StoryFn<typeof InteractableCard> = (
+  args
+) => {
   const [placement, setPlacement] =
     useState<InteractableCardProps["accentPlacement"]>("bottom");
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -238,7 +243,9 @@ export const InteractableAccentVariations: StoryFn<typeof Card> = (args) => {
   );
 };
 
-export const InteractableAsBlockLink: StoryFn<typeof Card> = (args) => {
+export const InteractableAsBlockLink: StoryFn<typeof InteractableCard> = (
+  args
+) => {
   return (
     <Link style={{ textDecoration: "none" }} href="#" IconComponent={null}>
       <InteractableCard {...args} style={{ width: "266px" }}>

--- a/packages/core/stories/salt-provider/salt-provider-next.doc.stories.mdx
+++ b/packages/core/stories/salt-provider/salt-provider-next.doc.stories.mdx
@@ -24,23 +24,24 @@ To use the new Salt Provider, you need to swap any existing `SaltProvider` to us
 and also import a new theme CSS.
 
 ```js static
+// Swap out existing SaltProvider
 import { UNSTABLE_SaltProviderNext } from "@salt-ds/core";
 ```
-
-The new provider adds additional `.salt-theme-next` to either the root or provider element, together with any additional
-data attributes needed for new props.
 
 ```js static
 // Alongside with existing `import "@salt-ds/theme/index.css";`
 import "@salt-ds/theme/css/theme-next.css";
 ```
 
-`theme-next.css` will scope values to `.salt-theme-next` to make sure any new values (like color palettes) could override
-existing values in `.salt-theme`.
+The new provider adds additional `.salt-theme-next` to either the root or provider element, together with
+any additional data attributes (e.g. `data-corner`) needed for new props.
+
+All values within `theme-next.css` will be scoped to `.salt-theme-next` to make sure any replacement values
+(like new color palettes) could override existing values in `.salt-theme`.
 
 ## Corner radius
 
-Although default Salt design language stays sharp to serve our institutional clients,
+Although default Salt design language stays sharp corners to serve our institutional clients,
 rounded corners can be made available to many components to achieve a softer, consumer friendly feel.
 
 The `cornerRadius` prop can be used to toggle between `"sharp"` (default) and `"rounded"`.
@@ -76,7 +77,7 @@ Following components have received corner options, and more components will be a
 
 #### Interactive (inner)
 
-Interactive elements sit within other interactive elements uses `--salt-palette-corner-weaker` token.
+Interactive components sit within other interactive components use `--salt-palette-corner-weaker` token.
 
 - Checkbox
 - Pill
@@ -85,7 +86,7 @@ Interactive elements sit within other interactive elements uses `--salt-palette-
 
 #### Interactive (outer)
 
-These components uses `--salt-palette-corner-weak` token
+Outer interactive components use `--salt-palette-corner-weak` token.
 
 - Button
 - Switch (track)
@@ -94,7 +95,7 @@ These components uses `--salt-palette-corner-weak` token
 
 #### Containers
 
-These components uses `--salt-palette-corner` token
+Container components use `--salt-palette-corner` token.
 
 - Banner
 - Card
@@ -106,7 +107,7 @@ These components uses `--salt-palette-corner` token
 
 #### Primitives
 
-These components uses `--salt-palette-corner-strongest` token
+These components use `--salt-palette-corner-strongest` token
 
 - Avatar
 - Badge

--- a/packages/core/stories/salt-provider/salt-provider-next.doc.stories.mdx
+++ b/packages/core/stories/salt-provider/salt-provider-next.doc.stories.mdx
@@ -44,10 +44,10 @@ All values within `theme-next.css` will be scoped to `.salt-theme-next` to make 
 Although default Salt design language stays sharp corners to serve our institutional clients,
 rounded corners can be made available to many components to achieve a softer, consumer friendly feel.
 
-The `cornerRadius` prop can be used to toggle between `"sharp"` (default) and `"rounded"`.
+The `corner` prop can be used to toggle between `"sharp"` (default) and `"rounded"`.
 
 ```tsx
-<UNSTABLE_SaltProviderNext cornerRadius="rounded">
+<UNSTABLE_SaltProviderNext corner="rounded">
 ```
 
 ### Token Structure

--- a/packages/core/stories/salt-provider/salt-provider-next.doc.stories.mdx
+++ b/packages/core/stories/salt-provider/salt-provider-next.doc.stories.mdx
@@ -53,21 +53,21 @@ The `cornerRadius` prop can be used to toggle between `"sharp"` (default) and `"
 
 A new set of foundation token (curve) is added with below values
 
-| Foundation Token   | HD    | MD/LD/TD |
-| ------------------ | ----- | -------- |
-| `--salt-curve-0`   | 0     | 0        |
-| `--salt-curve-100` | 1px   | 2px      |
-| `--salt-curve-200` | 2px   | 4px      |
-| `--salt-curve-300` | 4px   | 8px      |
-| `--salt-curve-999` | 999px | 999px    |
+| Foundation Token   | HD    | MD    | LD    | TD    |
+| ------------------ | ----- | ----- | ----- | ----- |
+| `--salt-curve-0`   | 0     | 0     | 0     | 0     |
+| `--salt-curve-50`  | 1px   | 2px   | 3px   | 4px   |
+| `--salt-curve-100` | 2px   | 4px   | 6px   | 8px   |
+| `--salt-curve-150` | 3px   | 6px   | 9px   | 12px  |
+| `--salt-curve-999` | 999px | 999px | 999px | 999px |
 
 A new set of palette token (corner) is added with below mapping
 
 | Palette Token                     | Sharp              | Rounded            |
 | --------------------------------- | ------------------ | ------------------ |
-| `--salt-palette-corner-weaker`    | `--salt-curve-0`   | `--salt-curve-100` |
-| `--salt-palette-corner-weak`      | `--salt-curve-0`   | `--salt-curve-200` |
-| `--salt-palette-corner`           | `--salt-curve-0`   | `--salt-curve-300` |
+| `--salt-palette-corner-weaker`    | `--salt-curve-0`   | `--salt-curve-50`  |
+| `--salt-palette-corner-weak`      | `--salt-curve-0`   | `--salt-curve-100` |
+| `--salt-palette-corner`           | `--salt-curve-0`   | `--salt-curve-150` |
 | `--salt-palette-corner-strongest` | `--salt-curve-999` | `--salt-curve-999` |
 
 ### Components

--- a/packages/core/stories/salt-provider/salt-provider-next.doc.stories.mdx
+++ b/packages/core/stories/salt-provider/salt-provider-next.doc.stories.mdx
@@ -1,0 +1,112 @@
+import { Meta } from "@storybook/addon-docs";
+import { Banner, BannerContent } from "@salt-ds/core";
+
+<Meta title="Experimental/Theme Next" />
+
+<Banner>
+  <BannerContent>
+    This page documents early phase of theme evolvement. Only use this when
+    there is a business need.
+  </BannerContent>
+</Banner>
+
+# Salt Provider Next
+
+The new Salt Provider introduces Salt's next phase theming capability with more styling options, including
+rounded corners, balanced color palettes, etc. Features will be introduced gradually over time and we're
+encouraging teams needing this to test to give us feedback.
+
+It extends existing [Salt Provider](/?path=/docs/documentation-core-salt-provider--docs) so existing options
+are still available (e.g. light/dark mode, high/medium/low/touch density). Additional props will be made available
+to switch between different look.
+
+To use the new Salt Provider, you need to swap any existing `SaltProvider` to use the new `UNSTABLE_SaltProviderNext`,
+and also import a new theme CSS.
+
+```js static
+import { UNSTABLE_SaltProviderNext } from "@salt-ds/core";
+```
+
+The new provider adds additional `.salt-theme-next` to either the root or provider element, together with any additional
+data attributes needed for new props.
+
+```js static
+// Alongside with existing `import "@salt-ds/theme/index.css";`
+import "@salt-ds/theme/css/theme-next.css";
+```
+
+`theme-next.css` will scope values to `.salt-theme-next` to make sure any new values (like color palettes) could override
+existing values in `.salt-theme`.
+
+## Corner radius
+
+Although default Salt design language stays sharp to serve our institutional clients,
+rounded corners can be made available to many components to achieve a softer, consumer friendly feel.
+
+The `cornerRadius` prop can be used to toggle between `"sharp"` (default) and `"rounded"`.
+
+```tsx
+<UNSTABLE_SaltProviderNext cornerRadius="rounded">
+```
+
+### Token Structure
+
+A new set of foundation token (curve) is added with below values
+
+| Foundation Token   | HD    | MD/LD/TD |
+| ------------------ | ----- | -------- |
+| `--salt-curve-0`   | 0     | 0        |
+| `--salt-curve-100` | 1px   | 2px      |
+| `--salt-curve-200` | 2px   | 4px      |
+| `--salt-curve-300` | 4px   | 8px      |
+| `--salt-curve-999` | 999px | 999px    |
+
+A new set of palette token (corner) is added with below mapping
+
+| Palette Token                     | Sharp              | Rounded            |
+| --------------------------------- | ------------------ | ------------------ |
+| `--salt-palette-corner-weaker`    | `--salt-curve-0`   | `--salt-curve-100` |
+| `--salt-palette-corner-weak`      | `--salt-curve-0`   | `--salt-curve-200` |
+| `--salt-palette-corner`           | `--salt-curve-0`   | `--salt-curve-300` |
+| `--salt-palette-corner-strongest` | `--salt-curve-999` | `--salt-curve-999` |
+
+### Components
+
+Following components have received corner options, and more components will be added from feedback.
+
+#### Interactive (inner)
+
+Interactive elements sit within other interactive elements uses `--salt-palette-corner-weaker` token.
+
+- Checkbox
+- Pill
+- Switch (thumb)
+- Toggle Button
+
+#### Interactive (outer)
+
+These components uses `--salt-palette-corner-weak` token
+
+- Button
+- Switch (track)
+- Toggle Button Group
+- Tooltip
+
+#### Containers
+
+These components uses `--salt-palette-corner` token
+
+- Banner
+- Card
+- Dialog
+- File drop zone
+- Overlay
+- Panel
+- Toast
+
+#### Primitives
+
+These components uses `--salt-palette-corner-strongest` token
+
+- Avatar
+- Badge

--- a/packages/lab/src/dialog/Dialog.css
+++ b/packages/lab/src/dialog/Dialog.css
@@ -17,6 +17,7 @@
   height: min-content;
   border: var(--salt-container-borderStyle) var(--salt-separable-tertiary-borderColor) var(--salt-size-border);
   box-sizing: border-box;
+  border-radius: var(--salt-palette-corner, 0);
 }
 
 /* Styles applied to Dialog when a status="info" */

--- a/packages/lab/src/overlay/Overlay.css
+++ b/packages/lab/src/overlay/Overlay.css
@@ -12,7 +12,7 @@
   border-color: var(--overlay-borderColor);
   border-style: var(--saltOverlay-borderStyle, var(--salt-container-borderStyle));
   border-width: var(--saltOverlay-borderWidth, var(--salt-size-border));
-  border-radius: var(--saltOverlay-borderRadius, var(--salt-palette-corner-small, 0));
+  border-radius: var(--saltOverlay-borderRadius, var(--salt-palette-corner, 0));
 
   background: var(--overlay-background);
   box-shadow: var(--saltOverlay-boxShadow, var(--salt-overlayable-shadow-popout));

--- a/packages/lab/src/overlay/Overlay.css
+++ b/packages/lab/src/overlay/Overlay.css
@@ -12,6 +12,7 @@
   border-color: var(--overlay-borderColor);
   border-style: var(--saltOverlay-borderStyle, var(--salt-container-borderStyle));
   border-width: var(--saltOverlay-borderWidth, var(--salt-size-border));
+  border-radius: var(--saltOverlay-borderRadius, var(--salt-palette-corner-small, 0));
 
   background: var(--overlay-background);
   box-shadow: var(--saltOverlay-boxShadow, var(--salt-overlayable-shadow-popout));

--- a/packages/lab/stories/kitchen-sink/kitchen-sink.stories.tsx
+++ b/packages/lab/stories/kitchen-sink/kitchen-sink.stories.tsx
@@ -113,7 +113,7 @@ const LaunchStatusDialog = () => {
         // focus the ok instead of the cancel button
         initialFocus={1}
       >
-        <DialogTitle>{status}</DialogTitle>
+        <DialogTitle title={status} />
         <DialogContent>{content}</DialogContent>
         <DialogActions>
           <Button onClick={handleClose}>Cancel</Button>

--- a/packages/lab/stories/kitchen-sink/kitchen-sink.stories.tsx
+++ b/packages/lab/stories/kitchen-sink/kitchen-sink.stories.tsx
@@ -62,6 +62,7 @@ import {
   Closable as PillClosable,
   Icon as PillIcon,
 } from "../../../core/stories/pill/pill.stories";
+import { Default as OverlayDefault } from "../../../lab/stories/overlay/overlay.stories";
 
 export default {
   title: "Experimental/Kitchen Sink",
@@ -271,7 +272,7 @@ export const Example1 = () => {
           content="I am a tooltip"
           status="warning"
           open
-          placement="bottom"
+          placement="right"
         >
           <Button>Warning</Button>
         </Tooltip>
@@ -279,10 +280,13 @@ export const Example1 = () => {
           content="I am a tooltip"
           status="success"
           open
-          placement="bottom"
+          placement="right"
         >
           <Button>Success</Button>
         </Tooltip>
+
+        <OverlayDefault open />
+        <OverlayDefault open placement="bottom" />
       </StackLayout>
       <StackLayout direction="row">
         <FlexItem>

--- a/packages/lab/stories/kitchen-sink/kitchen-sink.stories.tsx
+++ b/packages/lab/stories/kitchen-sink/kitchen-sink.stories.tsx
@@ -15,9 +15,16 @@ import {
   ValidationStatus,
   RadioButton,
   RadioButtonGroup,
+  H3,
+  FlexLayout,
 } from "@salt-ds/core";
 import { AD, GB, UN, US } from "@salt-ds/countries";
-import { NotificationIcon, NotificationSolidIcon } from "@salt-ds/icons";
+import {
+  NotificationIcon,
+  NotificationSolidIcon,
+  SaltShakerIcon,
+  SaltShakerSolidIcon,
+} from "@salt-ds/icons";
 import {
   DefaultGroup as AccordionDefault,
   Status as AccordionStatus,
@@ -63,6 +70,8 @@ import {
   Icon as PillIcon,
 } from "../../../core/stories/pill/pill.stories";
 import { Default as OverlayDefault } from "../../../lab/stories/overlay/overlay.stories";
+import AgGridThemeDefault from "../../../ag-grid-theme/stories/examples/Default";
+import AgGridThemeHDCompact from "../../../ag-grid-theme/stories/examples/HDCompact";
 
 export default {
   title: "Experimental/Kitchen Sink",
@@ -116,6 +125,17 @@ const LaunchStatusDialog = () => {
     </>
   );
 };
+
+const GriActionCellRenderer = () => (
+  <FlexLayout align="center" style={{ height: "100%" }} gap={1}>
+    <Button variant="cta">
+      <SaltShakerSolidIcon />
+    </Button>
+    <Button>
+      <SaltShakerIcon />
+    </Button>
+  </FlexLayout>
+);
 
 export const Example1 = () => {
   return (
@@ -285,8 +305,8 @@ export const Example1 = () => {
           <Button>Success</Button>
         </Tooltip>
 
-        <OverlayDefault open />
-        <OverlayDefault open placement="bottom" />
+        <OverlayDefault />
+        <OverlayDefault placement="bottom" />
       </StackLayout>
       <StackLayout direction="row">
         <FlexItem>
@@ -304,6 +324,55 @@ export const Example1 = () => {
       <StackLayout direction="row">
         <FormFieldValidation />
       </StackLayout>
+      <AgGridThemeDefault
+        columnDefs={[
+          {
+            headerName: "Name",
+            field: "name",
+            filterParams: {
+              buttons: ["reset", "apply"],
+            },
+            editable: false,
+          },
+          {
+            headerName: "Code",
+            field: "code",
+          },
+          {
+            headerName: "Capital",
+            field: "capital",
+          },
+          {
+            headerName: "Action",
+            cellRenderer: GriActionCellRenderer,
+          },
+        ]}
+      />
+      <H3>HD Compact</H3>
+      <AgGridThemeHDCompact
+        columnDefs={[
+          {
+            headerName: "Name",
+            field: "name",
+            filterParams: {
+              buttons: ["reset", "apply"],
+            },
+            editable: false,
+          },
+          {
+            headerName: "Code",
+            field: "code",
+          },
+          {
+            headerName: "Capital",
+            field: "capital",
+          },
+          {
+            headerName: "Action",
+            cellRenderer: GriActionCellRenderer,
+          },
+        ]}
+      />
     </StackLayout>
   );
 };

--- a/packages/lab/stories/kitchen-sink/kitchen-sink.stories.tsx
+++ b/packages/lab/stories/kitchen-sink/kitchen-sink.stories.tsx
@@ -1,0 +1,305 @@
+import {
+  Badge,
+  Button,
+  Card,
+  Display1,
+  FlexItem,
+  H1,
+  H2,
+  Link,
+  StackLayout,
+  StatusIndicator,
+  Text,
+  Tooltip,
+  VALIDATION_NAMED_STATUS,
+  ValidationStatus,
+  RadioButton,
+  RadioButtonGroup,
+} from "@salt-ds/core";
+import { AD, GB, UN, US } from "@salt-ds/countries";
+import { NotificationIcon, NotificationSolidIcon } from "@salt-ds/icons";
+import {
+  DefaultGroup as AccordionDefault,
+  Status as AccordionStatus,
+} from "../../../core/stories/accordion/accordion.stories";
+import { Fallback as AvatarFallback } from "../../../core/stories/avatar/avatar.stories";
+import {
+  StatusesPrimary as BannerStatusesPrimary,
+  StatusesSecondary as BannerStatusesSecondary,
+} from "../../../core/stories/banner/banner.stories";
+import { WithIcon as ButtonExamples } from "../../../core/stories/button/button.stories";
+import {
+  Horizontal as ToggleButtonGroupHorizontal,
+  HorizontalIconOnly as ToggleButtonGroupHorizontalIon,
+  HorizontalTextOnly as ToggleButtonGroupHorizontalText,
+} from "../../../core/stories/toggle-button-group/toggle-button-group.stories";
+import {
+  Default as CardDefault,
+  Interactable as InteractableCardStory,
+} from "../../../core/stories/card/card.stories";
+import {
+  HorizontalGroup as CheckboxHorizontalGroup,
+  Error as CheckboxError,
+  Readonly as CheckboxReadonly,
+} from "../../../core/stories/checkbox/checkbox.stories";
+import { Default as SwitchDefault } from "../../../core/stories/switch/switch.stories";
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+} from "@salt-ds/lab";
+import { useState } from "react";
+import {
+  Default as ToastDefault,
+  Error as ToastError,
+  Warning as ToastWarning,
+} from "../../../core/stories/toast/toast.stories";
+import { WithValidation as FormFieldValidation } from "../../../core/stories/form-field/form-field.stories";
+import {
+  Default as PillDefault,
+  Disabled as PillDisabled,
+  Closable as PillClosable,
+  Icon as PillIcon,
+} from "../../../core/stories/pill/pill.stories";
+
+export default {
+  title: "Experimental/Kitchen Sink",
+};
+
+const LaunchStatusDialog = () => {
+  const [status, setStatus] = useState<ValidationStatus>("info");
+  const [open, setOpen] = useState(false);
+  const handleRequestOpen = () => {
+    setOpen(true);
+  };
+  const onOpenChange = (value: boolean) => {
+    setOpen(value);
+  };
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const content =
+    "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.";
+  return (
+    <>
+      <RadioButtonGroup
+        onChange={(e) => setStatus(e.target.value as ValidationStatus)}
+        direction="horizontal"
+      >
+        {VALIDATION_NAMED_STATUS.map((s) => (
+          <RadioButton key={s} label={s} value={s} checked={status === s} />
+        ))}
+      </RadioButtonGroup>
+      <Button data-testid="dialog-button" onClick={handleRequestOpen}>
+        Click to open dialog
+      </Button>
+      <Dialog
+        role="alertdialog"
+        status={status}
+        open={open}
+        onOpenChange={onOpenChange}
+        // focus the ok instead of the cancel button
+        initialFocus={1}
+      >
+        <DialogTitle>{status}</DialogTitle>
+        <DialogContent>{content}</DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button variant="cta" onClick={handleClose}>
+            Ok
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export const Example1 = () => {
+  return (
+    <StackLayout>
+      <StackLayout direction="row">
+        <Card variant="primary">
+          <Display1>Masthead</Display1>
+          <H1>H1 Header</H1>
+          <H2>H2 Subheader</H2>
+          <Text variant="primary">Primary body copy</Text>
+          <Text variant="secondary">Secondary body copy</Text>
+          <Link>Default link text</Link>
+          <Text>
+            <code>Code example 123</code>
+          </Text>
+        </Card>
+        <Card variant="secondary">
+          <Display1>Masthead</Display1>
+          <H1>H1 Header</H1>
+          <H2>H2 Subheader</H2>
+          <Text variant="primary">Primary body copy</Text>
+          <Text variant="secondary">Secondary body copy</Text>
+          <Link>Default link text</Link>
+          <Text>
+            <code>Code example 123</code>
+          </Text>
+        </Card>
+        <Card variant="primary">
+          <Display1>Masthead</Display1>
+          <H1>H1 Header</H1>
+          <Card variant="secondary">
+            <H2>H2 Subheader</H2>
+            <Text variant="primary">Primary body copy</Text>
+            <Text variant="secondary">Secondary body copy</Text>
+          </Card>
+          <Link>Default link text</Link>
+          <Text>
+            <code>Code example 123</code>
+          </Text>
+        </Card>
+        <Card variant="secondary">
+          <Display1>Masthead</Display1>
+          <H1>H1 Header</H1>
+          <Card variant="primary">
+            <H2>H2 Subheader</H2>
+            <Text variant="primary">Primary body copy</Text>
+            <Text variant="secondary">Secondary body copy</Text>
+          </Card>
+          <Link>Default link text</Link>
+          <Text>
+            <code>Code example 123</code>
+          </Text>
+        </Card>
+      </StackLayout>
+      <StackLayout direction="row">
+        <AccordionStatus />
+        <AccordionDefault />
+      </StackLayout>
+      <StackLayout direction="row">
+        <AvatarFallback size={1} />
+        <AD />
+        <US />
+        <GB />
+        <UN />
+        <Badge value={1} />
+        <Badge value={1000} />
+        <Badge value="new" />
+        <NotificationIcon />
+        <NotificationSolidIcon />
+        <Link>Link</Link>
+        <Link variant="secondary">Link</Link>
+        <Link target="_blank">Link</Link>
+        <Link target="_blank" variant="secondary">
+          Link
+        </Link>
+        <StatusIndicator status="error" />
+        <StatusIndicator status="info" />
+        <StatusIndicator status="success" />
+        <StatusIndicator status="warning" />
+      </StackLayout>
+      <StackLayout direction="row">
+        <PillDefault />
+        <PillDisabled />
+        <PillIcon />
+        <PillClosable />
+      </StackLayout>
+      <StackLayout direction="row">
+        <BannerStatusesPrimary />
+        <BannerStatusesSecondary />
+      </StackLayout>
+      <StackLayout direction="row">
+        <ButtonExamples />
+        <Button disabled>Submit</Button>
+      </StackLayout>
+      <StackLayout direction="row">
+        <ToggleButtonGroupHorizontalText defaultValue="high" />
+        <ToggleButtonGroupHorizontalIon defaultValue="light" />
+        <ToggleButtonGroupHorizontal defaultValue="all" />
+      </StackLayout>
+      <StackLayout direction="row">
+        <FlexItem>
+          <ToggleButtonGroupHorizontalText
+            defaultValue="high"
+            orientation="vertical"
+          />
+        </FlexItem>
+        <FlexItem>
+          <ToggleButtonGroupHorizontalIon
+            defaultValue="light"
+            orientation="vertical"
+          />
+        </FlexItem>
+        <FlexItem>
+          <ToggleButtonGroupHorizontal
+            defaultValue="all"
+            orientation="vertical"
+          />
+        </FlexItem>
+        <CardDefault variant="primary" />
+        <CardDefault variant="secondary" />
+        <InteractableCardStory accentPlacement="top" />
+        <InteractableCardStory accentPlacement="right" variant="secondary" />
+        <InteractableCardStory accentPlacement="bottom" />
+        <InteractableCardStory accentPlacement="left" variant="secondary" />
+      </StackLayout>
+      <StackLayout direction="row">
+        <CheckboxHorizontalGroup />
+        <CheckboxError />
+        <CheckboxReadonly />
+
+        <SwitchDefault />
+        <SwitchDefault defaultChecked />
+        <SwitchDefault disabled />
+        <SwitchDefault disabled defaultChecked />
+
+        <SwitchDefault label="Switch" />
+        <SwitchDefault label="Switch" defaultChecked />
+        <SwitchDefault label="Switch" disabled />
+        <SwitchDefault label="Switch" disabled defaultChecked />
+      </StackLayout>
+      <StackLayout direction="row" gap={20} style={{ marginBlock: 60 }}>
+        <Tooltip content="I am a tooltip" status="info" open placement="bottom">
+          <Button>Info</Button>
+        </Tooltip>
+        <Tooltip
+          content="I am a tooltip"
+          status="error"
+          open
+          placement="bottom"
+        >
+          <Button>Error</Button>
+        </Tooltip>
+        <Tooltip
+          content="I am a tooltip"
+          status="warning"
+          open
+          placement="bottom"
+        >
+          <Button>Warning</Button>
+        </Tooltip>
+        <Tooltip
+          content="I am a tooltip"
+          status="success"
+          open
+          placement="bottom"
+        >
+          <Button>Success</Button>
+        </Tooltip>
+      </StackLayout>
+      <StackLayout direction="row">
+        <FlexItem>
+          <ToastDefault />
+        </FlexItem>
+        <ToastError />
+        <ToastWarning />
+        <FlexItem>
+          <ToastDefault status="success" />
+        </FlexItem>
+      </StackLayout>
+      <StackLayout direction="row">
+        <LaunchStatusDialog />
+      </StackLayout>
+      <StackLayout direction="row">
+        <FormFieldValidation />
+      </StackLayout>
+    </StackLayout>
+  );
+};

--- a/packages/theme/css/foundations/curve-next.css
+++ b/packages/theme/css/foundations/curve-next.css
@@ -1,0 +1,16 @@
+.salt-density-touch,
+.salt-density-low,
+.salt-density-medium {
+  --salt-curve-0: 0;
+  --salt-curve-100: 2px;
+  --salt-curve-200: 4px;
+  --salt-curve-300: 8px;
+  --salt-curve-999: 999px;
+}
+.salt-density-high {
+  --salt-curve-0: 0;
+  --salt-curve-100: 0px;
+  --salt-curve-200: 2px;
+  --salt-curve-300: 4px;
+  --salt-curve-999: 999px;
+}

--- a/packages/theme/css/foundations/curve-next.css
+++ b/packages/theme/css/foundations/curve-next.css
@@ -9,7 +9,7 @@
 }
 .salt-density-high {
   --salt-curve-0: 0;
-  --salt-curve-100: 0px;
+  --salt-curve-100: 1px;
   --salt-curve-200: 2px;
   --salt-curve-300: 4px;
   --salt-curve-999: 999px;

--- a/packages/theme/css/foundations/curve-next.css
+++ b/packages/theme/css/foundations/curve-next.css
@@ -1,16 +1,31 @@
-.salt-density-touch,
-.salt-density-low,
-.salt-density-medium {
-  --salt-curve-0: 0;
-  --salt-curve-100: 2px;
-  --salt-curve-200: 4px;
-  --salt-curve-300: 8px;
-  --salt-curve-999: 999px;
-}
 .salt-density-high {
   --salt-curve-0: 0;
-  --salt-curve-100: 1px;
-  --salt-curve-200: 2px;
-  --salt-curve-300: 4px;
+  --salt-curve-50: 1px;
+  --salt-curve-100: 2px;
+  --salt-curve-150: 3px;
+  --salt-curve-999: 999px;
+}
+
+.salt-density-medium {
+  --salt-curve-0: 0;
+  --salt-curve-50: 2px;
+  --salt-curve-100: 4px;
+  --salt-curve-150: 6px;
+  --salt-curve-999: 999px;
+}
+
+.salt-density-low {
+  --salt-curve-0: 0;
+  --salt-curve-50: 3px;
+  --salt-curve-100: 6px;
+  --salt-curve-150: 9px;
+  --salt-curve-999: 999px;
+}
+
+.salt-density-touch {
+  --salt-curve-0: 0;
+  --salt-curve-50: 4px;
+  --salt-curve-100: 8px;
+  --salt-curve-150: 12px;
   --salt-curve-999: 999px;
 }

--- a/packages/theme/css/palette/corner-next.css
+++ b/packages/theme/css/palette/corner-next.css
@@ -1,0 +1,12 @@
+.salt-theme-next[data-corner="rounded"] {
+  --salt-palette-corner-weaker: var(--salt-curve-100);
+  --salt-palette-corner-weak: var(--salt-curve-200);
+  --salt-palette-corner: var(--salt-curve-300);
+  --salt-palette-corner-strongest: var(--salt-curve-999);
+}
+.salt-theme-next[data-corner="sharp"] {
+  --salt-palette-corner-weaker: var(--salt-curve-0);
+  --salt-palette-corner-weak: var(--salt-curve-0);
+  --salt-palette-corner: var(--salt-curve-0);
+  --salt-palette-corner-strongest: var(--salt-curve-999);
+}

--- a/packages/theme/css/palette/corner-next.css
+++ b/packages/theme/css/palette/corner-next.css
@@ -1,7 +1,7 @@
 .salt-theme-next[data-corner="rounded"] {
-  --salt-palette-corner-weaker: var(--salt-curve-100);
-  --salt-palette-corner-weak: var(--salt-curve-200);
-  --salt-palette-corner: var(--salt-curve-300);
+  --salt-palette-corner-weaker: var(--salt-curve-50);
+  --salt-palette-corner-weak: var(--salt-curve-100);
+  --salt-palette-corner: var(--salt-curve-150);
   --salt-palette-corner-strongest: var(--salt-curve-999);
 }
 .salt-theme-next[data-corner="sharp"] {

--- a/packages/theme/css/theme-next.css
+++ b/packages/theme/css/theme-next.css
@@ -1,0 +1,2 @@
+@import url(foundations/curve-next.css);
+@import url(palette/corner-next.css);

--- a/packages/theme/scripts/build.mjs
+++ b/packages/theme/scripts/build.mjs
@@ -12,7 +12,12 @@ deleteSync([buildFolder], { force: true });
 esbuild
   .build({
     absWorkingDir: path.resolve(__dirname, ".."),
-    entryPoints: ["index.css", "css/theme.css", "css/global.css"],
+    entryPoints: [
+      "index.css",
+      "css/theme.css",
+      "css/global.css",
+      "css/theme-next.css",
+    ],
     assetNames: "[dir]/[name]",
     outdir: buildFolder,
     loader: {


### PR DESCRIPTION
- [x] New provider to offer more options, i.e., corner radius as first additional
- [x] Add new toggle to storybook to switch new options
- [x] Add corner radius properties to relevant components identified (complete list pending from design)
- [x] Add styles needed in theme as CSS
- [x] [Design] Identify how and where should token structure sit, i.e., foundation + palette
- [x] Document migration strategy for early testers
- [x] Decide which theme layer should the token be sitting. foundation + palette

This PR introduces `UNSTABLE_SaltProviderNext` including the `cornerRadius` (first of many) option. The intent is to release this as production quality code so early partners could use this as early as possible, and give us feedback.

New storybook toolbar options (Theme next, Corner Radius) are added.

<img width="233" alt="new storybook toolbar toggle" src="https://github.com/jpmorganchase/salt-ds/assets/5257855/eb547953-34ec-4a78-92ee-1e262640c9d3">

Additional `"@salt-ds/theme/css/theme-next.css"` is required to be imported to ensure new CSS variables are made available. All new tokens in the theme package is suffixed with `-next.css` to minimize accidental edit of wrong files, especially considering certain aspect (e.g. color palette) will be redefined to different values down the line. 


Q: How to handle breaking change styling conflict? e.g., foundation color ramps update
A: Use increased specificity to override, e.g., `.salt-theme.salt-theme-new`

Q: What does migration look like for early testers?
A: Swap `UNSTABLE_SaltProviderNext` with `SaltProvder` should be enough

Q: Does this approach support other breaking change (e.g. new color palette)?
A: Yes. Breaking / new changes can be added with scoped `.salt-theme-next`. So new colors will be overridden and taken into effect only when `UNSTABLE_SaltProviderNext` is used. When new color palette is introduced, foundation color ramps will be overridden, together with a remapping of existing palette layer. Given new structure (weak/strong/etc) is also going to be introduced, we will likely define them first, then map all existing characteristics layers to the new palette layer. To ensure maximum backwards compatibility, we will also map existing palette layer to the new palette names, which will give consumers (both design and dev sides) a chance to migrate custom usage of them correctly (codemod can follow as well).
