### PR TITLE
Fix Tab deletion during editing

### DIFF
--- a/.changeset/witty-flies-bake.md
+++ b/.changeset/witty-flies-bake.md
@@ -2,4 +2,4 @@
 "@salt-ds/lab": patch
 ---
 
-Fix to prevent Tab being deleted whilst editing Tab label and pressing backspace or delete
+Fixed Tab being deleted whilst editing Tab label and pressing backspace or delete

--- a/.changeset/witty-flies-bake.md
+++ b/.changeset/witty-flies-bake.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/lab": patch
+---
+
+Fix to prevent Tab being deleted whilst editing Tab label and pressing backspace or delete

--- a/packages/lab/src/tabs/Tab.tsx
+++ b/packages/lab/src/tabs/Tab.tsx
@@ -108,7 +108,7 @@ export const Tab = forwardRef(function Tab(
     switch (e.key) {
       case "Backspace":
       case "Delete":
-        if (closeable) {
+        if (closeable && !editing) {
           e.stopPropagation();
           onClose && onClose(index);
         }


### PR DESCRIPTION
Fixing issue where Tab could be deleting whilst editing label and pressing backspace. 

Referenced in issue https://github.com/jpmorganchase/salt-ds/issues/3036 