### PR TITLE
Added support for passing multiple theme names to SaltProvider

### DIFF
--- a/.changeset/modern-maps-breathe.md
+++ b/.changeset/modern-maps-breathe.md
@@ -1,0 +1,9 @@
+---
+"@salt-ds/core": minor
+---
+
+Added support for passing multiple theme names to `SaltProvider`.
+
+```tsx
+<SaltProvider theme={["custom-theme-1", "custom-theme-2"]}>
+```

--- a/packages/core/src/__tests__/__e2e__/salt-provider/SaltProvider.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/salt-provider/SaltProvider.cy.tsx
@@ -1,3 +1,4 @@
+import { clsx } from "clsx";
 import {
   ownerWindow,
   SaltProvider,
@@ -28,7 +29,7 @@ const TestComponent = ({
       id={id}
       className={className}
       data-density={density}
-      data-theme={theme}
+      data-theme={clsx(theme)}
       data-mode={mode}
       data-announcer={announcerPresent}
       data-corner={UNSTABLE_corner}
@@ -106,7 +107,7 @@ describe("Given a SaltProvider", () => {
         .and("have.attr", "data-announcer", "true");
     });
 
-    it("should apply values specified in props", () => {
+    it("should apply density and mode values specified in props", () => {
       mount(
         <SaltProvider density="high" mode="dark">
           <TestComponent />
@@ -117,6 +118,37 @@ describe("Given a SaltProvider", () => {
         .and("have.attr", "data-density", "high")
         .and("have.attr", "data-mode", "dark")
         .and("have.attr", "data-announcer", "true");
+    });
+
+    it("should apply theme (string) prop specified in props", () => {
+      mount(
+        <SaltProvider theme="custom-theme">
+          <TestComponent />
+        </SaltProvider>
+      );
+      cy.get("html")
+        .should("exist")
+        .and("have.class", "salt-theme")
+        .and("have.class", "custom-theme");
+      cy.get("#test-1")
+        .should("exist")
+        .and("have.attr", "data-theme", "custom-theme");
+    });
+
+    it("should apply theme (string[]) prop specified in props", () => {
+      mount(
+        <SaltProvider theme={["custom-theme-1", "custom-theme-2"]}>
+          <TestComponent />
+        </SaltProvider>
+      );
+      cy.get("html")
+        .should("exist")
+        .and("have.class", "salt-theme")
+        .and("have.class", "custom-theme-1")
+        .and("have.class", "custom-theme-2");
+      cy.get("#test-1")
+        .should("exist")
+        .and("have.attr", "data-theme", "custom-theme-1 custom-theme-2");
     });
   });
 
@@ -135,9 +167,9 @@ describe("Given a SaltProvider", () => {
 
     it("should inherit values not passed as props", () => {
       mount(
-        <SaltProvider density="high" mode="dark">
+        <SaltProvider density="high" mode="dark" theme="custom-theme-1">
           <TestComponent />
-          <SaltProvider density="medium">
+          <SaltProvider density="medium" theme="custom-theme-2">
             <TestComponent id="test-2" />
           </SaltProvider>
         </SaltProvider>
@@ -147,13 +179,14 @@ describe("Given a SaltProvider", () => {
         .should("exist")
         .and("have.attr", "data-density", "high")
         .and("have.attr", "data-mode", "dark")
-        .and("have.attr", "data-announcer", "true");
-
+        .and("have.attr", "data-announcer", "true")
+        .and("have.attr", "data-theme", "custom-theme-1");
       cy.get("#test-2")
         .should("exist")
         .and("have.attr", "data-density", "medium")
         .and("have.attr", "data-mode", "dark")
-        .and("have.attr", "data-announcer", "true");
+        .and("have.attr", "data-announcer", "true")
+        .and("have.attr", "data-theme", "custom-theme-2");
     });
   });
 
@@ -242,7 +275,7 @@ describe("Given a SaltProvider", () => {
     );
   }
 
-  it.skip("should not warn when two providers are set to apply to root but are in different windows", () => {
+  it("should not warn when two providers are set to apply to root but are in different windows", () => {
     cy.spy(console, "warn").as("consoleSpy");
 
     mount(

--- a/packages/core/src/__tests__/__e2e__/salt-provider/SaltProvider.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/salt-provider/SaltProvider.cy.tsx
@@ -275,7 +275,7 @@ describe("Given a SaltProvider", () => {
     );
   }
 
-  it("should not warn when two providers are set to apply to root but are in different windows", () => {
+  it.skip("should not warn when two providers are set to apply to root but are in different windows", () => {
     cy.spy(console, "warn").as("consoleSpy");
 
     mount(

--- a/packages/core/src/salt-provider/SaltProvider.tsx
+++ b/packages/core/src/salt-provider/SaltProvider.tsx
@@ -52,15 +52,19 @@ export const BreakpointContext =
 /**
  * We're relying `DEFAULT_THEME_NAME` to determine whether the provider is a root.
  */
-const getThemeNames = (themeName: ThemeName, themeNext?: boolean) => {
+const getThemeNames = (themeName: ThemeName, themeNext?: boolean): string[] => {
   if (themeNext) {
     return themeName === DEFAULT_THEME_NAME
       ? [DEFAULT_THEME_NAME, UNSTABLE_ADDITIONAL_THEME_NAME]
+      : Array.isArray(themeName)
+      ? [DEFAULT_THEME_NAME, UNSTABLE_ADDITIONAL_THEME_NAME, ...themeName]
       : [DEFAULT_THEME_NAME, UNSTABLE_ADDITIONAL_THEME_NAME, themeName];
   } else {
     {
       return themeName === DEFAULT_THEME_NAME
         ? [DEFAULT_THEME_NAME]
+        : Array.isArray(themeName)
+        ? [DEFAULT_THEME_NAME, ...themeName]
         : [DEFAULT_THEME_NAME, themeName];
     }
   }

--- a/packages/core/src/theme/Theme.ts
+++ b/packages/core/src/theme/Theme.ts
@@ -16,7 +16,7 @@ export type characteristic =
   | "text"
   | "differential" /* **deprecated** */;
 
-export type ThemeName = string;
+export type ThemeName = string | string[];
 
 export const getCharacteristicValue = (
   themeName: ThemeName,
@@ -26,7 +26,12 @@ export const getCharacteristicValue = (
 ): string | null => {
   const cssVariableName = `--salt-${characteristicName}-${variant}`;
   const scopeTarget =
-    scopeElement || document.body.querySelector(`.${themeName}`);
+    scopeElement ??
+    document.body.querySelector(
+      Array.isArray(themeName)
+        ? themeName.map((t) => "." + t).join()
+        : `.${themeName}`
+    );
   if (scopeTarget) {
     const style = getComputedStyle(scopeTarget);
     const variableValue = style.getPropertyValue(cssVariableName);

--- a/packages/core/stories/salt-provider/salt-provider.stories.css
+++ b/packages/core/stories/salt-provider/salt-provider.stories.css
@@ -1,0 +1,7 @@
+.custom-font.salt-theme {
+  --salt-typography-fontFamily: "Times New Roman";
+}
+
+.no-spacing.salt-theme {
+  --salt-spacing-100: 0px;
+}

--- a/packages/core/stories/salt-provider/salt-provider.stories.tsx
+++ b/packages/core/stories/salt-provider/salt-provider.stories.tsx
@@ -1,16 +1,19 @@
-import { SyntheticEvent, useState } from "react";
 import {
   Button,
   Card,
   Checkbox,
+  CheckboxGroup,
   Density,
+  H1,
   Mode,
   SaltProvider,
   ToggleButton,
   ToggleButtonGroup,
 } from "@salt-ds/core";
+import { ChangeEvent, ReactNode, SyntheticEvent, useState } from "react";
 
 import "docs/story.css";
+import "./salt-provider.stories.css";
 
 export default {
   title: "Core/Salt Provider",
@@ -41,7 +44,7 @@ export const ToggleTheme = () => {
     <SaltProvider mode={mode}>
       <Card>
         <div>
-          <h1>This Card is wrapped with a SaltProvider</h1>
+          <H1>This Card is wrapped with a SaltProvider</H1>
           <ToggleButtonGroup onChange={handleChangeTheme} value={mode}>
             <ToggleButton aria-label="light theme" value="light">
               Light
@@ -75,52 +78,75 @@ export const ToggleTheme = () => {
   );
 };
 
-export const NestedProviders = () => {
-  const [outerMode, setOuterMode] = useState<Mode | "unset">("light");
-  const [outerDensity, setOuterDensity] = useState<Density | "unset">("high");
-  const [innerMode, setInnerMode] = useState<Mode | "unset">("dark");
-  const [innerDensity, setInnerDensity] = useState<Density | "unset">("unset");
+const getThemeName = (selectedTheme: string[]) => {
+  if (selectedTheme.length === 0) {
+    return undefined;
+  } else if (selectedTheme.length === 1) {
+    return selectedTheme[0];
+  } else {
+    return selectedTheme;
+  }
+};
 
-  const handleChangeOuterTheme = (event: SyntheticEvent<HTMLButtonElement>) => {
-    setOuterMode(event.currentTarget.value as Mode);
+const CardWithProvider = ({
+  defaultMode,
+  defaultDensity,
+  children,
+}: {
+  defaultMode: Mode | "unset";
+  defaultDensity: Density | "unset";
+  children?: ReactNode;
+}) => {
+  const [mode, setMode] = useState(defaultMode);
+  const [density, setDensity] = useState(defaultDensity);
+  const [selectedThemes, setSelectedThemes] = useState<string[]>([]);
+
+  const handleChangeMode = (event: SyntheticEvent<HTMLButtonElement>) => {
+    setMode(event.currentTarget.value as Mode);
+  };
+  const handleChangeDensity = (event: SyntheticEvent<HTMLButtonElement>) => {
+    setDensity(event.currentTarget.value as Density);
   };
 
-  const handleChangeOuterDensity = (
-    event: SyntheticEvent<HTMLButtonElement>
-  ) => {
-    setOuterDensity(event.currentTarget.value as Density);
-  };
-
-  const handleChangeInnerTheme = (event: SyntheticEvent<HTMLButtonElement>) => {
-    setInnerMode(event.currentTarget.value as Mode);
-  };
-  const handleChangeInnerDensity = (
-    event: SyntheticEvent<HTMLButtonElement>
-  ) => {
-    setInnerDensity(event.currentTarget.value as Density);
+  const handleThemeNamesChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    if (selectedThemes.indexOf(value) === -1) {
+      setSelectedThemes((prevControlledValues) => [
+        ...prevControlledValues,
+        value,
+      ]);
+    } else {
+      setSelectedThemes((prevControlledValues) =>
+        prevControlledValues.filter(
+          (controlledValue) => controlledValue !== value
+        )
+      );
+    }
   };
 
   return (
     <SaltProvider
-      density={outerDensity === "unset" ? undefined : outerDensity}
-      mode={outerMode === "unset" ? undefined : outerMode}
+      mode={mode === "unset" ? undefined : mode}
+      density={density === "unset" ? undefined : density}
+      theme={getThemeName(selectedThemes)}
     >
       <Card>
         <div>
-          <h1>This Card is wrapped with a SaltProvider</h1>
+          <H1>Card with Salt Provider</H1>
           <ToggleButtonGroup
-            aria-label="Outer theme selection"
-            onChange={handleChangeOuterTheme}
-            value={outerMode}
+            aria-label="Theme selection"
+            onChange={handleChangeMode}
+            value={mode}
           >
             <ToggleButton value="light">Light</ToggleButton>
             <ToggleButton value="dark">Dark</ToggleButton>
             <ToggleButton value="unset">Not set</ToggleButton>
           </ToggleButtonGroup>
+
           <ToggleButtonGroup
-            aria-label="Outer density selection"
-            onChange={handleChangeOuterDensity}
-            value={outerDensity}
+            aria-label="Density selection"
+            onChange={handleChangeDensity}
+            value={density}
           >
             <ToggleButton value="high">High</ToggleButton>
             <ToggleButton value="medium">Medium</ToggleButton>
@@ -128,50 +154,31 @@ export const NestedProviders = () => {
             <ToggleButton value="touch">Touch</ToggleButton>
             <ToggleButton value="unset">Not set</ToggleButton>
           </ToggleButtonGroup>
+
+          <CheckboxGroup
+            checkedValues={selectedThemes}
+            onChange={handleThemeNamesChange}
+          >
+            <Checkbox label="Custom font" value="custom-font" />
+            <Checkbox label="No spacing" value="no-spacing" />
+          </CheckboxGroup>
+
           <p>
-            This Card is wrapped with a SaltProvider, theme is light, density is
-            high.
+            This Card is wrapped with SaltProvider, default mode is{" "}
+            {defaultMode}, default density is {defaultDensity}
           </p>
+
+          {children}
         </div>
-        <br />
-        <SaltProvider
-          mode={innerMode === "unset" ? undefined : innerMode}
-          density={innerDensity === "unset" ? undefined : innerDensity}
-        >
-          <Card>
-            <div>
-              <h1>Nested Card</h1>
-              <ToggleButtonGroup
-                aria-label="Inner theme selection"
-                onChange={handleChangeInnerTheme}
-                value={innerMode}
-              >
-                <ToggleButton value="light">Light</ToggleButton>
-                <ToggleButton value="dark">Dark</ToggleButton>
-                <ToggleButton value="unset">Not set</ToggleButton>
-              </ToggleButtonGroup>
-
-              <ToggleButtonGroup
-                aria-label="Inner density selection"
-                onChange={handleChangeInnerDensity}
-                value={innerDensity}
-              >
-                <ToggleButton value="high">High</ToggleButton>
-                <ToggleButton value="medium">Medium</ToggleButton>
-                <ToggleButton value="low">Low</ToggleButton>
-                <ToggleButton value="touch">Touch</ToggleButton>
-                <ToggleButton value="unset">Not set</ToggleButton>
-              </ToggleButtonGroup>
-
-              <p>
-                This nested Card is also wrapped with a SaltProvider, theme is
-                dark. Density is not specified, so inherits high value from
-                outer SaltProvider
-              </p>
-            </div>
-          </Card>
-        </SaltProvider>
       </Card>
     </SaltProvider>
+  );
+};
+
+export const NestedProviders = () => {
+  return (
+    <CardWithProvider defaultMode="light" defaultDensity="high">
+      <CardWithProvider defaultMode="dark" defaultDensity="unset" />
+    </CardWithProvider>
   );
 };


### PR DESCRIPTION
Redo #2816

Found it very useful when implementing multiple themes within a single app (same feedback from early partner teams)

- [ ] investigate pros/cons when treat `theme` props as normal `classname` (i.e. may include space)