### PR TITLE
Fix example for inline tabstrip

### DIFF
--- a/site/src/examples/tabs/Inline.tsx
+++ b/site/src/examples/tabs/Inline.tsx
@@ -5,8 +5,12 @@ export const Inline = (): ReactElement => {
   const tabs = ["Home", "Transactions", "Loans", "Checks", "Liquidity"];
 
   return (
-    <div>
-      <TabstripNext variant="inline" defaultValue={tabs[0]}>
+    <div style={{ width: "100%" }}>
+      <TabstripNext
+        variant="inline"
+        defaultValue={tabs[0]}
+        style={{ maxWidth: "400px", margin: "auto" }}
+      >
         {tabs.map((label) => (
           <TabNext value={label} key={label}>
             {label}


### PR DESCRIPTION
the example wrapper currently has no width set, which makes the tabstrip collapse