### PR TITLE
[DO NOT MERGE] Unstable SaltProviderNext with corner radius - Unify curve across density

### DIFF
--- a/packages/theme/css/foundations/curve-next.css
+++ b/packages/theme/css/foundations/curve-next.css
@@ -11,6 +11,6 @@
   --salt-curve-0: 0;
   --salt-curve-100: 2px;
   --salt-curve-200: 4px;
-  --salt-curve-300: 4px;
+  --salt-curve-300: 8px;
   --salt-curve-999: 999px;
 }

--- a/packages/theme/css/foundations/curve-next.css
+++ b/packages/theme/css/foundations/curve-next.css
@@ -9,8 +9,8 @@
 }
 .salt-density-high {
   --salt-curve-0: 0;
-  --salt-curve-100: 1px;
-  --salt-curve-200: 2px;
+  --salt-curve-100: 2px;
+  --salt-curve-200: 4px;
   --salt-curve-300: 4px;
   --salt-curve-999: 999px;
 }

--- a/packages/theme/css/foundations/curve-next.css
+++ b/packages/theme/css/foundations/curve-next.css
@@ -1,5 +1,11 @@
-.salt-density-touch,
-.salt-density-low,
+.salt-density-high {
+  --salt-curve-0: 0;
+  --salt-curve-100: 1px;
+  --salt-curve-200: 2px;
+  --salt-curve-300: 4px;
+  --salt-curve-999: 999px;
+}
+
 .salt-density-medium {
   --salt-curve-0: 0;
   --salt-curve-100: 2px;
@@ -7,10 +13,19 @@
   --salt-curve-300: 8px;
   --salt-curve-999: 999px;
 }
-.salt-density-high {
+
+.salt-density-low {
   --salt-curve-0: 0;
-  --salt-curve-100: 2px;
-  --salt-curve-200: 4px;
-  --salt-curve-300: 8px;
+  --salt-curve-100: 3px;
+  --salt-curve-200: 6px;
+  --salt-curve-300: 12px;
+  --salt-curve-999: 999px;
+}
+
+.salt-density-touch {
+  --salt-curve-0: 0;
+  --salt-curve-100: 4px;
+  --salt-curve-200: 8px;
+  --salt-curve-300: 16px;
   --salt-curve-999: 999px;
 }

--- a/packages/theme/css/foundations/curve-next.css
+++ b/packages/theme/css/foundations/curve-next.css
@@ -2,7 +2,7 @@
   --salt-curve-0: 0;
   --salt-curve-100: 1px;
   --salt-curve-200: 2px;
-  --salt-curve-300: 4px;
+  --salt-curve-300: 3px;
   --salt-curve-999: 999px;
 }
 
@@ -10,7 +10,7 @@
   --salt-curve-0: 0;
   --salt-curve-100: 2px;
   --salt-curve-200: 4px;
-  --salt-curve-300: 8px;
+  --salt-curve-300: 6px;
   --salt-curve-999: 999px;
 }
 
@@ -18,7 +18,7 @@
   --salt-curve-0: 0;
   --salt-curve-100: 3px;
   --salt-curve-200: 6px;
-  --salt-curve-300: 12px;
+  --salt-curve-300: 9px;
   --salt-curve-999: 999px;
 }
 
@@ -26,6 +26,6 @@
   --salt-curve-0: 0;
   --salt-curve-100: 4px;
   --salt-curve-200: 8px;
-  --salt-curve-300: 16px;
+  --salt-curve-300: 12px;
   --salt-curve-999: 999px;
 }


### PR DESCRIPTION
Unify curve across density

- 2/4/8 For all densities: https://b8da4309.saltdesignsystem-storybook.pages.dev/?path=/story/experimental-kitchen-sink--example-1&globals=density:high;themeNext:enable;cornerRadius:rounded
- scale up for different densities (1/2/4 * density): https://e8c196a0.saltdesignsystem-storybook.pages.dev/?path=/story/experimental-kitchen-sink--example-1&globals=density:touch;themeNext:enable;cornerRadius:rounded
- scale up with (1/2/3 * density): https://af4d9dfe.saltdesignsystem-storybook.pages.dev/?path=/story/experimental-kitchen-sink--example-1&globals=themeNext:enable;cornerRadius:rounded

Decision made, last option to go.