### PR TITLE
JPM fix

### DIFF
--- a/site/docs/getting-started/designing/index.mdx
+++ b/site/docs/getting-started/designing/index.mdx
@@ -37,7 +37,7 @@ There are two ways of accessing the libraries—as a J.P. Morgan employee or as 
 Use the Salt Design System team space to view working files and our comprehensive component guides. You can also instantly add components and styling to your designs.
 
 <InlineCard
-  icon={<Image src="/img/design-getting-started/jpmIcon.svg" alt="JPM logo" />}
+  icon={<Image src="/img/design-getting-started/jpmIcon.svg" alt="J.P. Morgan logo" />}
   description={
     <p>
       To start using the Salt libraries, enable them directly from the “Assets”

--- a/site/docs/getting-started/designing/index.mdx
+++ b/site/docs/getting-started/designing/index.mdx
@@ -37,7 +37,12 @@ There are two ways of accessing the libraries—as a J.P. Morgan employee or as 
 Use the Salt Design System team space to view working files and our comprehensive component guides. You can also instantly add components and styling to your designs.
 
 <InlineCard
-  icon={<Image src="/img/design-getting-started/jpmIcon.svg" alt="J.P. Morgan logo" />}
+  icon={
+    <Image
+      src="/img/design-getting-started/jpmIcon.svg"
+      alt="J.P. Morgan logo"
+    />
+  }
   description={
     <p>
       To start using the Salt libraries, enable them directly from the “Assets”

--- a/site/docs/getting-started/designing/tableau.mdx
+++ b/site/docs/getting-started/designing/tableau.mdx
@@ -18,7 +18,7 @@ They key principles this guidance covers derive from the [Analytical Dashboard p
 
 ## Tableau template
 
-[JPM employees only] Follow the [instructions](https://go/salt-tableau) to access and start using the Tableau template within the dedicated Salt server. For any issues with the steps highlighted, please [contact us](/salt/support-and-contributions/index).
+_(J.P. Morgan employees only)_ Follow the [instructions](https://go/salt-tableau) to access and start using the Tableau template within the dedicated Salt server. For any issues with the steps highlighted, please [contact us](/salt/support-and-contributions/index).
 
 <ExampleContainer type="neutral">
   The dimensions and specifications in the examples below use the medium density

--- a/site/docs/patterns/dashboards/analytical-dashboard.mdx
+++ b/site/docs/patterns/dashboards/analytical-dashboard.mdx
@@ -18,7 +18,7 @@ data:
 
 An analytical dashboard enables users to analyze trends, patterns and metrics effectively. You can use this to present data in a hierarchical and intuitive manner.
 
-The mock-ups displayed in this pattern are available as [templates](https://www.figma.com/file/O3FYUQYXLosmEuZc0T30Qo/Analytical-Dashboard-Pattern?type=design&node-id=1288-5747&mode=design&t=Pu46NKEwCeMRSjPD-0) in Figma _(JPM employees only)_.
+The mock-ups displayed in this pattern are available as [templates](https://www.figma.com/file/O3FYUQYXLosmEuZc0T30Qo/Analytical-Dashboard-Pattern?type=design&node-id=1288-5747&mode=design&t=Pu46NKEwCeMRSjPD-0) in Figma _(J.P. Morgan employees only)_.
 
 <Diagram
   src="/img/patterns/dashboards/analytical_dashboard.png"
@@ -235,7 +235,7 @@ Use the [`Card` component](../../components/card) as a container or widget type 
 #### Styling
 
 - By default, the Salt [card](../../components/card) is styled using a primary background. Use the `--salt-container-secondary-background` token to achieve visual hierarchy in your design.
-- _(JPM employees only)_ For styling data visualizations such as charts, follow the UITK guidelines on data visualization, where you can find further information on presenting data in a visually cohesive manner. We recommend using the categorical color palette within your dashboard design, as it’s ideal for visualizing distinct groups of items.
+- _(J.P. Morgan employees only)_ For styling data visualizations such as charts, follow the UITK guidelines on data visualization, where you can find further information on presenting data in a visually cohesive manner. We recommend using the categorical color palette within your dashboard design, as it’s ideal for visualizing distinct groups of items.
 
 </ExampleContainer>
 

--- a/site/src/layouts/DetailPattern/Resources.tsx
+++ b/site/src/layouts/DetailPattern/Resources.tsx
@@ -68,7 +68,7 @@ export function Resources() {
         {internal.length > 0 && (
           <>
             <Text className={styles.subtitle} styleAs="label">
-              JPM employees only:
+              J.P. Morgan employees only:
             </Text>
             <ul className={styles.list}>
               {internal.map(({ href, label }) => (


### PR DESCRIPTION
Our site uses the term "JPM" in some places to refer to J.P. Morgan.

The style guide recommends only using "JPM" when referring to the stock ticker. We should use "J.P. Morgan" when referring to the company.

This PR removes all "JPM" references.