### PR TITLE
Add link to examples for the selectable card pattern

### DIFF
--- a/site/docs/patterns/selectable-card.mdx
+++ b/site/docs/patterns/selectable-card.mdx
@@ -5,7 +5,7 @@ aliases:
   - /salt/patterns/content-status
 data:
   resources:
-  [
+    [
       { href: "https://storybook.saltdesignsystem.com/?path=/story/patterns-selectable-card--single-selection", label: "Examples" },
     ]
   components: ["Card", "Checkbox", "Radio button", "Stack layout", "Grid layout"]

--- a/site/docs/patterns/selectable-card.mdx
+++ b/site/docs/patterns/selectable-card.mdx
@@ -5,8 +5,9 @@ aliases:
   - /salt/patterns/content-status
 data:
   resources:
-    [
-   ]
+  [
+      { href: "https://storybook.saltdesignsystem.com/?path=/story/patterns-selectable-card--single-selection, label: "Examples" },
+    ]
   components: ["Card", "Checkbox", "Radio button", "Stack layout", "Grid layout"]
 ---
 

--- a/site/docs/patterns/selectable-card.mdx
+++ b/site/docs/patterns/selectable-card.mdx
@@ -6,7 +6,7 @@ aliases:
 data:
   resources:
   [
-      { href: "https://storybook.saltdesignsystem.com/?path=/story/patterns-selectable-card--single-selection, label: "Examples" },
+      { href: "https://storybook.saltdesignsystem.com/?path=/story/patterns-selectable-card--single-selection", label: "Examples" },
     ]
   components: ["Card", "Checkbox", "Radio button", "Stack layout", "Grid layout"]
 ---


### PR DESCRIPTION
This PR adds a link to the selectable card pattern storybook on the docs page.