### PR TITLE
Update Accordion story to be not centered

### DIFF
--- a/packages/core/stories/accordion/accordion.stories.css
+++ b/packages/core/stories/accordion/accordion.stories.css
@@ -1,8 +1,3 @@
-#storybook-root .story-root {
-  height: 80vh;
-  padding: var(--salt-spacing-200);
-}
-
 .saltAccordion,
 .saltAccordionGroup {
   width: 300px;

--- a/packages/core/stories/accordion/accordion.stories.tsx
+++ b/packages/core/stories/accordion/accordion.stories.tsx
@@ -19,31 +19,31 @@ export default {
   component: Accordion,
   // Default is centered, but accordion will jump around when interacting
   parameters: {
-    layout: 'padded',
+    layout: "padded",
   },
 } as Meta<typeof Accordion>;
 
 export const Default: StoryFn<AccordionProps> = (props) => (
-    <Accordion {...props}>
-      <AccordionHeader>Internal form</AccordionHeader>
-      <AccordionPanel>
-        <FlowLayout>
-          Please fill out the following details.
-          <FormField labelPlacement="left">
-            <FormLabel>Disclosure ID</FormLabel>
-            <Input />
-          </FormField>
-          <FormField labelPlacement="left">
-            <FormLabel>Email</FormLabel>
-            <Input />
-          </FormField>
-          <FormField labelPlacement="left">
-            <FormLabel>Justification</FormLabel>
-            <Input />
-          </FormField>
-        </FlowLayout>
-      </AccordionPanel>
-    </Accordion>
+  <Accordion {...props}>
+    <AccordionHeader>Internal form</AccordionHeader>
+    <AccordionPanel>
+      <FlowLayout>
+        Please fill out the following details.
+        <FormField labelPlacement="left">
+          <FormLabel>Disclosure ID</FormLabel>
+          <Input />
+        </FormField>
+        <FormField labelPlacement="left">
+          <FormLabel>Email</FormLabel>
+          <Input />
+        </FormField>
+        <FormField labelPlacement="left">
+          <FormLabel>Justification</FormLabel>
+          <Input />
+        </FormField>
+      </FlowLayout>
+    </AccordionPanel>
+  </Accordion>
 );
 
 Default.args = {
@@ -51,30 +51,30 @@ Default.args = {
 };
 
 export const DefaultGroup: StoryFn<AccordionGroupProps> = (props) => (
-    <AccordionGroup {...props}>
-      {Array.from({ length: 3 }, (_, i) => i + 1).map((i) => (
-        <Accordion value={`accordion-${i}`} key={`accordion-${i}`}>
-          <AccordionHeader>Internal form</AccordionHeader>
-          <AccordionPanel>
-            <FlowLayout>
-              Please fill out the following details.
-              <FormField labelPlacement="left">
-                <FormLabel>Disclosure ID</FormLabel>
-                <Input />
-              </FormField>
-              <FormField labelPlacement="left">
-                <FormLabel>Email</FormLabel>
-                <Input />
-              </FormField>
-              <FormField labelPlacement="left">
-                <FormLabel>Justification</FormLabel>
-                <Input />
-              </FormField>
-            </FlowLayout>
-          </AccordionPanel>
-        </Accordion>
-      ))}
-    </AccordionGroup>
+  <AccordionGroup {...props}>
+    {Array.from({ length: 3 }, (_, i) => i + 1).map((i) => (
+      <Accordion value={`accordion-${i}`} key={`accordion-${i}`}>
+        <AccordionHeader>Internal form</AccordionHeader>
+        <AccordionPanel>
+          <FlowLayout>
+            Please fill out the following details.
+            <FormField labelPlacement="left">
+              <FormLabel>Disclosure ID</FormLabel>
+              <Input />
+            </FormField>
+            <FormField labelPlacement="left">
+              <FormLabel>Email</FormLabel>
+              <Input />
+            </FormField>
+            <FormField labelPlacement="left">
+              <FormLabel>Justification</FormLabel>
+              <Input />
+            </FormField>
+          </FlowLayout>
+        </AccordionPanel>
+      </Accordion>
+    ))}
+  </AccordionGroup>
 );
 
 export const ExclusiveGroup: StoryFn<AccordionGroupProps> = (props) => {
@@ -86,45 +86,13 @@ export const ExclusiveGroup: StoryFn<AccordionGroupProps> = (props) => {
   };
 
   return (
-      <AccordionGroup {...props}>
-        {Array.from({ length: 3 }, (_, i) => i + 1).map((i) => (
-          <Accordion
-            value={`accordion-${i}`}
-            expanded={expanded === `accordion-${i}`}
-            onToggle={onChange}
-            key={`accordion-${i}`}
-          >
-            <AccordionHeader>Internal form</AccordionHeader>
-            <AccordionPanel>
-              <FlowLayout>
-                Please fill out the following details.
-                <FormField labelPlacement="left">
-                  <FormLabel>Disclosure ID</FormLabel>
-                  <Input />
-                </FormField>
-                <FormField labelPlacement="left">
-                  <FormLabel>Email</FormLabel>
-                  <Input />
-                </FormField>
-                <FormField labelPlacement="left">
-                  <FormLabel>Justification</FormLabel>
-                  <Input />
-                </FormField>
-              </FlowLayout>
-            </AccordionPanel>
-          </Accordion>
-        ))}
-      </AccordionGroup>
-  );
-};
-
-export const Disabled: StoryFn<AccordionGroupProps> = (props) => (
     <AccordionGroup {...props}>
       {Array.from({ length: 3 }, (_, i) => i + 1).map((i) => (
         <Accordion
           value={`accordion-${i}`}
+          expanded={expanded === `accordion-${i}`}
+          onToggle={onChange}
           key={`accordion-${i}`}
-          disabled={i === 2}
         >
           <AccordionHeader>Internal form</AccordionHeader>
           <AccordionPanel>
@@ -147,6 +115,38 @@ export const Disabled: StoryFn<AccordionGroupProps> = (props) => (
         </Accordion>
       ))}
     </AccordionGroup>
+  );
+};
+
+export const Disabled: StoryFn<AccordionGroupProps> = (props) => (
+  <AccordionGroup {...props}>
+    {Array.from({ length: 3 }, (_, i) => i + 1).map((i) => (
+      <Accordion
+        value={`accordion-${i}`}
+        key={`accordion-${i}`}
+        disabled={i === 2}
+      >
+        <AccordionHeader>Internal form</AccordionHeader>
+        <AccordionPanel>
+          <FlowLayout>
+            Please fill out the following details.
+            <FormField labelPlacement="left">
+              <FormLabel>Disclosure ID</FormLabel>
+              <Input />
+            </FormField>
+            <FormField labelPlacement="left">
+              <FormLabel>Email</FormLabel>
+              <Input />
+            </FormField>
+            <FormField labelPlacement="left">
+              <FormLabel>Justification</FormLabel>
+              <Input />
+            </FormField>
+          </FlowLayout>
+        </AccordionPanel>
+      </Accordion>
+    ))}
+  </AccordionGroup>
 );
 
 const statuses: AccordionProps["status"][] = [
@@ -157,32 +157,32 @@ const statuses: AccordionProps["status"][] = [
 ];
 
 export const Status: StoryFn<AccordionGroupProps> = (props) => (
-    <AccordionGroup {...props}>
-      {Array.from({ length: 3 }, (_, i) => i + 1).map((i) => (
-        <Accordion
-          value={`accordion-${i}`}
-          key={`accordion-${i}`}
-          status={statuses[i]}
-        >
-          <AccordionHeader>Internal form</AccordionHeader>
-          <AccordionPanel>
-            <FlowLayout>
-              Please fill out the following details.
-              <FormField labelPlacement="left">
-                <FormLabel>Disclosure ID</FormLabel>
-                <Input />
-              </FormField>
-              <FormField labelPlacement="left">
-                <FormLabel>Email</FormLabel>
-                <Input />
-              </FormField>
-              <FormField labelPlacement="left">
-                <FormLabel>Justification</FormLabel>
-                <Input />
-              </FormField>
-            </FlowLayout>
-          </AccordionPanel>
-        </Accordion>
-      ))}
-    </AccordionGroup>
+  <AccordionGroup {...props}>
+    {Array.from({ length: 3 }, (_, i) => i + 1).map((i) => (
+      <Accordion
+        value={`accordion-${i}`}
+        key={`accordion-${i}`}
+        status={statuses[i]}
+      >
+        <AccordionHeader>Internal form</AccordionHeader>
+        <AccordionPanel>
+          <FlowLayout>
+            Please fill out the following details.
+            <FormField labelPlacement="left">
+              <FormLabel>Disclosure ID</FormLabel>
+              <Input />
+            </FormField>
+            <FormField labelPlacement="left">
+              <FormLabel>Email</FormLabel>
+              <Input />
+            </FormField>
+            <FormField labelPlacement="left">
+              <FormLabel>Justification</FormLabel>
+              <Input />
+            </FormField>
+          </FlowLayout>
+        </AccordionPanel>
+      </Accordion>
+    ))}
+  </AccordionGroup>
 );

--- a/packages/core/stories/accordion/accordion.stories.tsx
+++ b/packages/core/stories/accordion/accordion.stories.tsx
@@ -17,10 +17,13 @@ import "./accordion.stories.css";
 export default {
   title: "Core/Accordion",
   component: Accordion,
+  // Default is centered, but accordion will jump around when interacting
+  parameters: {
+    layout: 'padded',
+  },
 } as Meta<typeof Accordion>;
 
 export const Default: StoryFn<AccordionProps> = (props) => (
-  <div className="story-root">
     <Accordion {...props}>
       <AccordionHeader>Internal form</AccordionHeader>
       <AccordionPanel>
@@ -41,7 +44,6 @@ export const Default: StoryFn<AccordionProps> = (props) => (
         </FlowLayout>
       </AccordionPanel>
     </Accordion>
-  </div>
 );
 
 Default.args = {
@@ -49,7 +51,6 @@ Default.args = {
 };
 
 export const DefaultGroup: StoryFn<AccordionGroupProps> = (props) => (
-  <div className="story-root">
     <AccordionGroup {...props}>
       {Array.from({ length: 3 }, (_, i) => i + 1).map((i) => (
         <Accordion value={`accordion-${i}`} key={`accordion-${i}`}>
@@ -74,7 +75,6 @@ export const DefaultGroup: StoryFn<AccordionGroupProps> = (props) => (
         </Accordion>
       ))}
     </AccordionGroup>
-  </div>
 );
 
 export const ExclusiveGroup: StoryFn<AccordionGroupProps> = (props) => {
@@ -86,7 +86,6 @@ export const ExclusiveGroup: StoryFn<AccordionGroupProps> = (props) => {
   };
 
   return (
-    <div className="story-root">
       <AccordionGroup {...props}>
         {Array.from({ length: 3 }, (_, i) => i + 1).map((i) => (
           <Accordion
@@ -116,12 +115,10 @@ export const ExclusiveGroup: StoryFn<AccordionGroupProps> = (props) => {
           </Accordion>
         ))}
       </AccordionGroup>
-    </div>
   );
 };
 
 export const Disabled: StoryFn<AccordionGroupProps> = (props) => (
-  <div className="story-root">
     <AccordionGroup {...props}>
       {Array.from({ length: 3 }, (_, i) => i + 1).map((i) => (
         <Accordion
@@ -150,7 +147,6 @@ export const Disabled: StoryFn<AccordionGroupProps> = (props) => (
         </Accordion>
       ))}
     </AccordionGroup>
-  </div>
 );
 
 const statuses: AccordionProps["status"][] = [
@@ -161,7 +157,6 @@ const statuses: AccordionProps["status"][] = [
 ];
 
 export const Status: StoryFn<AccordionGroupProps> = (props) => (
-  <div className="story-root">
     <AccordionGroup {...props}>
       {Array.from({ length: 3 }, (_, i) => i + 1).map((i) => (
         <Accordion
@@ -190,5 +185,4 @@ export const Status: StoryFn<AccordionGroupProps> = (props) => (
         </Accordion>
       ))}
     </AccordionGroup>
-  </div>
 );


### PR DESCRIPTION
Want to reuse stories for theme kitchen sink. Having `80vh` in story doesn't help to stack with others.