### PR TITLE
Dialog Title Refactor

### DIFF
--- a/.changeset/cuddly-hats-bake.md
+++ b/.changeset/cuddly-hats-bake.md
@@ -26,7 +26,7 @@ export const Default = (): ReactElement => {
 
   return (
     <>
-      <Button data-testid="dialog-button" onClick={handleRequestOpen}>
+      <Button onClick={handleRequestOpen}>
         Open default dialog
       </Button>
       <Dialog open={open} onOpenChange={onOpenChange} id={id}>

--- a/.changeset/cuddly-hats-bake.md
+++ b/.changeset/cuddly-hats-bake.md
@@ -5,3 +5,44 @@
 - Convert `Dialog Title` to accept props instead of a composable api
 - Optional Props `title` and `subtitle` added to `Dialog Title`
 - `Dialog Title` no longer accepts children
+- Optional `id` prop added to `Dialog` to announce the `title` and `subtitle` when using a screen reader
+
+```tsx
+export const Default = (): ReactElement => {
+  const [open, setOpen] = useState(false);
+  const id = useId();
+
+  const handleRequestOpen = () => {
+    setOpen(true);
+  };
+
+  const onOpenChange = (value: boolean) => {
+    setOpen(value);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <Button data-testid="dialog-button" onClick={handleRequestOpen}>
+        Open default dialog
+      </Button>
+      <Dialog open={open} onOpenChange={onOpenChange} id={id}>
+        <DialogTitle title="Terms and conditions" />
+        <DialogContent>
+          Dialog Content
+          </StackLayout>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button variant="cta" onClick={handleClose}>
+            Accept
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+```

--- a/.changeset/cuddly-hats-bake.md
+++ b/.changeset/cuddly-hats-bake.md
@@ -1,0 +1,7 @@
+---
+"@salt-ds/lab": minor
+---
+
+- Convert `Dialog Title` to accept props instead of a composable api
+- Optional Props `title` and `subtitle` added to `Dialog Title`
+- `Dialog Title` no longer accepts children

--- a/packages/lab/src/__tests__/__e2e__/dialog/Dialog.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/dialog/Dialog.cy.tsx
@@ -3,10 +3,10 @@ import * as dialogStories from "@stories/dialog/dialog.stories";
 
 const composedStories = composeStories(dialogStories);
 
-const { Default } = composedStories;
+const { Default, Subtitle } = composedStories;
 
 describe("GIVEN a Dialog", () => {
-  describe("WHEN no props are provided", () => {
+  describe("WHEN only title is provided", () => {
     it("THEN it should display a dialog by default", () => {
       cy.mount(<Default />);
 
@@ -16,6 +16,15 @@ describe("GIVEN a Dialog", () => {
       cy.get(".saltDialogTitle").should("be.visible");
       cy.get(".saltDialogContent").should("be.visible");
       cy.get(".saltDialogActions").should("be.visible");
+    });
+
+    it("THEN it should display the titile", () => {
+      cy.mount(<Default />);
+
+      cy.findByRole("button").click();
+
+      cy.findByRole("dialog").should("be.visible");
+      cy.get(".saltDialogTitle-title").should("be.visible");
     });
 
     it("THEN it should add the accent class to the title component", () => {
@@ -47,6 +56,35 @@ describe("GIVEN a Dialog", () => {
         cy.findByRole("dialog").should("have.class", "saltDialog-medium-xl");
       }
     );
+  });
+
+  describe("WHEN subtitle is provided", () => {
+    it("THEN it should display the subtitle", () => {
+      cy.mount(<Subtitle />);
+
+      cy.findByRole("button").click();
+
+      cy.get("label").should("be.visible");
+    });
+  });
+
+  describe("WHEN disableScrim is provided", () => {
+    it("THEN it should not display the scrim", () => {
+      cy.mount(<Default disableScrim />);
+      cy.findByRole("button").click();
+      cy.findByRole("dialog").should("be.visible");
+      cy.get(".saltScrim").should("not.exist");
+    });
+  });
+
+  describe("WHEN disableDismiss is provided", () => {
+    it("THEN it should not close when clicking outside the dialog", () => {
+      cy.mount(<Default disableDismiss />);
+      cy.findByRole("button").click();
+      cy.findByRole("dialog").should("be.visible");
+      cy.get(".saltScrim").click("left", { force: true });
+      cy.findByRole("dialog").should("exist");
+    });
   });
 
   describe("WHEN a size is provided", () => {

--- a/packages/lab/src/dialog/Dialog.tsx
+++ b/packages/lab/src/dialog/Dialog.tsx
@@ -70,6 +70,11 @@ export interface DialogProps extends HTMLAttributes<HTMLDivElement> {
    * Prevent Scrim from rendering
    * */
   disableScrim?: boolean;
+  /**
+   * Optional id prop
+   * Used for accessibility purposes to announce the title and subtitle when using a screen reader
+   * */
+  id?: string;
 }
 
 const withBaseName = makePrefixer("saltDialog");
@@ -87,6 +92,7 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>(function Dialog(
     disableDismiss,
     size = "medium",
     disableScrim,
+    id,
     ...rest
   } = props;
   const targetWindow = useWindow();
@@ -127,7 +133,7 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>(function Dialog(
     }
   }, [open, showComponent, setShowComponent]);
 
-  const contextValue = useMemo(() => ({ status }), [status]);
+  const contextValue = useMemo(() => ({ status, id }), [status, id]);
 
   return (
     <DialogContext.Provider value={contextValue}>
@@ -136,6 +142,7 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>(function Dialog(
           open={showComponent}
           role="dialog"
           aria-modal="true"
+          aria-labelledby={`${id}-subtitle ${id}-title`}
           ref={floatingRef}
           width={elements.floating?.offsetWidth}
           height={elements.floating?.offsetHeight}

--- a/packages/lab/src/dialog/Dialog.tsx
+++ b/packages/lab/src/dialog/Dialog.tsx
@@ -22,6 +22,7 @@ import {
   useForkRef,
   ValidationStatus,
   Scrim,
+  useId,
 } from "@salt-ds/core";
 import { useWindow } from "@salt-ds/window";
 import { useComponentCssInjection } from "@salt-ds/styles";
@@ -74,7 +75,7 @@ export interface DialogProps extends HTMLAttributes<HTMLDivElement> {
    * Optional id prop
    * Used for accessibility purposes to announce the title and subtitle when using a screen reader
    * */
-  id?: string;
+  idProp?: string;
 }
 
 const withBaseName = makePrefixer("saltDialog");
@@ -92,7 +93,7 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>(function Dialog(
     disableDismiss,
     size = "medium",
     disableScrim,
-    id,
+    idProp,
     ...rest
   } = props;
   const targetWindow = useWindow();
@@ -101,6 +102,8 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>(function Dialog(
     css: dialogCss,
     window: targetWindow,
   });
+
+  const id = useId(idProp);
 
   const currentbreakpoint = useCurrentBreakpoint();
 
@@ -142,7 +145,7 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>(function Dialog(
           open={showComponent}
           role="dialog"
           aria-modal="true"
-          aria-labelledby={`${id}-subtitle ${id}-title`}
+          aria-labelledby={id}
           ref={floatingRef}
           width={elements.floating?.offsetWidth}
           height={elements.floating?.offsetHeight}

--- a/packages/lab/src/dialog/Dialog.tsx
+++ b/packages/lab/src/dialog/Dialog.tsx
@@ -16,7 +16,6 @@ import {
 } from "@floating-ui/react";
 import {
   makePrefixer,
-  useId,
   useFloatingComponent,
   useFloatingUI,
   useCurrentBreakpoint,

--- a/packages/lab/src/dialog/DialogContent.css
+++ b/packages/lab/src/dialog/DialogContent.css
@@ -5,9 +5,10 @@
   background: var(--salt-container-primary-background);
   padding-bottom: var(--salt-spacing-50);
 
-  margin-left: var(--salt-spacing-300);
+  margin-left: var(--salt-spacing-200);
   margin-right: var(--salt-spacing-300);
   padding-right: var(--salt-spacing-300);
+  padding-left: var(--salt-spacing-100);
   border-bottom: var(--salt-size-border) var(--salt-separable-borderStyle) transparent;
   box-shadow: none;
 }

--- a/packages/lab/src/dialog/DialogContext.tsx
+++ b/packages/lab/src/dialog/DialogContext.tsx
@@ -3,8 +3,10 @@ import { ValidationStatus } from "@salt-ds/core";
 
 export const DialogContext = createContext<{
   status?: ValidationStatus;
+  id: string | undefined;
 }>({
   status: undefined,
+  id: "",
 });
 
 export const useDialogContext = () => {

--- a/packages/lab/src/dialog/DialogTitle.css
+++ b/packages/lab/src/dialog/DialogTitle.css
@@ -1,10 +1,15 @@
 /* Styles applied to the root element */
 .saltDialogTitle {
-  display: flex;
-  gap: var(--salt-spacing-100);
   padding-bottom: var(--salt-spacing-100);
   padding-left: var(--salt-spacing-300);
   padding-right: var(--salt-spacing-300);
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  gap: var(--salt-spacing-100);
+}
+
+.saltDialogTitle-title {
   margin: 0;
 }
 

--- a/packages/lab/src/dialog/DialogTitle.tsx
+++ b/packages/lab/src/dialog/DialogTitle.tsx
@@ -41,6 +41,7 @@ export const DialogTitle = ({
   className,
   title,
   subtitle,
+  id,
   disableAccent,
   status: statusProp,
   ...rest
@@ -74,7 +75,9 @@ export const DialogTitle = ({
             {subtitle}
           </Text>
         )}
-        <H2 className={clsx(withBaseName("title"))}>{title}</H2>
+        <H2 className={clsx(withBaseName("title"))} id={id}>
+          {title}
+        </H2>
       </div>
     </div>
   );

--- a/packages/lab/src/dialog/DialogTitle.tsx
+++ b/packages/lab/src/dialog/DialogTitle.tsx
@@ -51,13 +51,11 @@ export const DialogTitle = ({
     window: targetWindow,
   });
 
-  const subtitleId = `${id}-subtitle`;
-  const titleId = `${id}-title`;
-
   const status = statusProp ?? (statusContext as ValidationStatus);
 
   return (
     <div
+      id={id as string}
       className={clsx(
         withBaseName(),
         {
@@ -71,13 +69,11 @@ export const DialogTitle = ({
       {status && <StatusIndicator status={status} />}
       <div>
         {subtitle && (
-          <Text as={"label"} variant="secondary" id={subtitleId}>
+          <Text as={"label"} variant="secondary">
             {subtitle}
           </Text>
         )}
-        <H2 className={clsx(withBaseName("title"))} id={titleId}>
-          {title}
-        </H2>
+        <H2 className={clsx(withBaseName("title"))}>{title}</H2>
       </div>
     </div>
   );

--- a/packages/lab/src/dialog/DialogTitle.tsx
+++ b/packages/lab/src/dialog/DialogTitle.tsx
@@ -32,8 +32,6 @@ interface DialogTitleProps
    **/
   subtitle?: ReactNode;
 
-  id?: string;
-
   className?: string;
 }
 
@@ -41,18 +39,20 @@ export const DialogTitle = ({
   className,
   title,
   subtitle,
-  id,
   disableAccent,
   status: statusProp,
   ...rest
 }: DialogTitleProps) => {
-  const { status: statusContext } = useDialogContext();
+  const { status: statusContext, id } = useDialogContext();
   const targetWindow = useWindow();
   useComponentCssInjection({
     testId: "salt-dialog-title",
     css: dialogTitleCss,
     window: targetWindow,
   });
+
+  const subtitleId = `${id}-subtitle`;
+  const titleId = `${id}-title`;
 
   const status = statusProp ?? (statusContext as ValidationStatus);
 
@@ -71,11 +71,11 @@ export const DialogTitle = ({
       {status && <StatusIndicator status={status} />}
       <div>
         {subtitle && (
-          <Text as={"label"} variant="secondary">
+          <Text as={"label"} variant="secondary" id={subtitleId}>
             {subtitle}
           </Text>
         )}
-        <H2 className={clsx(withBaseName("title"))} id={id}>
+        <H2 className={clsx(withBaseName("title"))} id={titleId}>
           {title}
         </H2>
       </div>

--- a/packages/lab/src/dialog/DialogTitle.tsx
+++ b/packages/lab/src/dialog/DialogTitle.tsx
@@ -1,10 +1,11 @@
-import { ComponentPropsWithoutRef } from "react";
+import { ReactNode, ComponentPropsWithoutRef } from "react";
 import clsx from "clsx";
 import {
   H2,
   StatusIndicator,
   ValidationStatus,
   makePrefixer,
+  Text,
 } from "@salt-ds/core";
 import { useDialogContext } from "./DialogContext";
 import { useWindow } from "@salt-ds/window";
@@ -13,20 +14,33 @@ import dialogTitleCss from "./DialogTitle.css";
 
 const withBaseName = makePrefixer("saltDialogTitle");
 
-interface DialogTitleProps extends ComponentPropsWithoutRef<"h2"> {
+interface DialogTitleProps
+  extends Omit<ComponentPropsWithoutRef<"div">, "title"> {
   /**
    * The status of the Dialog
-   * */
+   */
   status?: ValidationStatus | undefined;
   /**
-   * Displays the accent bar in the Dialog Title
-   * */
+   * Displays the accent bar in the Dialog Title */
   disableAccent?: boolean;
+  /**
+   * Displays the Dialog Title in a H2 component
+   */
+  title: ReactNode;
+  /**
+   * Displays the Dialog Subtitle in a Label component
+   **/
+  subtitle?: ReactNode;
+
+  id?: string;
+
+  className?: string;
 }
 
 export const DialogTitle = ({
-  children,
   className,
+  title,
+  subtitle,
   disableAccent,
   status: statusProp,
   ...rest
@@ -42,7 +56,7 @@ export const DialogTitle = ({
   const status = statusProp ?? (statusContext as ValidationStatus);
 
   return (
-    <H2
+    <div
       className={clsx(
         withBaseName(),
         {
@@ -54,7 +68,14 @@ export const DialogTitle = ({
       {...rest}
     >
       {status && <StatusIndicator status={status} />}
-      {children}
-    </H2>
+      <div>
+        {subtitle && (
+          <Text as={"label"} variant="secondary">
+            {subtitle}
+          </Text>
+        )}
+        <H2 className={clsx(withBaseName("title"))}>{title}</H2>
+      </div>
+    </div>
   );
 };

--- a/packages/lab/stories/components/CloseTabWarningDialog.tsx
+++ b/packages/lab/stories/components/CloseTabWarningDialog.tsx
@@ -29,7 +29,8 @@ export const CloseTabWarningDialog = ({
       }
     }}
   >
-    <DialogTitle>Do you want to close this tab?</DialogTitle>
+    <DialogTitle title="Do you want to close this tab?" />
+
     <DialogContent>
       {`Closing the tab will cause any changes made to
                   '${closedTab.label}' to be lost.`}

--- a/packages/lab/stories/dialog/dialog.qa.stories.tsx
+++ b/packages/lab/stories/dialog/dialog.qa.stories.tsx
@@ -1,4 +1,10 @@
-import { Button, StackLayout } from "@salt-ds/core";
+import {
+  Button,
+  StackLayout,
+  FormField,
+  FormFieldLabel,
+  Input,
+} from "@salt-ds/core";
 import {
   Dialog,
   DialogTitle,
@@ -39,7 +45,7 @@ const DialogTemplate: StoryFn<typeof Dialog> = ({
   return (
     <StackLayout>
       <FakeDialog status={status}>
-        <DialogTitle> {title} </DialogTitle>
+        <DialogTitle title={title} />
         <DialogContent>This is dialog content...</DialogContent>
         <DialogActions>
           <Button style={{ marginRight: "auto" }} variant="secondary">
@@ -52,6 +58,49 @@ const DialogTemplate: StoryFn<typeof Dialog> = ({
       </FakeDialog>
     </StackLayout>
   );
+};
+
+export const Default: StoryFn<QAContainerProps> = (props) => {
+  const { ...rest } = props;
+  return (
+    <QAContainer cols={3} height={300} itemPadding={3} {...rest}>
+      <DialogTemplate title={"Dialog Title"} />
+    </QAContainer>
+  );
+};
+
+Default.parameters = {
+  chromatic: { disableSnapshot: false },
+};
+
+export const Subtitle: StoryFn<QAContainerProps> = () => {
+  return (
+    <QAContainer width={1300} itemPadding={3}>
+      <FakeDialog>
+        <DialogTitle
+          title="Subscribe"
+          subtitle="Recieve emails about the latest updates"
+          style={{ width: "500px" }}
+        />
+        <DialogCloseButton />
+
+        <DialogContent>
+          <FormField necessity="asterisk">
+            <FormFieldLabel> Email </FormFieldLabel>
+            <Input defaultValue="Email Address" />
+          </FormField>
+        </DialogContent>
+        <DialogActions>
+          <Button>Cancel</Button>
+          <Button variant="cta">Subscribe</Button>
+        </DialogActions>
+      </FakeDialog>
+    </QAContainer>
+  );
+};
+
+Subtitle.parameters = {
+  chromatic: { disableSnapshot: false },
 };
 
 type sizes = "small" | "medium" | "large";

--- a/packages/lab/stories/dialog/dialog.qa.stories.tsx
+++ b/packages/lab/stories/dialog/dialog.qa.stories.tsx
@@ -19,9 +19,9 @@ import { QAContainer, QAContainerProps } from "docs/components";
 
 import "./dialog.stories.css";
 
-function FakeDialog({ children, status }: DialogProps) {
+function FakeDialog({ children, status, id }: DialogProps) {
   return (
-    <DialogContext.Provider value={{ status }}>
+    <DialogContext.Provider value={{ status, id }}>
       <div className="fakeDialogWindow">{children}</div>
     </DialogContext.Provider>
   );

--- a/packages/lab/stories/dialog/dialog.stories.css
+++ b/packages/lab/stories/dialog/dialog.stories.css
@@ -3,7 +3,6 @@
   padding-bottom: var(--salt-spacing-300);
   background: var(--salt-container-primary-background);
   box-shadow: var(--salt-overlayable-shadow-modal);
-  overflow-y: auto;
   z-index: var(--salt-zIndex-drawer);
   height: min-content;
   border-width: var(--salt-size-border);

--- a/packages/lab/stories/dialog/dialog.stories.tsx
+++ b/packages/lab/stories/dialog/dialog.stories.tsx
@@ -1,5 +1,11 @@
 import { PropsWithChildren, useState } from "react";
-import { Button, StackLayout } from "@salt-ds/core";
+import {
+  Button,
+  StackLayout,
+  FormField,
+  FormFieldLabel,
+  Input,
+} from "@salt-ds/core";
 import {
   Dialog,
   DialogTitle,
@@ -22,10 +28,10 @@ export default {
 
 const DialogTemplate: StoryFn<typeof Dialog> = ({
   title,
-  id,
-  size,
   // @ts-ignore
   content,
+  id,
+  size,
   open: openProp = false,
   ...args
 }) => {
@@ -55,7 +61,8 @@ const DialogTemplate: StoryFn<typeof Dialog> = ({
         id={id}
         size={size}
       >
-        <DialogTitle>{title}</DialogTitle>
+        {/* eslint-disable-next-line */}
+        <DialogTitle title={title} />
         <DialogContent>{content}</DialogContent>
         <DialogActions>
           <Button variant="secondary" onClick={handleClose}>
@@ -169,7 +176,7 @@ const AlertDialogTemplate: StoryFn<typeof Dialog> = ({
         // focus the ok instead of the cancel button
         initialFocus={1}
       >
-        <DialogTitle>{title}</DialogTitle>
+        <DialogTitle title={title} />
         <DialogContent>{content}</DialogContent>
         <DialogActions>
           <Button onClick={handleClose}>Cancel</Button>
@@ -208,8 +215,6 @@ ErrorStatus.args = {
 
 export const MandatoryAction: StoryFn<typeof Dialog> = ({
   open: openProp = false,
-  status = "info",
-  size = "small",
 }) => {
   const [open, setOpen] = useState(openProp);
 
@@ -240,7 +245,8 @@ export const MandatoryAction: StoryFn<typeof Dialog> = ({
         initialFocus={1}
         disableDismiss
       >
-        <DialogTitle id="mandatory-action">Delete Transaction</DialogTitle>
+        <DialogTitle id="mandatory-action" title="Delete Transaction" />
+
         <DialogContent>
           Are you sure you want to permanently delete this transaction
         </DialogContent>
@@ -248,6 +254,50 @@ export const MandatoryAction: StoryFn<typeof Dialog> = ({
           <Button onClick={handleClose}>Cancel</Button>
           <Button variant="cta" onClick={handleClose}>
             Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export const Subtitle: StoryFn<typeof Dialog> = ({
+  open: openProp = false,
+}) => {
+  const [open, setOpen] = useState(openProp);
+
+  const handleRequestOpen = () => {
+    setOpen(true);
+  };
+
+  const onOpenChange = (value: boolean) => {
+    setOpen(value);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <Button onClick={handleRequestOpen}>Open dialog with subtitle</Button>
+      <Dialog open={open} onOpenChange={onOpenChange} size="small">
+        <DialogTitle
+          title="Subscribe"
+          subtitle="Recieve emails about the latest updates"
+        />
+        <DialogCloseButton onClick={handleClose} />
+
+        <DialogContent>
+          <FormField necessity="asterisk">
+            <FormFieldLabel> Email </FormFieldLabel>
+            <Input defaultValue="Email Address" />
+          </FormField>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button variant="cta" onClick={handleClose}>
+            Subscribe
           </Button>
         </DialogActions>
       </Dialog>
@@ -268,7 +318,7 @@ export const DesktopDialog = () => {
   return (
     <StackLayout>
       <FakeWindow>
-        <DialogTitle>Window Dialog</DialogTitle>
+        <DialogTitle title="Window Dialog" />
         <DialogContent>Hello world!</DialogContent>
         <DialogActions>
           <Button>Cancel</Button>
@@ -277,7 +327,7 @@ export const DesktopDialog = () => {
       </FakeWindow>
 
       <FakeWindow>
-        <DialogTitle>Window Dialog</DialogTitle>
+        <DialogTitle title="Window Dialog" />
         <DialogContent>Accent world!</DialogContent>
         <DialogActions>
           <Button>Cancel</Button>
@@ -286,7 +336,7 @@ export const DesktopDialog = () => {
       </FakeWindow>
 
       <FakeWindow>
-        <DialogTitle status="warning">Warning Dialog</DialogTitle>
+        <DialogTitle status="warning" title="Warning Dialog" />
         <DialogContent>Potential issues abound!</DialogContent>
         <DialogActions>
           <Button>Cancel</Button>

--- a/site/docs/components/dialog/examples.mdx
+++ b/site/docs/components/dialog/examples.mdx
@@ -61,6 +61,13 @@ You can also render the `DialogCloseButton` as a child of the `Dialog` component
 
 </LivePreview>
 
+<LivePreview componentName="dialog" exampleName="Subtitle" >
+    ### Subtitle
+
+You can use the optional `subtitle` prop to render a subtitle above the main title of your dialog
+
+</LivePreview>
+
     <LivePreview componentName="dialog" exampleName="Info" >
       ### Info
 
@@ -105,15 +112,15 @@ You can also render the `DialogCloseButton` as a child of the `Dialog` component
      <LivePreview componentName="dialog" exampleName="MandatoryAction" >
     ### Mandatory Action
 
-    Use the closeOnBlur prop to prevent a click away dismissing the dialog.
+    Use the `disableDismiss` prop to prevent a click away dismissing the dialog.
 
-    This should be used to force a user to action something within the dialog.
+    This forces a user to action something within the dialog.
     </LivePreview>
 
       <LivePreview componentName="dialog" exampleName="DisableScrim" >
     ### Disble Scrim
 
-    Use the disableScrim prop to prevent the scrim from rendering.
+    Use the `disableScrim` prop to prevent the scrim from rendering.
 
     </LivePreview>
 

--- a/site/src/examples/dialog/CloseButton.tsx
+++ b/site/src/examples/dialog/CloseButton.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, useState } from "react";
-import { Button, H3, StackLayout } from "@salt-ds/core";
+import { Button, H3, StackLayout, useId } from "@salt-ds/core";
 import {
   Dialog,
   DialogTitle,
@@ -10,6 +10,7 @@ import {
 
 export const CloseButton = (): ReactElement => {
   const [open, setOpen] = useState(false);
+  const id = useId();
 
   const handleRequestOpen = () => {
     setOpen(true);
@@ -28,14 +29,8 @@ export const CloseButton = (): ReactElement => {
       <Button data-testid="dialog-button" onClick={handleRequestOpen}>
         Open dialog with close button
       </Button>
-      <Dialog
-        open={open}
-        onOpenChange={onOpenChange}
-        aria-labelledby="terms-and-conditions-dialog"
-      >
-        <DialogTitle id="terms-and-conditions-dialog-heading">
-          Terms and conditions
-        </DialogTitle>
+      <Dialog open={open} onOpenChange={onOpenChange} aria-labelledby={id}>
+        <DialogTitle title="Terms and conditions" id={id} />
         <DialogContent>
           <StackLayout>
             <div>

--- a/site/src/examples/dialog/CloseButton.tsx
+++ b/site/src/examples/dialog/CloseButton.tsx
@@ -26,9 +26,7 @@ export const CloseButton = (): ReactElement => {
 
   return (
     <>
-      <Button data-testid="dialog-button" onClick={handleRequestOpen}>
-        Open dialog with close button
-      </Button>
+      <Button onClick={handleRequestOpen}>Open dialog with close button</Button>
       <Dialog open={open} onOpenChange={onOpenChange} id={id}>
         <DialogTitle title="Terms and conditions" />
         <DialogContent>

--- a/site/src/examples/dialog/CloseButton.tsx
+++ b/site/src/examples/dialog/CloseButton.tsx
@@ -29,8 +29,8 @@ export const CloseButton = (): ReactElement => {
       <Button data-testid="dialog-button" onClick={handleRequestOpen}>
         Open dialog with close button
       </Button>
-      <Dialog open={open} onOpenChange={onOpenChange} aria-labelledby={id}>
-        <DialogTitle title="Terms and conditions" id={id} />
+      <Dialog open={open} onOpenChange={onOpenChange} id={id}>
+        <DialogTitle title="Terms and conditions" />
         <DialogContent>
           <StackLayout>
             <div>

--- a/site/src/examples/dialog/Default.tsx
+++ b/site/src/examples/dialog/Default.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, useState } from "react";
-import { Button, H3, StackLayout } from "@salt-ds/core";
+import { Button, H3, StackLayout, useId } from "@salt-ds/core";
 import {
   Dialog,
   DialogTitle,
@@ -9,6 +9,7 @@ import {
 
 export const Default = (): ReactElement => {
   const [open, setOpen] = useState(false);
+  const id = useId();
 
   const handleRequestOpen = () => {
     setOpen(true);
@@ -27,14 +28,8 @@ export const Default = (): ReactElement => {
       <Button data-testid="dialog-button" onClick={handleRequestOpen}>
         Open default dialog
       </Button>
-      <Dialog
-        open={open}
-        onOpenChange={onOpenChange}
-        aria-labelledby="terms-and-conditions-dialog"
-      >
-        <DialogTitle id="terms-and-conditions-dialog-heading">
-          Terms and conditions
-        </DialogTitle>
+      <Dialog open={open} onOpenChange={onOpenChange} aria-labelledby={id}>
+        <DialogTitle title="Terms and conditions" id={id} />
         <DialogContent>
           <StackLayout>
             <div>

--- a/site/src/examples/dialog/Default.tsx
+++ b/site/src/examples/dialog/Default.tsx
@@ -28,8 +28,8 @@ export const Default = (): ReactElement => {
       <Button data-testid="dialog-button" onClick={handleRequestOpen}>
         Open default dialog
       </Button>
-      <Dialog open={open} onOpenChange={onOpenChange} aria-labelledby={id}>
-        <DialogTitle title="Terms and conditions" id={id} />
+      <Dialog open={open} onOpenChange={onOpenChange} id={id}>
+        <DialogTitle title="Terms and conditions" />
         <DialogContent>
           <StackLayout>
             <div>

--- a/site/src/examples/dialog/DisableScrim.tsx
+++ b/site/src/examples/dialog/DisableScrim.tsx
@@ -28,13 +28,8 @@ export const DisableScrim = (): ReactElement => {
       <Button data-testid="dialog-button" onClick={handleRequestOpen}>
         Open dialog without Scrim
       </Button>
-      <Dialog
-        open={open}
-        onOpenChange={onOpenChange}
-        aria-labelledby={id}
-        disableScrim
-      >
-        <DialogTitle title="Terms and conditions" disableAccent id={id} />
+      <Dialog open={open} onOpenChange={onOpenChange} disableScrim id={id}>
+        <DialogTitle title="Terms and conditions" disableAccent />
         <DialogContent>
           <StackLayout>
             <div>

--- a/site/src/examples/dialog/DisableScrim.tsx
+++ b/site/src/examples/dialog/DisableScrim.tsx
@@ -25,9 +25,7 @@ export const DisableScrim = (): ReactElement => {
 
   return (
     <>
-      <Button data-testid="dialog-button" onClick={handleRequestOpen}>
-        Open dialog without Scrim
-      </Button>
+      <Button onClick={handleRequestOpen}>Open dialog without Scrim</Button>
       <Dialog open={open} onOpenChange={onOpenChange} disableScrim id={id}>
         <DialogTitle title="Terms and conditions" disableAccent />
         <DialogContent>

--- a/site/src/examples/dialog/DisableScrim.tsx
+++ b/site/src/examples/dialog/DisableScrim.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, useState } from "react";
-import { Button, H3, StackLayout } from "@salt-ds/core";
+import { Button, H3, StackLayout, useId } from "@salt-ds/core";
 import {
   Dialog,
   DialogTitle,
@@ -9,6 +9,7 @@ import {
 
 export const DisableScrim = (): ReactElement => {
   const [open, setOpen] = useState(false);
+  const id = useId();
 
   const handleRequestOpen = () => {
     setOpen(true);
@@ -30,12 +31,10 @@ export const DisableScrim = (): ReactElement => {
       <Dialog
         open={open}
         onOpenChange={onOpenChange}
-        aria-labelledby="terms-and-conditions-dialog"
+        aria-labelledby={id}
         disableScrim
       >
-        <DialogTitle disableAccent id="terms-and-conditions-dialog-heading">
-          Terms and conditions
-        </DialogTitle>
+        <DialogTitle title="Terms and conditions" disableAccent id={id} />
         <DialogContent>
           <StackLayout>
             <div>

--- a/site/src/examples/dialog/Error.tsx
+++ b/site/src/examples/dialog/Error.tsx
@@ -25,9 +25,7 @@ export const Error = (): ReactElement => {
 
   return (
     <>
-      <Button data-testid="dialog-button" onClick={handleRequestOpen}>
-        Open error dialog
-      </Button>
+      <Button onClick={handleRequestOpen}>Open error dialog</Button>
       <Dialog
         open={open}
         onOpenChange={onOpenChange}

--- a/site/src/examples/dialog/Error.tsx
+++ b/site/src/examples/dialog/Error.tsx
@@ -34,9 +34,9 @@ export const Error = (): ReactElement => {
         role="alertdialog"
         status="error"
         size="small"
-        aria-labelledby={id}
+        id={id}
       >
-        <DialogTitle title="Can`t move file" id={id} />
+        <DialogTitle title="Can`t move file" />
         <DialogContent>
           You don’t have permission to move or delete this file.
         </DialogContent>

--- a/site/src/examples/dialog/Error.tsx
+++ b/site/src/examples/dialog/Error.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, useState } from "react";
-import { Button } from "@salt-ds/core";
+import { Button, useId } from "@salt-ds/core";
 import {
   Dialog,
   DialogTitle,
@@ -9,6 +9,7 @@ import {
 
 export const Error = (): ReactElement => {
   const [open, setOpen] = useState(false);
+  const id = useId();
 
   const handleRequestOpen = () => {
     setOpen(true);
@@ -33,9 +34,9 @@ export const Error = (): ReactElement => {
         role="alertdialog"
         status="error"
         size="small"
-        aria-labelledby="error-dialog"
+        aria-labelledby={id}
       >
-        <DialogTitle id="error-dialog-heading">Can`t move file</DialogTitle>
+        <DialogTitle title="Can`t move file" id={id} />
         <DialogContent>
           You don’t have permission to move or delete this file.
         </DialogContent>

--- a/site/src/examples/dialog/Info.tsx
+++ b/site/src/examples/dialog/Info.tsx
@@ -33,9 +33,9 @@ export const Info = (): ReactElement => {
         onOpenChange={onOpenChange}
         status="info"
         size="small"
-        aria-labelledby={id}
+        id={id}
       >
-        <DialogTitle title="File update" id={id} />
+        <DialogTitle title="File update" />
         <DialogContent>
           A new version of this file is available with 26 updates.
         </DialogContent>

--- a/site/src/examples/dialog/Info.tsx
+++ b/site/src/examples/dialog/Info.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, useState } from "react";
-import { Button } from "@salt-ds/core";
+import { Button, useId } from "@salt-ds/core";
 import {
   Dialog,
   DialogTitle,
@@ -9,6 +9,7 @@ import {
 
 export const Info = (): ReactElement => {
   const [open, setOpen] = useState(false);
+  const id = useId();
 
   const handleRequestOpen = () => {
     setOpen(true);
@@ -32,9 +33,9 @@ export const Info = (): ReactElement => {
         onOpenChange={onOpenChange}
         status="info"
         size="small"
-        aria-labelledby="info-dialog"
+        aria-labelledby={id}
       >
-        <DialogTitle id="info-dialog-heading">File update</DialogTitle>
+        <DialogTitle title="File update" id={id} />
         <DialogContent>
           A new version of this file is available with 26 updates.
         </DialogContent>

--- a/site/src/examples/dialog/Info.tsx
+++ b/site/src/examples/dialog/Info.tsx
@@ -25,9 +25,7 @@ export const Info = (): ReactElement => {
 
   return (
     <>
-      <Button data-testid="dialog-button" onClick={handleRequestOpen}>
-        Open info dialog
-      </Button>
+      <Button onClick={handleRequestOpen}>Open info dialog</Button>
       <Dialog
         open={open}
         onOpenChange={onOpenChange}

--- a/site/src/examples/dialog/MandatoryAction.tsx
+++ b/site/src/examples/dialog/MandatoryAction.tsx
@@ -34,9 +34,9 @@ export const MandatoryAction = (): ReactElement => {
         disableDismiss
         size="small"
         status="error"
-        aria-labelledby={id}
+        id={id}
       >
-        <DialogTitle title="Delete Transaction" id={id} />
+        <DialogTitle title="Delete Transaction" />
         <DialogContent>
           Are you sure you want to permenantly delete transaction?
         </DialogContent>

--- a/site/src/examples/dialog/MandatoryAction.tsx
+++ b/site/src/examples/dialog/MandatoryAction.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, useState } from "react";
-import { Button } from "@salt-ds/core";
+import { Button, useId } from "@salt-ds/core";
 import {
   Dialog,
   DialogTitle,
@@ -9,6 +9,7 @@ import {
 
 export const MandatoryAction = (): ReactElement => {
   const [open, setOpen] = useState(false);
+  const id = useId();
 
   const handleRequestOpen = () => {
     setOpen(true);
@@ -33,9 +34,9 @@ export const MandatoryAction = (): ReactElement => {
         disableDismiss
         size="small"
         status="error"
-        aria-labelledby="error-dialog"
+        aria-labelledby={id}
       >
-        <DialogTitle id="error-dialog-heading">Delete Transaction</DialogTitle>
+        <DialogTitle title="Delete Transaction" id={id} />
         <DialogContent>
           Are you sure you want to permenantly delete transaction?
         </DialogContent>

--- a/site/src/examples/dialog/MandatoryAction.tsx
+++ b/site/src/examples/dialog/MandatoryAction.tsx
@@ -25,9 +25,7 @@ export const MandatoryAction = (): ReactElement => {
 
   return (
     <>
-      <Button data-testid="dialog-button" onClick={handleRequestOpen}>
-        Open Mandatory Action Dialog
-      </Button>
+      <Button onClick={handleRequestOpen}>Open Mandatory Action Dialog</Button>
       <Dialog
         open={open}
         onOpenChange={onOpenChange}

--- a/site/src/examples/dialog/Sizes.tsx
+++ b/site/src/examples/dialog/Sizes.tsx
@@ -1,5 +1,12 @@
 import { ReactElement, useState } from "react";
-import { Button, StackLayout, NavigationItem, H2 } from "@salt-ds/core";
+import {
+  Button,
+  StackLayout,
+  NavigationItem,
+  H2,
+  SplitLayout,
+  useId,
+} from "@salt-ds/core";
 import {
   Dialog,
   DialogTitle,
@@ -13,6 +20,7 @@ import {
 
 const SmallDialog = (): ReactElement => {
   const [open, setOpen] = useState(false);
+  const id = useId();
 
   const handleRequestOpen = () => {
     setOpen(true);
@@ -36,11 +44,9 @@ const SmallDialog = (): ReactElement => {
         onOpenChange={onOpenChange}
         size="small"
         status="warning"
-        aria-labelledby="warning-dialog"
+        aria-labelledby={id}
       >
-        <DialogTitle disableAccent id="warning-dialog-heading">
-          Reset grid settings?
-        </DialogTitle>
+        <DialogTitle disableAccent title="Reset grid settings?" id={id} />
         <DialogContent>
           Are you sure you want to reset all grid data? Any previous settings
           will not be saved
@@ -150,11 +156,9 @@ const MediumDialog = (): ReactElement => {
         size="medium"
         aria-labelledby="preferences-dialog"
       >
-        <DialogTitle id={"preferences-dialog-heading"} disableAccent>
-          Preferences
-        </DialogTitle>
+        <DialogTitle title="Preferences" disableAccent />
         <DialogContent>
-          <StackLayout direction={"row"}>
+          <StackLayout direction="row">
             <ParentChildLayout parent={parent} child={child} />
           </StackLayout>
         </DialogContent>
@@ -195,23 +199,31 @@ const LargeDialog = (): ReactElement => {
         size="medium"
         aria-labelledby="wizard-dialog"
       >
-        <DialogTitle id="wizard-dialog-heading">
-          <div style={{ flexGrow: 1 }}>Add a Beneficiary</div>
-          <SteppedTracker activeStep={0} style={{ width: "400px" }}>
-            <TrackerStep>
-              <StepLabel>Beneficiary</StepLabel>
-            </TrackerStep>
-            <TrackerStep>
-              <StepLabel>Amount</StepLabel>
-            </TrackerStep>
-            <TrackerStep>
-              <StepLabel>Account</StepLabel>
-            </TrackerStep>
-            <TrackerStep>
-              <StepLabel>Delivery</StepLabel>
-            </TrackerStep>
-          </SteppedTracker>
-        </DialogTitle>
+        <SplitLayout
+          align="center"
+          startItem={
+            <DialogTitle
+              title="Add a Beneficiary"
+              subtitle="Customize your Experience"
+            />
+          }
+          endItem={
+            <SteppedTracker activeStep={0} style={{ width: "400px" }}>
+              <TrackerStep>
+                <StepLabel>Beneficiary</StepLabel>
+              </TrackerStep>
+              <TrackerStep>
+                <StepLabel>Amount</StepLabel>
+              </TrackerStep>
+              <TrackerStep>
+                <StepLabel>Account</StepLabel>
+              </TrackerStep>
+              <TrackerStep>
+                <StepLabel>Delivery</StepLabel>
+              </TrackerStep>
+            </SteppedTracker>
+          }
+        />
 
         <DialogContent
           style={{

--- a/site/src/examples/dialog/Sizes.tsx
+++ b/site/src/examples/dialog/Sizes.tsx
@@ -36,9 +36,7 @@ const SmallDialog = (): ReactElement => {
 
   return (
     <>
-      <Button data-testid="dialog-button" onClick={handleRequestOpen}>
-        Open Small Dialog
-      </Button>
+      <Button onClick={handleRequestOpen}>Open Small Dialog</Button>
       <Dialog
         open={open}
         onOpenChange={onOpenChange}

--- a/site/src/examples/dialog/Sizes.tsx
+++ b/site/src/examples/dialog/Sizes.tsx
@@ -44,9 +44,9 @@ const SmallDialog = (): ReactElement => {
         onOpenChange={onOpenChange}
         size="small"
         status="warning"
-        aria-labelledby={id}
+        id={id}
       >
-        <DialogTitle disableAccent title="Reset grid settings?" id={id} />
+        <DialogTitle disableAccent title="Reset grid settings?" />
         <DialogContent>
           Are you sure you want to reset all grid data? Any previous settings
           will not be saved

--- a/site/src/examples/dialog/Subtitle.tsx
+++ b/site/src/examples/dialog/Subtitle.tsx
@@ -27,8 +27,14 @@ export const Subtitle = (): ReactElement => {
   return (
     <>
       <Button onClick={handleRequestOpen}>Open dialog with subtitle</Button>
-      <Dialog open={open} onOpenChange={onOpenChange} size="small">
+      <Dialog
+        open={open}
+        onOpenChange={onOpenChange}
+        size="small"
+        aria-labelledby={id}
+      >
         <DialogTitle
+          id={id}
           title="Subscribe"
           subtitle="Recieve emails about the latest updates"
         />

--- a/site/src/examples/dialog/Subtitle.tsx
+++ b/site/src/examples/dialog/Subtitle.tsx
@@ -27,14 +27,8 @@ export const Subtitle = (): ReactElement => {
   return (
     <>
       <Button onClick={handleRequestOpen}>Open dialog with subtitle</Button>
-      <Dialog
-        open={open}
-        onOpenChange={onOpenChange}
-        size="small"
-        aria-labelledby={id}
-      >
+      <Dialog open={open} onOpenChange={onOpenChange} size="small" id={id}>
         <DialogTitle
-          id={id}
           title="Subscribe"
           subtitle="Recieve emails about the latest updates"
         />

--- a/site/src/examples/dialog/Subtitle.tsx
+++ b/site/src/examples/dialog/Subtitle.tsx
@@ -1,13 +1,14 @@
 import { ReactElement, useState } from "react";
-import { Button, useId } from "@salt-ds/core";
+import { Button, FormField, FormFieldLabel, Input, useId } from "@salt-ds/core";
 import {
   Dialog,
   DialogTitle,
   DialogActions,
   DialogContent,
+  DialogCloseButton,
 } from "@salt-ds/lab";
 
-export const Warning = (): ReactElement => {
+export const Subtitle = (): ReactElement => {
   const [open, setOpen] = useState(false);
   const id = useId();
 
@@ -25,26 +26,24 @@ export const Warning = (): ReactElement => {
 
   return (
     <>
-      <Button data-testid="dialog-button" onClick={handleRequestOpen}>
-        Open warning dialog
-      </Button>
-      <Dialog
-        open={open}
-        onOpenChange={onOpenChange}
-        status="warning"
-        size="small"
-        aria-labelledby={id}
-      >
-        <DialogTitle id={id} title="File access" />
+      <Button onClick={handleRequestOpen}>Open dialog with subtitle</Button>
+      <Dialog open={open} onOpenChange={onOpenChange} size="small">
+        <DialogTitle
+          title="Subscribe"
+          subtitle="Recieve emails about the latest updates"
+        />
+        <DialogCloseButton onClick={handleClose} />
 
         <DialogContent>
-          Users will be able to make edits and modify Trades 2023 file. Give
-          access anyway?
+          <FormField necessity="asterisk">
+            <FormFieldLabel> Email </FormFieldLabel>
+            <Input defaultValue="Email Address" />
+          </FormField>
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose}>Cancel</Button>
           <Button variant="cta" onClick={handleClose}>
-            Give access
+            Subscribe
           </Button>
         </DialogActions>
       </Dialog>

--- a/site/src/examples/dialog/Success.tsx
+++ b/site/src/examples/dialog/Success.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, useState } from "react";
-import { Button } from "@salt-ds/core";
+import { Button, useId } from "@salt-ds/core";
 import {
   Dialog,
   DialogTitle,
@@ -9,6 +9,7 @@ import {
 
 export const Success = (): ReactElement => {
   const [open, setOpen] = useState(false);
+  const id = useId();
 
   const handleRequestOpen = () => {
     setOpen(true);
@@ -32,9 +33,9 @@ export const Success = (): ReactElement => {
         onOpenChange={onOpenChange}
         status="success"
         size="small"
-        aria-labelledby="success-dialog"
+        aria-labelledby={id}
       >
-        <DialogTitle id="success-dialog-heading">File uploaded</DialogTitle>
+        <DialogTitle title="File uploaded" id={id} />
         <DialogContent>
           File has been successfully uploaded to the shared drive.
         </DialogContent>

--- a/site/src/examples/dialog/Success.tsx
+++ b/site/src/examples/dialog/Success.tsx
@@ -33,9 +33,9 @@ export const Success = (): ReactElement => {
         onOpenChange={onOpenChange}
         status="success"
         size="small"
-        aria-labelledby={id}
+        id={id}
       >
-        <DialogTitle title="File uploaded" id={id} />
+        <DialogTitle title="File uploaded" />
         <DialogContent>
           File has been successfully uploaded to the shared drive.
         </DialogContent>

--- a/site/src/examples/dialog/Success.tsx
+++ b/site/src/examples/dialog/Success.tsx
@@ -25,7 +25,7 @@ export const Success = (): ReactElement => {
 
   return (
     <>
-      <Button data-testid="dialog-button" onClick={handleRequestOpen}>
+      <Button onClick={handleRequestOpen}>
         Open success dialog
       </Button>
       <Dialog

--- a/site/src/examples/dialog/Success.tsx
+++ b/site/src/examples/dialog/Success.tsx
@@ -25,9 +25,7 @@ export const Success = (): ReactElement => {
 
   return (
     <>
-      <Button onClick={handleRequestOpen}>
-        Open success dialog
-      </Button>
+      <Button onClick={handleRequestOpen}>Open success dialog</Button>
       <Dialog
         open={open}
         onOpenChange={onOpenChange}

--- a/site/src/examples/dialog/Warning.tsx
+++ b/site/src/examples/dialog/Warning.tsx
@@ -33,9 +33,9 @@ export const Warning = (): ReactElement => {
         onOpenChange={onOpenChange}
         status="warning"
         size="small"
-        aria-labelledby={id}
+        id={id}
       >
-        <DialogTitle id={id} title="File access" />
+        <DialogTitle title="File access" />
 
         <DialogContent>
           Users will be able to make edits and modify Trades 2023 file. Give

--- a/site/src/examples/dialog/Warning.tsx
+++ b/site/src/examples/dialog/Warning.tsx
@@ -25,9 +25,7 @@ export const Warning = (): ReactElement => {
 
   return (
     <>
-      <Button data-testid="dialog-button" onClick={handleRequestOpen}>
-        Open warning dialog
-      </Button>
+      <Button onClick={handleRequestOpen}>Open warning dialog</Button>
       <Dialog
         open={open}
         onOpenChange={onOpenChange}

--- a/site/src/examples/dialog/WithoutAccent.tsx
+++ b/site/src/examples/dialog/WithoutAccent.tsx
@@ -28,8 +28,8 @@ export const WithoutAccent = (): ReactElement => {
       <Button data-testid="dialog-button" onClick={handleRequestOpen}>
         Open dialog without accent
       </Button>
-      <Dialog open={open} onOpenChange={onOpenChange} aria-labelledby={id}>
-        <DialogTitle title="Terms and conditions" disableAccent id={id} />
+      <Dialog open={open} onOpenChange={onOpenChange} id={id}>
+        <DialogTitle title="Terms and conditions" disableAccent />
         <DialogContent>
           <StackLayout>
             <div>

--- a/site/src/examples/dialog/WithoutAccent.tsx
+++ b/site/src/examples/dialog/WithoutAccent.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, useState } from "react";
-import { Button, H3, StackLayout } from "@salt-ds/core";
+import { Button, H3, StackLayout, useId } from "@salt-ds/core";
 import {
   Dialog,
   DialogTitle,
@@ -9,6 +9,7 @@ import {
 
 export const WithoutAccent = (): ReactElement => {
   const [open, setOpen] = useState(false);
+  const id = useId();
 
   const handleRequestOpen = () => {
     setOpen(true);
@@ -27,14 +28,8 @@ export const WithoutAccent = (): ReactElement => {
       <Button data-testid="dialog-button" onClick={handleRequestOpen}>
         Open dialog without accent
       </Button>
-      <Dialog
-        open={open}
-        onOpenChange={onOpenChange}
-        aria-labelledby="terms-and-conditions-dialog"
-      >
-        <DialogTitle id="terms-and-conditions-dialog-heading" disableAccent>
-          Terms and conditions
-        </DialogTitle>
+      <Dialog open={open} onOpenChange={onOpenChange} aria-labelledby={id}>
+        <DialogTitle title="Terms and conditions" disableAccent id={id} />
         <DialogContent>
           <StackLayout>
             <div>

--- a/site/src/examples/dialog/WithoutAccent.tsx
+++ b/site/src/examples/dialog/WithoutAccent.tsx
@@ -25,9 +25,7 @@ export const WithoutAccent = (): ReactElement => {
 
   return (
     <>
-      <Button data-testid="dialog-button" onClick={handleRequestOpen}>
-        Open dialog without accent
-      </Button>
+      <Button onClick={handleRequestOpen}>Open dialog without accent</Button>
       <Dialog open={open} onOpenChange={onOpenChange} id={id}>
         <DialogTitle title="Terms and conditions" disableAccent />
         <DialogContent>

--- a/site/src/examples/dialog/index.ts
+++ b/site/src/examples/dialog/index.ts
@@ -8,3 +8,4 @@ export * from "./CloseButton";
 export * from "./MandatoryAction";
 export * from "./Sizes";
 export * from "./DisableScrim";
+export * from "./Subtitle";


### PR DESCRIPTION
- Title and subtitle now passed via props to ensure consistent styling for the Title and Subtitle
- id attached to `Dialog` and passed to aria-labelledby to read out title and subtitle when using a screen reader
- tests added for `title` / `subtitle` props and `disableDismiss`


