### PR TITLE
Fix missing FileDropZone visual regression tests

### DIFF
--- a/packages/core/stories/file-drop-zone/file-drop-zone.qa.stories.tsx
+++ b/packages/core/stories/file-drop-zone/file-drop-zone.qa.stories.tsx
@@ -22,3 +22,7 @@ export const AllExamplesGrid: StoryFn<typeof FileDropZone> = () => {
     </AllRenderer>
   );
 };
+
+AllExamplesGrid.parameters = {
+  chromatic: { disableSnapshot: false },
+};


### PR DESCRIPTION
Noticed this when looking at #2977 