### PR TITLE
Fix vite warning in custom-floating-ui-platform.stories.tsx

### DIFF
--- a/packages/core/stories/floating-platform/custom-floating-ui-platform.stories.tsx
+++ b/packages/core/stories/floating-platform/custom-floating-ui-platform.stories.tsx
@@ -27,7 +27,7 @@ import {
 import { useWindow } from "@salt-ds/window";
 import { useComponentCssInjection } from "@salt-ds/styles";
 
-import floatingCss from "./floating-platform.css";
+import floatingCss from "./floating-platform.css?inline";
 
 import { NewWindow, FloatingComponentWindow } from "./NewWindow";
 


### PR DESCRIPTION
```
23 |  import floatingCss from "./floating-platform.css";
   |                           ^
24 |  import { NewWindow, FloatingComponentWindow } from "./NewWindow";
25 |  export default {
Default and named imports from CSS files are deprecated. Use the ?inline query instead. For example: import floatingCss from "./floating-platform.css?inline"
  Plugin: vite:import-analysis
```