### PR TITLE
Alternative responsive props

### DIFF
--- a/.changeset/dry-pumpkins-battle.md
+++ b/.changeset/dry-pumpkins-battle.md
@@ -1,0 +1,8 @@
+---
+"@salt-ds/core": minor
+---
+
+Added `useBreakpoint` which returns on object containing matchedBreakpoints and `breakpoint`.
+
+- `matchedBreakpoints` - is an array of all matched breakpoints e.g. when the viewport matches the M breakpoint this array contains M, SM and XS.
+- `breakpoint` - is the current matched breakpoint.

--- a/.changeset/shiny-bees-listen.md
+++ b/.changeset/shiny-bees-listen.md
@@ -1,0 +1,16 @@
+---
+"@salt-ds/core": minor
+---
+
+Added support for passing a string gap values to FlexLayout and GridLayout.
+
+```tsx
+<FlexLayout gap="spacing-100" />
+<GridLayout gap="spacing-100" rowGap="spacing-100" columnGap="spacing-100" />
+```
+
+Added support for passing a string column and row template to GridLayout.
+
+```tsx
+<GridLayout columns="1fr 1fr 2fr" rows="1fr 2fr" />
+```

--- a/packages/core/src/__tests__/__e2e__/breakpoint-provider/BreakpointProvider.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/breakpoint-provider/BreakpointProvider.cy.tsx
@@ -1,0 +1,81 @@
+import { useBreakpoint } from "@salt-ds/core";
+
+function TestComponent() {
+  const { matchedBreakpoints } = useBreakpoint();
+
+  return <div>{matchedBreakpoints}</div>;
+}
+
+describe("Given a BreakpointProvider", () => {
+  it(
+    "should return XL, L, M, S, XS if the viewport is above 1920",
+    { viewportWidth: 1921 },
+    () => {
+      cy.mount(<TestComponent />);
+      cy.findByText("XL,L,M,S,XS");
+    }
+  );
+
+  it(
+    "should return L, M, S, XS if the viewport is 1919",
+    { viewportWidth: 1919 },
+    () => {
+      cy.mount(<TestComponent />);
+      cy.findByText("L,M,S,XS");
+    }
+  );
+
+  it(
+    "should return L, M, S, XS if the viewport is 1280",
+    { viewportWidth: 1280 },
+    () => {
+      cy.mount(<TestComponent />);
+      cy.findByText("L,M,S,XS");
+    }
+  );
+
+  it(
+    "should return M, S, XS if the viewport is 1279",
+    { viewportWidth: 1279 },
+    () => {
+      cy.mount(<TestComponent />);
+      cy.findByText("M,S,XS");
+    }
+  );
+
+  it(
+    "should return M, S, XS if the viewport is 960",
+    { viewportWidth: 960 },
+    () => {
+      cy.mount(<TestComponent />);
+      cy.findByText("M,S,XS");
+    }
+  );
+
+  it(
+    "should return S, XS if the viewport is 959",
+    { viewportWidth: 959 },
+    () => {
+      cy.mount(<TestComponent />);
+      cy.findByText("S,XS");
+    }
+  );
+
+  it(
+    "should return S, XS if the viewport is 600",
+    { viewportWidth: 600 },
+    () => {
+      cy.mount(<TestComponent />);
+      cy.findByText("S,XS");
+    }
+  );
+
+  it(
+    "should return XS if the viewport is less than 600",
+    { viewportWidth: 599 },
+    () => {
+      cy.mount(<TestComponent />);
+      cy.findByText("XS");
+    }
+  );
+});

