### PR TITLE
Fix text inside Panel having the incorrect color when color-scheme is not set or doesn't change the default text color e.g. in Safari

### DIFF
--- a/.changeset/plenty-pans-film.md
+++ b/.changeset/plenty-pans-film.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Fixed text inside Panel having the incorrect color when color-scheme is not set or doesn't change the default text color e.g. in Safari.

--- a/packages/core/src/panel/Panel.css
+++ b/packages/core/src/panel/Panel.css
@@ -16,7 +16,7 @@
 /* Styles applied to the root element */
 .saltPanel {
   background: var(--saltPanel-background, var(--panel-background));
-  color: var(--saltPanel-color, initial);
+  color: var(--saltPanel-color, inherit);
   height: var(--saltPanel-height, 100%);
   overflow: auto;
   padding: var(--saltPanel-padding, var(--salt-size-container-spacing));


### PR DESCRIPTION
closes #3013

also adds font-family to Panel, as in Safari this isn't picked up within plain text in a Panel (unless Text component directly used)