### PR TITLE
Fix --salt-navigable-background-hover referencing deprecated token

### DIFF
--- a/.changeset/smooth-bananas-know.md
+++ b/.changeset/smooth-bananas-know.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/theme": patch
+---
+
+Fix `--salt-navigable-background-hover` referencing deprecated value `--salt-palette-navigate-primary-background-hover`, change to reference correct value `--salt-palette-navigate-background-hover`

--- a/packages/theme/css/characteristics/navigable.css
+++ b/packages/theme/css/characteristics/navigable.css
@@ -12,7 +12,7 @@
   --salt-navigable-indicator-hover: var(--salt-palette-navigate-indicator-hover);
   --salt-navigable-indicator-active: var(--salt-palette-navigate-indicator-active);
 
-  --salt-navigable-background-hover: var(--salt-palette-navigate-primary-background-hover);
+  --salt-navigable-background-hover: var(--salt-palette-navigate-background-hover);
 
   /* Link */
   --salt-navigable-textDecoration: underline;


### PR DESCRIPTION
token refd deprecated value: --salt-palette-navigate-primary-background-hover
change to ref correct value: --salt-palette-navigate-background-hover