--- a/packages/core/src/__tests__/__e2e__/breakpoint-provider/BreakpointProvider.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/breakpoint-provider/BreakpointProvider.cy.tsx
@@ -3,79 +3,79 @@ import { useBreakpoint } from "@salt-ds/core";
 function TestComponent() {
   const { matchedBreakpoints } = useBreakpoint();
 
-  return <div>{matchedBreakpoints}</div>;
+  return <div>{matchedBreakpoints.join(",")}</div>;
 }
 
 describe("Given a BreakpointProvider", () => {
   it(
-    "should return XL, L, M, S, XS if the viewport is above 1920",
+    "should return xl, lg, md, sm, xs if the viewport is above 1920",
     { viewportWidth: 1921 },
     () => {
       cy.mount(<TestComponent />);
-      cy.findByText("XL,L,M,S,XS");
+      cy.findByText("xl,lg,md,sm,xs");
     }
   );
 
   it(
-    "should return L, M, S, XS if the viewport is 1919",
+    "should return lg, md, sm, xs if the viewport is 1919",
     { viewportWidth: 1919 },
     () => {
       cy.mount(<TestComponent />);
-      cy.findByText("L,M,S,XS");
+      cy.findByText("lg,md,sm,xs");
     }
   );
 
   it(
-    "should return L, M, S, XS if the viewport is 1280",
+    "should return lg, md, sm, xs if the viewport is 1280",
     { viewportWidth: 1280 },
     () => {
       cy.mount(<TestComponent />);
-      cy.findByText("L,M,S,XS");
+      cy.findByText("lg,md,sm,xs");
     }
   );
 
   it(
-    "should return M, S, XS if the viewport is 1279",
+    "should return md, sm, xs if the viewport is 1279",
     { viewportWidth: 1279 },
     () => {
       cy.mount(<TestComponent />);
-      cy.findByText("M,S,XS");
+      cy.findByText("md,sm,xs");
     }
   );
 
   it(
-    "should return M, S, XS if the viewport is 960",
+    "should return md, sm, xs if the viewport is 960",
     { viewportWidth: 960 },
     () => {
       cy.mount(<TestComponent />);
-      cy.findByText("M,S,XS");
+      cy.findByText("md,sm,xs");
     }
   );
 
   it(
-    "should return S, XS if the viewport is 959",
+    "should return sm, xs if the viewport is 959",
     { viewportWidth: 959 },
     () => {
       cy.mount(<TestComponent />);
-      cy.findByText("S,XS");
+      cy.findByText("sm,xs");
     }
   );
 
   it(
-    "should return S, XS if the viewport is 600",
+    "should return sm, xs if the viewport is 600",
     { viewportWidth: 600 },
     () => {
       cy.mount(<TestComponent />);
-      cy.findByText("S,XS");
+      cy.findByText("sm,xs");
     }
   );
 
   it(
-    "should return XS if the viewport is less than 600",
+    "should return xs if the viewport is less than 600",
     { viewportWidth: 599 },
     () => {
       cy.mount(<TestComponent />);
-      cy.findByText("XS");
+      cy.findByText("xs");
     }
   );
 });

--- a/packages/core/src/__tests__/__e2e__/grid-layout/GridLayout.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/grid-layout/GridLayout.cy.tsx
@@ -140,7 +140,7 @@ describe("GIVEN a Grid", () => {
       "THEN it should render 1 column and 12 rows on xs viewport",
       {
         viewportHeight: 900,
-        viewportWidth: 600,
+        viewportWidth: 599,
       },
       () => {
         cy.mount(<Default columns={columns} rows={rows} />);

--- a/packages/core/src/__tests__/__e2e__/grid-layout/GridLayout.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/grid-layout/GridLayout.cy.tsx
@@ -15,7 +15,7 @@ describe("GIVEN a Grid", () => {
   describe("WHEN no props are provided", () => {
     it("THEN it should render 12 columns and 1 row", () => {
       // Passing empty columns to test default, as example needs columns for accessibility purposes.
-      cy.mount(<Default columns={{}} />);
+      cy.mount(<Default columns={undefined} />);
 
       cy.get(".saltGridLayout")
         .invoke("css", "grid-template-columns")

--- a/packages/core/src/breakpoints/Breakpoints.tsx
+++ b/packages/core/src/breakpoints/Breakpoints.tsx
@@ -1,17 +1,15 @@
-export type Breakpoints = {
+export interface Breakpoints {
   xs: number;
   sm: number;
   md: number;
   lg: number;
   xl: number;
-};
+}
 
-const breakpoints: Breakpoints = {
+export const DEFAULT_BREAKPOINTS: Breakpoints = {
   xs: 0,
   sm: 600,
   md: 960,
   lg: 1280,
   xl: 1920,
 };
-
-export const DEFAULT_BREAKPOINTS = breakpoints;

--- a/packages/core/src/breakpoints/index.ts
+++ b/packages/core/src/breakpoints/index.ts
@@ -1,1 +1,2 @@
 export * from "./Breakpoints";
+export * from "./BreakpointProvider";

--- a/packages/core/src/flex-item/FlexItem.tsx
+++ b/packages/core/src/flex-item/FlexItem.tsx
@@ -2,14 +2,15 @@ import { forwardRef, ElementType, ReactElement, CSSProperties } from "react";
 import {
   makePrefixer,
   ResponsiveProp,
-  useResponsiveProp,
   PolymorphicComponentPropWithRef,
   PolymorphicRef,
+  resolveResponsiveValue,
 } from "../utils";
 import flexItemCss from "./FlexItem.css";
 import { clsx } from "clsx";
 import { useWindow } from "@salt-ds/window";
 import { useComponentCssInjection } from "@salt-ds/styles";
+import { useMatchedBreakpointContext } from "../salt-provider/matched-breakpoints";
 
 const withBaseName = makePrefixer("saltFlexItem");
 export const FLEX_ITEM_ALIGNMENTS = [
@@ -69,11 +70,12 @@ export const FlexItem: FlexItemComponent = forwardRef(
       css: flexItemCss,
       window: targetWindow,
     });
+    const { matchedBreakpoints } = useMatchedBreakpointContext();
 
     const Component = as || "div";
-    const flexItemShrink = useResponsiveProp(shrink, 1);
-    const flexItemGrow = useResponsiveProp(grow, 0);
-    const flexItemBasis = useResponsiveProp(basis, "auto");
+    const flexItemShrink = resolveResponsiveValue(shrink, matchedBreakpoints);
+    const flexItemGrow = resolveResponsiveValue(grow, matchedBreakpoints);
+    const flexItemBasis = resolveResponsiveValue(basis, matchedBreakpoints);
 
     const itemStyle = {
       "--saltFlexItem-alignment": align,

--- a/packages/core/src/flex-item/FlexItem.tsx
+++ b/packages/core/src/flex-item/FlexItem.tsx
@@ -10,7 +10,7 @@ import flexItemCss from "./FlexItem.css";
 import { clsx } from "clsx";
 import { useWindow } from "@salt-ds/window";
 import { useComponentCssInjection } from "@salt-ds/styles";
-import { useMatchedBreakpointContext } from "../salt-provider/matched-breakpoints";
+import { useBreakpoint } from "../breakpoints";
 
 const withBaseName = makePrefixer("saltFlexItem");
 export const FLEX_ITEM_ALIGNMENTS = [
@@ -70,7 +70,7 @@ export const FlexItem: FlexItemComponent = forwardRef(
       css: flexItemCss,
       window: targetWindow,
     });
-    const { matchedBreakpoints } = useMatchedBreakpointContext();
+    const { matchedBreakpoints } = useBreakpoint();
 
     const Component = as || "div";
     const flexItemShrink = resolveResponsiveValue(shrink, matchedBreakpoints);

--- a/packages/core/src/flex-layout/FlexLayout.css
+++ b/packages/core/src/flex-layout/FlexLayout.css
@@ -1,13 +1,11 @@
 /* Default variables applied to the root element */
 .saltFlexLayout {
-  --flexLayout-gap-multiplier: var(--flexLayout-gap-density-multiplier, 3);
   --flexLayout-layout-display: flex;
   --flexLayout-direction: row;
   --flexLayout-wrap: nowrap;
   --flexLayout-justify: flex-start;
   --flexLayout-align: stretch;
   --flexLayout-separator: var(--salt-size-border);
-  --flexLayout-gap: calc(var(--salt-size-unit) * var(--flexLayout-gap-multiplier));
 }
 
 /* Style applied to the root element */

--- a/packages/core/src/flex-layout/FlexLayout.tsx
+++ b/packages/core/src/flex-layout/FlexLayout.tsx
@@ -12,7 +12,7 @@ import {
 import flexLayoutCss from "./FlexLayout.css";
 import { useWindow } from "@salt-ds/window";
 import { useComponentCssInjection } from "@salt-ds/styles";
-import { useMatchedBreakpointContext } from "../salt-provider/matched-breakpoints";
+import { useBreakpoint } from "../breakpoints";
 
 const withBaseName = makePrefixer("saltFlexLayout");
 
@@ -106,7 +106,7 @@ export const FlexLayout: FlexLayoutComponent = forwardRef(
     const Component = as || "div";
     const separatorAlignment = separators === true ? "center" : separators;
 
-    const { matchedBreakpoints } = useMatchedBreakpointContext();
+    const { matchedBreakpoints } = useBreakpoint();
     const flexGap = resolveResponsiveValue(gap, matchedBreakpoints);
     const flexDirection = resolveResponsiveValue(direction, matchedBreakpoints);
     const flexWrap = resolveResponsiveValue(wrap, matchedBreakpoints);

--- a/packages/core/src/grid-item/GridItem.tsx
+++ b/packages/core/src/grid-item/GridItem.tsx
@@ -4,13 +4,14 @@ import { clsx } from "clsx";
 import {
   makePrefixer,
   ResponsiveProp,
-  useResponsiveProp,
   PolymorphicRef,
   PolymorphicComponentPropWithRef,
+  resolveResponsiveValue,
 } from "../utils";
 import gridItemCss from "./GridItem.css";
 import { useWindow } from "@salt-ds/window";
 import { useComponentCssInjection } from "@salt-ds/styles";
+import { useMatchedBreakpointContext } from "../salt-provider/matched-breakpoints";
 
 export const GRID_ALIGNMENT_BASE = [
   "start",
@@ -62,8 +63,8 @@ export const GridItem: GridItemComponent = forwardRef(
       as,
       children,
       className,
-      colSpan,
-      rowSpan,
+      colSpan = "auto",
+      rowSpan = "auto",
       horizontalAlignment = "stretch",
       verticalAlignment = "stretch",
       style,
@@ -78,10 +79,12 @@ export const GridItem: GridItemComponent = forwardRef(
       window: targetWindow,
     });
 
-    const Component = as || "div";
-    const gridItemColSpan = useResponsiveProp(colSpan, "auto");
+    const { matchedBreakpoints } = useMatchedBreakpointContext();
 
-    const gridItemRowSpan = useResponsiveProp(rowSpan, "auto");
+    const Component = as || "div";
+    const gridItemColSpan = resolveResponsiveValue(colSpan, matchedBreakpoints);
+
+    const gridItemRowSpan = resolveResponsiveValue(rowSpan, matchedBreakpoints);
 
     const gridColumnStart = gridItemColSpan
       ? `span ${gridItemColSpan}`

--- a/packages/core/src/grid-item/GridItem.tsx
+++ b/packages/core/src/grid-item/GridItem.tsx
@@ -11,7 +11,7 @@ import {
 import gridItemCss from "./GridItem.css";
 import { useWindow } from "@salt-ds/window";
 import { useComponentCssInjection } from "@salt-ds/styles";
-import { useMatchedBreakpointContext } from "../salt-provider/matched-breakpoints";
+import { useBreakpoint } from "../breakpoints";
 
 export const GRID_ALIGNMENT_BASE = [
   "start",
@@ -79,7 +79,7 @@ export const GridItem: GridItemComponent = forwardRef(
       window: targetWindow,
     });
 
-    const { matchedBreakpoints } = useMatchedBreakpointContext();
+    const { matchedBreakpoints } = useBreakpoint();
 
     const Component = as || "div";
     const gridItemColSpan = resolveResponsiveValue(colSpan, matchedBreakpoints);

--- a/packages/core/src/grid-layout/GridLayout.css
+++ b/packages/core/src/grid-layout/GridLayout.css
@@ -1,21 +1,10 @@
-.salt-density-touch {
-  --gridLayout-gap-density-multiplier: 2;
-}
-
-/* Default variables applied to the root element */
-.saltGridLayout {
-  --gridLayout-space: 1fr;
-  --gridLayout-rowGap: var(--gridLayout-gap-density-multiplier, 3);
-  --gridLayout-columnGap: var(--gridLayout-gap-density-multiplier, 3);
-}
-
 /* Style applied to the root element */
 .saltGridLayout {
   display: grid;
-  column-gap: calc(var(--salt-size-unit) * var(--gridLayout-columnGap));
-  row-gap: calc(var(--salt-size-unit) * var(--gridLayout-rowGap));
-  grid-template-columns: repeat(var(--gridLayout-columns), var(--gridLayout-space));
-  grid-template-rows: repeat(var(--gridLayout-rows), var(--gridLayout-space));
+  column-gap: var(--gridLayout-columnGap);
+  row-gap: var(--gridLayout-rowGap);
+  grid-template-columns: var(--gridLayout-columns);
+  grid-template-rows: var(--gridLayout-rows);
   grid-auto-columns: auto;
   grid-auto-rows: auto;
 }

--- a/packages/core/src/grid-layout/GridLayout.tsx
+++ b/packages/core/src/grid-layout/GridLayout.tsx
@@ -12,7 +12,7 @@ import {
 import gridLayoutCss from "./GridLayout.css";
 import { useWindow } from "@salt-ds/window";
 import { useComponentCssInjection } from "@salt-ds/styles";
-import { useMatchedBreakpointContext } from "../salt-provider/matched-breakpoints";
+import { useBreakpoint } from "../breakpoints";
 
 export type GridLayoutProps<T extends ElementType> =
   PolymorphicComponentPropWithRef<
@@ -87,7 +87,7 @@ export const GridLayout: GridLayoutComponent = forwardRef(
     });
     const Component = as || "div";
 
-    const { matchedBreakpoints } = useMatchedBreakpointContext();
+    const { matchedBreakpoints } = useBreakpoint();
 
     const gridColumns = resolveResponsiveValue(columns, matchedBreakpoints);
 

--- a/packages/core/src/grid-layout/GridLayout.tsx
+++ b/packages/core/src/grid-layout/GridLayout.tsx
@@ -4,14 +4,15 @@ import { clsx } from "clsx";
 import {
   makePrefixer,
   ResponsiveProp,
-  useResponsiveProp,
   PolymorphicComponentPropWithRef,
   PolymorphicRef,
+  resolveResponsiveValue,
 } from "../utils";
 
 import gridLayoutCss from "./GridLayout.css";
 import { useWindow } from "@salt-ds/window";
 import { useComponentCssInjection } from "@salt-ds/styles";
+import { useMatchedBreakpointContext } from "../salt-provider/matched-breakpoints";
 
 export type GridLayoutProps<T extends ElementType> =
   PolymorphicComponentPropWithRef<
@@ -20,23 +21,23 @@ export type GridLayoutProps<T extends ElementType> =
       /**
        * Number of columns to be displayed. Defaults to 12
        */
-      columns?: ResponsiveProp<number>;
+      columns?: ResponsiveProp<number | string>;
       /**
        * Number of rows to be displayed. Defaults to 1
        */
-      rows?: ResponsiveProp<number>;
+      rows?: ResponsiveProp<number | string>;
       /**
        * Defines the size of the gutter between the columns and the rows by setting a density multiplier. Defaults to 3
        */
-      gap?: ResponsiveProp<number>;
+      gap?: ResponsiveProp<number | string>;
       /**
        * Defines the size of the gutter between the columns by setting a density multiplier. Defaults to 1
        */
-      columnGap?: ResponsiveProp<number>;
+      columnGap?: ResponsiveProp<number | string>;
       /**
        * Defines the size of the gutter between the rows by setting a density multiplier. Defaults to 1
        */
-      rowGap?: ResponsiveProp<number>;
+      rowGap?: ResponsiveProp<number | string>;
     }
   >;
 
@@ -46,6 +47,22 @@ type GridLayoutComponent = <T extends ElementType = "div">(
 
 const withBaseName = makePrefixer("saltGridLayout");
 
+function parseGridValue(value: number | string | undefined) {
+  if (value === undefined || typeof value === "string") {
+    return value;
+  }
+
+  return `repeat(${value}, 1fr)`;
+}
+
+function parseSpacing(value: number | string | undefined) {
+  if (value === undefined || typeof value === "string") {
+    return value;
+  }
+
+  return `calc(var(--salt-spacing-100) * ${value})`;
+}
+
 export const GridLayout: GridLayoutComponent = forwardRef(
   <T extends ElementType = "div">(
     {
@@ -54,7 +71,7 @@ export const GridLayout: GridLayoutComponent = forwardRef(
       className,
       columns = 12,
       rows = 1,
-      gap,
+      gap = 3,
       columnGap,
       rowGap,
       style,
@@ -70,22 +87,24 @@ export const GridLayout: GridLayoutComponent = forwardRef(
     });
     const Component = as || "div";
 
-    const gridColumns = useResponsiveProp(columns, 12);
+    const { matchedBreakpoints } = useMatchedBreakpointContext();
 
-    const gridRows = useResponsiveProp(rows, 1);
+    const gridColumns = resolveResponsiveValue(columns, matchedBreakpoints);
 
-    const gridGap = useResponsiveProp(gap, 3);
+    const gridRows = resolveResponsiveValue(rows, matchedBreakpoints);
 
-    const gridColumnGap = useResponsiveProp(columnGap, 3);
+    const gridGap = resolveResponsiveValue(gap, matchedBreakpoints);
 
-    const gridRowGap = useResponsiveProp(rowGap, 3);
+    const gridColumnGap = resolveResponsiveValue(columnGap, matchedBreakpoints);
+
+    const gridRowGap = resolveResponsiveValue(rowGap, matchedBreakpoints);
 
     const gridLayoutStyles = {
       ...style,
-      "--gridLayout-columns": gridColumns,
-      "--gridLayout-rows": gridRows,
-      "--gridLayout-columnGap": gridColumnGap ?? gridGap,
-      "--gridLayout-rowGap": gridRowGap ?? gridGap,
+      "--gridLayout-columns": parseGridValue(gridColumns),
+      "--gridLayout-rows": parseGridValue(gridRows),
+      "--gridLayout-columnGap": parseSpacing(gridColumnGap ?? gridGap),
+      "--gridLayout-rowGap": parseSpacing(gridRowGap ?? gridGap),
     };
 
     return (

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,11 @@ export * from "./badge";
 export * from "./banner";
 export * from "./border-item";
 export * from "./border-layout";
-export * from "./breakpoints";
+export {
+  type Breakpoints,
+  DEFAULT_BREAKPOINTS,
+  useBreakpoint,
+} from "./breakpoints";
 export * from "./button";
 export * from "./card";
 export * from "./checkbox";

--- a/packages/core/src/salt-provider/SaltProvider.tsx
+++ b/packages/core/src/salt-provider/SaltProvider.tsx
@@ -20,6 +20,10 @@ import {
   StyleInjectionProvider,
 } from "@salt-ds/styles";
 import { UNSTABLE_Corner } from "../theme/Corner";
+import {
+  MatchedBreakpointProvider,
+  useMatchedBreakpoints,
+} from "./matched-breakpoints";
 
 export const DEFAULT_DENSITY = "medium";
 
@@ -264,12 +268,16 @@ function InternalSaltProvider({
     corner,
   ]);
 
+  const matchedBreakpoints = useMatchedBreakpoints(breakpoints);
+
   const saltProvider = (
     <DensityContext.Provider value={density}>
       <ThemeContext.Provider value={themeContextValue}>
-        <BreakpointContext.Provider value={breakpoints}>
-          <ViewportProvider>{themedChildren}</ViewportProvider>
-        </BreakpointContext.Provider>
+        <MatchedBreakpointProvider matchedBreakpoints={matchedBreakpoints}>
+          <BreakpointContext.Provider value={breakpoints}>
+            <ViewportProvider>{themedChildren}</ViewportProvider>
+          </BreakpointContext.Provider>
+        </MatchedBreakpointProvider>
       </ThemeContext.Provider>
     </DensityContext.Provider>
   );

--- a/packages/core/src/salt-provider/SaltProvider.tsx
+++ b/packages/core/src/salt-provider/SaltProvider.tsx
@@ -8,7 +8,12 @@ import React, {
   useMemo,
 } from "react";
 import { AriaAnnouncerProvider } from "../aria-announcer";
-import { Breakpoints, DEFAULT_BREAKPOINTS } from "../breakpoints";
+import {
+  Breakpoints,
+  DEFAULT_BREAKPOINTS,
+  BreakpointProvider,
+  useMatchedBreakpoints,
+} from "../breakpoints";
 import { Density, Mode, ThemeName } from "../theme";
 import { ViewportProvider } from "../viewport";
 import { useIsomorphicLayoutEffect } from "../utils";
@@ -20,10 +25,6 @@ import {
   StyleInjectionProvider,
 } from "@salt-ds/styles";
 import { UNSTABLE_Corner } from "../theme/Corner";
-import {
-  MatchedBreakpointProvider,
-  useMatchedBreakpoints,
-} from "./matched-breakpoints";
 
 export const DEFAULT_DENSITY = "medium";
 
@@ -273,11 +274,11 @@ function InternalSaltProvider({
   const saltProvider = (
     <DensityContext.Provider value={density}>
       <ThemeContext.Provider value={themeContextValue}>
-        <MatchedBreakpointProvider matchedBreakpoints={matchedBreakpoints}>
+        <BreakpointProvider matchedBreakpoints={matchedBreakpoints}>
           <BreakpointContext.Provider value={breakpoints}>
             <ViewportProvider>{themedChildren}</ViewportProvider>
           </BreakpointContext.Provider>
-        </MatchedBreakpointProvider>
+        </BreakpointProvider>
       </ThemeContext.Provider>
     </DensityContext.Provider>
   );

--- a/packages/core/src/salt-provider/matched-breakpoints.tsx
+++ b/packages/core/src/salt-provider/matched-breakpoints.tsx
@@ -1,0 +1,84 @@
+import { createContext, useIsomorphicLayoutEffect } from "../utils";
+import { ReactNode, useContext, useState } from "react";
+import { Breakpoints } from "../breakpoints";
+
+type Breakpoint = keyof Breakpoints;
+
+interface MatchedBreakpointContext {
+  matchedBreakpoints: Breakpoint[];
+}
+
+const Context = createContext<MatchedBreakpointContext>(
+  "MatchedBreakpointContext",
+  { matchedBreakpoints: [] }
+);
+
+interface MatchedBreakpointProviderProps {
+  children?: ReactNode;
+  matchedBreakpoints: Breakpoint[];
+}
+
+export function MatchedBreakpointProvider(
+  props: MatchedBreakpointProviderProps
+) {
+  const { children, matchedBreakpoints } = props;
+
+  return (
+    <Context.Provider value={{ matchedBreakpoints }}>
+      {children}
+    </Context.Provider>
+  );
+}
+
+export function useMatchedBreakpoints(breakpoints: Breakpoints): Breakpoint[] {
+  const entries = Object.entries(breakpoints).sort(([, a], [, b]) => b - a);
+  const queries = entries.map(([, value]) => `(min-width: ${value}px)`);
+  const supportsMatchMedia =
+    typeof window !== "undefined" && typeof window.matchMedia === "function";
+
+  const [matchedBreakpoints, setMatchedBreakpoints] = useState<Breakpoint[]>(
+    []
+  );
+
+  useIsomorphicLayoutEffect(() => {
+    if (!supportsMatchMedia) {
+      return;
+    }
+
+    const matchers = queries.map((query, index) => {
+      const mq = window.matchMedia(query);
+      const bp = entries[index][0] as Breakpoint;
+
+      return {
+        mq,
+        handler: () => {
+          if (mq.matches) {
+            setMatchedBreakpoints((prev) => prev.concat([bp]));
+          } else {
+            setMatchedBreakpoints((prev) =>
+              prev.filter((breakpoint) => breakpoint !== bp)
+            );
+          }
+        },
+      };
+    });
+
+    matchers.forEach(({ mq, handler }) => {
+      handler();
+      mq.addEventListener("change", handler);
+    });
+
+    return () => {
+      matchers.forEach(({ mq, handler }) => {
+        mq.removeEventListener("change", handler);
+      });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [supportsMatchMedia]);
+
+  return matchedBreakpoints;
+}
+
+export function useMatchedBreakpointContext(): MatchedBreakpointContext {
+  return useContext(Context);
+}

--- a/packages/core/src/stack-layout/StackLayout.css
+++ b/packages/core/src/stack-layout/StackLayout.css
@@ -1,8 +1,6 @@
 /* Default variables applied to the root element */
 .saltStackLayout {
-  --stackLayout-gap-multiplier: var(--stackLayout-gap-density-multiplier, 3);
   --stackLayout-separator-weight: var(--salt-size-border, 1);
-  --stackLayout-gap: calc(var(--salt-size-unit) * var(--stackLayout-gap-multiplier));
 }
 
 .saltStackLayout-separator > * {

--- a/packages/core/src/stack-layout/StackLayout.tsx
+++ b/packages/core/src/stack-layout/StackLayout.tsx
@@ -16,7 +16,7 @@ import { clsx } from "clsx";
 import stackLayoutCss from "./StackLayout.css";
 import { useWindow } from "@salt-ds/window";
 import { useComponentCssInjection } from "@salt-ds/styles";
-import { useMatchedBreakpointContext } from "../salt-provider/matched-breakpoints";
+import { useBreakpoint } from "../breakpoints";
 
 const withBaseName = makePrefixer("saltStackLayout");
 
@@ -75,7 +75,7 @@ export const StackLayout: StackLayoutComponent = forwardRef(
       window: targetWindow,
     });
 
-    const { matchedBreakpoints } = useMatchedBreakpointContext();
+    const { matchedBreakpoints } = useBreakpoint();
 
     const flexGap = resolveResponsiveValue(gap, matchedBreakpoints);
     const separatorAlignment = separators === true ? "center" : separators;

--- a/packages/core/src/stack-layout/StackLayout.tsx
+++ b/packages/core/src/stack-layout/StackLayout.tsx
@@ -9,13 +9,14 @@ import {
   makePrefixer,
   PolymorphicComponentPropWithRef,
   PolymorphicRef,
+  resolveResponsiveValue,
   ResponsiveProp,
-  useResponsiveProp,
 } from "../utils";
 import { clsx } from "clsx";
 import stackLayoutCss from "./StackLayout.css";
 import { useWindow } from "@salt-ds/window";
 import { useComponentCssInjection } from "@salt-ds/styles";
+import { useMatchedBreakpointContext } from "../salt-provider/matched-breakpoints";
 
 const withBaseName = makePrefixer("saltStackLayout");
 
@@ -46,13 +47,21 @@ type StackLayoutComponent = <T extends ElementType = "div">(
   props: StackLayoutProps<T>
 ) => ReactElement | null;
 
+function parseSpacing(value: number | string | undefined) {
+  if (value === undefined || typeof value === "string") {
+    return value;
+  }
+
+  return `calc(var(--salt-spacing-100) * ${value})`;
+}
+
 export const StackLayout: StackLayoutComponent = forwardRef(
   <T extends ElementType = "div">(
     {
       children,
       className,
       direction = "column",
-      gap,
+      gap = 3,
       separators,
       style,
       ...rest
@@ -66,19 +75,21 @@ export const StackLayout: StackLayoutComponent = forwardRef(
       window: targetWindow,
     });
 
-    const flexGap = useResponsiveProp(gap, 3);
+    const { matchedBreakpoints } = useMatchedBreakpointContext();
+
+    const flexGap = resolveResponsiveValue(gap, matchedBreakpoints);
     const separatorAlignment = separators === true ? "center" : separators;
-    const flexDirection = useResponsiveProp(direction, "column");
+    const flexDirection = resolveResponsiveValue(direction, matchedBreakpoints);
     const stackLayoutStyles = {
       ...style,
-      "--stackLayout-gap-multiplier": flexGap,
+      "--stackLayout-gap": parseSpacing(flexGap),
     };
     return (
       <FlexLayout
         className={clsx(
           withBaseName(),
-          withBaseName(flexDirection),
           {
+            [withBaseName(flexDirection ?? "")]: flexDirection,
             [withBaseName("separator")]: !!separatorAlignment,
             [separatorAlignment
               ? withBaseName(`separator-${separatorAlignment}`)

--- a/packages/core/src/utils/useResponsiveProp.ts
+++ b/packages/core/src/utils/useResponsiveProp.ts
@@ -109,3 +109,24 @@ export const useResponsiveProp = <T>(
   }
   return value;
 };
+
+function isBreakpointProp<T>(
+  value: ResponsiveProp<T>
+): value is BreakpointProp<T> {
+  return typeof value === "object" && !Array.isArray(value);
+}
+
+export function resolveResponsiveValue<Value>(
+  value: ResponsiveProp<Value>,
+  matchedBreakpoints: (keyof Breakpoints)[]
+) {
+  if (value && isBreakpointProp(value)) {
+    for (const breakpoint of matchedBreakpoints) {
+      if (value[breakpoint] != null) {
+        return value[breakpoint];
+      }
+    }
+    return undefined;
+  }
+  return value;
+}

--- a/packages/core/stories/grid-layout/grid-layout.stories.tsx
+++ b/packages/core/stories/grid-layout/grid-layout.stories.tsx
@@ -228,3 +228,8 @@ const GridLayoutNestedExample: StoryFn<typeof GridLayout> = () => {
 };
 export const Nested = GridLayoutNestedExample.bind({});
 Nested.args = {};
+
+export const ColumnTemplate = Template.bind({});
+ColumnTemplate.args = {
+  columns: "1fr auto 200px",
+};

--- a/site/docs/components/grid-layout/examples.mdx
+++ b/site/docs/components/grid-layout/examples.mdx
@@ -83,4 +83,12 @@ Use the `verticalAlignment` and `horizontalAlignment` props to control the posit
 
 </LivePreview>
 
+<LivePreview componentName="grid-layout" exampleName="CustomColumnsAndRows">
+
+## Custom columns and rows
+
+The `columns` and `rows` props allow you to pass a string to define a column or row template.
+
+</LivePreview>
+
 </LivePreviewControls>

--- a/site/src/examples/grid-layout/CustomColumnsAndRows.tsx
+++ b/site/src/examples/grid-layout/CustomColumnsAndRows.tsx
@@ -1,0 +1,13 @@
+import { ReactElement } from "react";
+import { GridLayout, GridItem } from "@salt-ds/core";
+import styles from "./index.module.css";
+
+export const CustomColumnsAndRows = (): ReactElement => (
+  <GridLayout columns="1fr 1fr 2fr" rows={3}>
+    {Array.from({ length: 9 }, (_, index) => (
+      <GridItem key={index} className={styles.gridItem}>
+        <p>{index + 1}</p>
+      </GridItem>
+    ))}
+  </GridLayout>
+);

--- a/site/src/examples/grid-layout/index.ts
+++ b/site/src/examples/grid-layout/index.ts
@@ -1,4 +1,5 @@
 export * from "./ColumnsAndRows";
+export * from "./CustomColumnsAndRows";
 export * from "./Default";
 export * from "./ExpandingAndCollapsingItems";
 export * from "./PositioningItems";


### PR DESCRIPTION
This moves us from using ViewportProvider and other logic when dealing with responsive props. Now at a provider level we calculate the matching breakpoints that allow components to get that list and check their props against them. 

There's a bit of duplication with how the breakpoints are handled in the code now, but the idea is that this would become the sole way and ViewportProvider should be removed in the next major.