### PR TITLE
Fix usage of deprecated tokens in core and data-grid

### DIFF
--- a/.changeset/violet-news-beg.md
+++ b/.changeset/violet-news-beg.md
@@ -1,0 +1,6 @@
+---
+"@salt-ds/core": patch
+"@salt-ds/data-grid": patch
+---
+
+Fixed deprecated `--salt-size-accent` references to `--salt-size-bar`. Fixed deprecated `--salt-size-unit` references to `--salt-spacing-100`.

--- a/packages/core/src/button/Button.css
+++ b/packages/core/src/button/Button.css
@@ -52,7 +52,7 @@
   line-height: var(--saltButton-lineHeight, var(--salt-text-lineHeight));
   letter-spacing: var(--saltButton-letterSpacing, var(--salt-text-action-letterSpacing));
   text-transform: var(--saltButton-textTransform, var(--salt-text-action-textTransform));
-  padding: 0 var(--saltButton-padding, var(--salt-size-unit));
+  padding: 0 var(--saltButton-padding, var(--salt-spacing-100));
   margin: var(--saltButton-margin, 0);
   height: var(--saltButton-height, var(--salt-size-base));
   min-width: var(--saltButton-minWidth, unset);

--- a/packages/core/src/card/Card.css
+++ b/packages/core/src/card/Card.css
@@ -32,7 +32,7 @@
 .saltCard-accentBottom::after {
   left: calc(-1 * var(--salt-size-border));
   bottom: calc(-1 * var(--salt-size-border));
-  height: var(--salt-size-accent);
+  height: var(--salt-size-bar);
   width: calc(100% + calc(2 * var(--salt-size-border)));
 }
 
@@ -41,14 +41,14 @@
   left: calc(-1 * var(--salt-size-border));
   top: calc(-1 * var(--salt-size-border));
   height: calc(100% + calc(2 * var(--salt-size-border)));
-  width: var(--salt-size-accent);
+  width: var(--salt-size-bar);
 }
 
 /* Styles applied to Card if `accent="top"` */
 .saltCard-accentTop::after {
   left: calc(-1 * var(--salt-size-border));
   top: calc(-1 * var(--salt-size-border));
-  height: var(--salt-size-accent);
+  height: var(--salt-size-bar);
   width: calc(100% + calc(2 * var(--salt-size-border)));
 }
 
@@ -57,7 +57,7 @@
   right: calc(-1 * var(--salt-size-border));
   top: calc(-1 * var(--salt-size-border));
   height: calc(100% + calc(2 * var(--salt-size-border)));
-  width: var(--salt-size-accent);
+  width: var(--salt-size-bar);
 }
 
 /*

--- a/packages/core/src/dialog/DialogHeader.css
+++ b/packages/core/src/dialog/DialogHeader.css
@@ -30,7 +30,7 @@
   top: 0;
   left: 0;
   bottom: var(--salt-spacing-100);
-  width: var(--salt-size-accent);
+  width: var(--salt-size-bar);
   background: var(--salt-accent-background);
 }
 

--- a/packages/core/src/interactable-card/InteractableCard.css
+++ b/packages/core/src/interactable-card/InteractableCard.css
@@ -35,7 +35,7 @@
 .saltInteractableCard-accentBottom::after {
   left: calc(-1 * var(--salt-size-border));
   bottom: calc(-1 * var(--salt-size-border));
-  height: var(--salt-size-accent);
+  height: var(--salt-size-bar);
   width: calc(100% + calc(2 * var(--salt-size-border)));
 }
 
@@ -44,14 +44,14 @@
   left: calc(-1 * var(--salt-size-border));
   top: calc(-1 * var(--salt-size-border));
   height: calc(100% + calc(2 * var(--salt-size-border)));
-  width: var(--salt-size-accent);
+  width: var(--salt-size-bar);
 }
 
 /* Styles applied to InteractableCard if `accent="top"` */
 .saltInteractableCard-accentTop::after {
   left: calc(-1 * var(--salt-size-border));
   top: calc(-1 * var(--salt-size-border));
-  height: var(--salt-size-accent);
+  height: var(--salt-size-bar);
   width: calc(100% + calc(2 * var(--salt-size-border)));
 }
 
@@ -60,7 +60,7 @@
   right: calc(-1 * var(--salt-size-border));
   top: calc(-1 * var(--salt-size-border));
   height: calc(100% + calc(2 * var(--salt-size-border)));
-  width: var(--salt-size-accent);
+  width: var(--salt-size-bar);
 }
 
 /* Styles applied to InteractableCard on focus */

--- a/packages/core/src/link-card/LinkCard.css
+++ b/packages/core/src/link-card/LinkCard.css
@@ -35,7 +35,7 @@
 .saltLinkCard-accentBottom::after {
   left: calc(-1 * var(--salt-size-border));
   bottom: calc(-1 * var(--salt-size-border));
-  height: var(--salt-size-accent);
+  height: var(--salt-size-bar);
   width: calc(100% + calc(2 * var(--salt-size-border)));
 }
 
@@ -44,14 +44,14 @@
   left: calc(-1 * var(--salt-size-border));
   top: calc(-1 * var(--salt-size-border));
   height: calc(100% + calc(2 * var(--salt-size-border)));
-  width: var(--salt-size-accent);
+  width: var(--salt-size-bar);
 }
 
 /* Styles applied to LinkCard if `accent="top"` */
 .saltLinkCard-accentTop::after {
   left: calc(-1 * var(--salt-size-border));
   top: calc(-1 * var(--salt-size-border));
-  height: var(--salt-size-accent);
+  height: var(--salt-size-bar);
   width: calc(100% + calc(2 * var(--salt-size-border)));
 }
 
@@ -60,7 +60,7 @@
   right: calc(-1 * var(--salt-size-border));
   top: calc(-1 * var(--salt-size-border));
   height: calc(100% + calc(2 * var(--salt-size-border)));
-  width: var(--salt-size-accent);
+  width: var(--salt-size-bar);
 }
 
 /* Styles applied to LinkCard on focus */

--- a/packages/core/src/tooltip/Tooltip.css
+++ b/packages/core/src/tooltip/Tooltip.css
@@ -20,7 +20,7 @@
   font-weight: var(--saltTooltip-fontWeight, var(--salt-text-fontWeight));
   line-height: var(--saltTooltip-lineHeight, var(--salt-text-lineHeight));
   max-width: var(--saltTooltip-maxWidth, 230px);
-  padding: var(--saltTooltip-padding, var(--salt-size-unit));
+  padding: var(--saltTooltip-padding, var(--salt-spacing-100));
   position: relative;
   text-align: var(--saltTooltip-textAlign, left);
   z-index: var(--tooltip-zIndex);

--- a/packages/core/stories/card/card.stories.css
+++ b/packages/core/stories/card/card.stories.css
@@ -6,9 +6,9 @@
 .card-demo-inner-content {
   display: grid;
   grid-template-columns: repeat(2, auto);
-  gap: calc(var(--salt-size-unit) * 2);
+  gap: var(--salt-spacing-200);
   align-items: center;
-  padding: var(--salt-size-unit) var(--salt-size-unit) 0 var(--salt-size-unit);
+  padding: var(--salt-spacing-100) var(--salt-spacing-100) 0 var(--salt-spacing-100);
 }
 
 .salt-density-high {

--- a/packages/core/stories/layout/layout.stories.css
+++ b/packages/core/stories/layout/layout.stories.css
@@ -66,7 +66,7 @@
 }
 
 .flow-layout-container {
-  padding: calc(var(--salt-size-unit) * 2) var(--salt-size-container-spacing);
+  padding: var(--salt-spacing-200) var(--salt-size-container-spacing);
   background-color: var(--salt-container-secondary-background);
 }
 
@@ -90,20 +90,20 @@
 }
 
 .border-layout-custom-form .saltInputLegacy-suffixContainer {
-  margin-right: var(--salt-size-unit);
+  margin-right: var(--salt-spacing-100);
 }
 
 .border-layout-switch-container {
-  padding: var(--salt-size-unit);
+  padding: var(--salt-spacing-100);
 }
 
 .border-layout-button-container,
 .flow-layout-form-container {
-  padding: calc(var(--salt-size-unit) * 2) var(--salt-size-container-spacing);
+  padding: var(--salt-spacing-200) var(--salt-size-container-spacing);
 }
 
 .border-layout-pill {
-  margin: calc(var(--salt-size-unit) * 2) var(--salt-size-container-spacing);
+  margin: calc(var(--salt-spacing-100) * 2) var(--salt-size-container-spacing);
   --saltPill-background: var(--salt-status-success-foreground);
   --saltPill-text-color: var(--salt-color-white);
   --saltPill-borderRadius: 10px;
@@ -115,7 +115,7 @@
   z-index: 10;
 }
 .border-layout-form-footer button {
-  margin-top: calc(var(--salt-size-unit) * 2);
+  margin-top: calc(var(--salt-spacing-100) * 2);
   margin-bottom: 16px;
 }
 
@@ -135,7 +135,7 @@
 .border-layout-contacts-footer {
   border-top: 1px solid;
   border-color: var(--salt-separable-secondary-borderColor);
-  padding: var(--salt-size-container-spacing) 0 calc(var(--salt-size-unit) * 2) 0;
+  padding: var(--salt-size-container-spacing) 0 calc(var(--salt-spacing-100) * 2) 0;
   text-align: center;
 }
 
@@ -198,7 +198,7 @@
 
 .parent-child-composite-empty-container {
   width: 12px;
-  padding: var(--salt-size-unit);
+  padding: var(--salt-spacing-100);
 }
 
 .parent-child-composite-container p,
@@ -221,7 +221,7 @@
 
 .parent-child-composite-empty-container {
   width: 12px;
-  padding: var(--salt-size-unit);
+  padding: var(--salt-spacing-100);
 }
 
 .parent-child-composite-container p,

--- a/packages/core/stories/overlay/overlay.stories.css
+++ b/packages/core/stories/overlay/overlay.stories.css
@@ -1,5 +1,5 @@
 .content-heading {
-  margin: 0 0 calc(var(--salt-size-unit) / 2);
+  margin: 0 0 var(--salt-spacing-50);
   font-size: var(--salt-text-fontSize);
   font-weight: var(--salt-text-fontWeight-strong);
 }

--- a/packages/data-grid/src/Grid.css
+++ b/packages/data-grid/src/Grid.css
@@ -65,7 +65,7 @@
 
   --grid-headerColumnSeparator-color: var(--saltGrid-headerColumnSeparator-color, var(--salt-separable-tertiary-borderColor));
   --grid-headerRowSeparator-color: var(--saltGrid-headerRowSeparator-color, var(--salt-separable-primary-borderColor));
-  --grid-headerRowSeparator-gap: var(--saltGrid-headerRowSeparator-gap, var(--salt-size-unit));
+  --grid-headerRowSeparator-gap: var(--saltGrid-headerRowSeparator-gap, var(--salt-spacing-100));
   --grid-headerRowSeparator-height: var(--saltGrid-headerRowSeparator-height, 1px);
   --grid-groupHeaderRowSeparator-color: var(--saltGrid-groupHeaderRowSeparator-color, var(--salt-separable-tertiary-borderColor));
 

--- a/packages/data-grid/src/HeaderCell.css
+++ b/packages/data-grid/src/HeaderCell.css
@@ -27,11 +27,11 @@
 }
 
 .saltGridHeaderCell-alignRightWithSortOrder {
-  margin-left: calc(var(--salt-size-unit) * 2);
+  margin-left: var(--salt-spacing-100);
 }
 
 .saltGridHeaderCell-alignLeftWithSortOrder {
-  margin-right: calc(var(--salt-size-unit) * 2);
+  margin-right: var(--salt-spacing-200);
 }
 
 .saltGridHeaderCell-autosizeContainer {
@@ -103,7 +103,7 @@
 
 .saltGridHeaderCell-sortingIcon {
   display: flex;
-  margin: 0 var(--salt-size-unit);
+  margin: 0 var(--salt-spacing-100);
 }
 
 .saltGridHeaderCell-sortingIconStart {

--- a/packages/data-grid/stories/grid.stories.css
+++ b/packages/data-grid/stories/grid.stories.css
@@ -83,7 +83,7 @@
 }
 
 .customHeaderText {
-  padding-left: var(--salt-size-unit);
+  padding-left: var(--salt-spacing-100);
   flex-grow: 1;
 }
 
@@ -96,5 +96,5 @@
 }
 
 .treeNodeName {
-  padding-left: var(--salt-size-unit);
+  padding-left: var(--salt-spacing-100);
 }

--- a/packages/theme/css/deprecated/foundations.css
+++ b/packages/theme/css/deprecated/foundations.css
@@ -72,33 +72,33 @@
 }
 
 .salt-density-high {
-  --salt-size-unit: calc(var(--salt-size-basis-unit) * 1);
+  --salt-size-unit: calc(var(--salt-size-basis-unit) * 1); /* Use --salt-spacing-100 */
   --salt-size-compact: calc(var(--salt-size-basis-unit) * 1.5);
-  --salt-size-accent: calc(var(--salt-size-basis-unit) * 0.5);
+  --salt-size-accent: calc(var(--salt-size-basis-unit) * 0.5); /* Use --salt-size-bar */
   --salt-icon-size-base: 10px; /* Use --salt-size-icon */
   --salt-icon-size-status-adornment: 6px; /* Use --salt-size-adornment */
 }
 
 .salt-density-medium {
-  --salt-size-unit: calc(var(--salt-size-basis-unit) * 2);
+  --salt-size-unit: calc(var(--salt-size-basis-unit) * 2); /* Use --salt-spacing-100 */
   --salt-size-compact: calc(var(--salt-size-basis-unit) * 2);
-  --salt-size-accent: calc(var(--salt-size-basis-unit) * 1);
+  --salt-size-accent: calc(var(--salt-size-basis-unit) * 1); /* Use --salt-size-bar */
   --salt-icon-size-base: 12px; /* Use --salt-size-icon */
   --salt-icon-size-status-adornment: 8px; /* Use --salt-size-adornment */
 }
 
 .salt-density-low {
-  --salt-size-unit: calc(var(--salt-size-basis-unit) * 3);
+  --salt-size-unit: calc(var(--salt-size-basis-unit) * 3); /* Use --salt-spacing-100 */
   --salt-size-compact: calc(var(--salt-size-basis-unit) * 2.5);
-  --salt-size-accent: calc(var(--salt-size-basis-unit) * 1.5);
+  --salt-size-accent: calc(var(--salt-size-basis-unit) * 1.5); /* Use --salt-size-bar */
   --salt-icon-size-base: 14px; /* Use --salt-size-icon */
   --salt-icon-size-status-adornment: 10px; /* Use --salt-size-adornment */
 }
 
 .salt-density-touch {
-  --salt-size-unit: calc(var(--salt-size-basis-unit) * 4);
+  --salt-size-unit: calc(var(--salt-size-basis-unit) * 4); /* Use --salt-spacing-100 */
   --salt-size-compact: calc(var(--salt-size-basis-unit) * 3);
-  --salt-size-accent: calc(var(--salt-size-basis-unit) * 2);
+  --salt-size-accent: calc(var(--salt-size-basis-unit) * 2); /* Use --salt-size-bar */
   --salt-icon-size-base: 16px; /* Use --salt-size-icon */
   --salt-icon-size-status-adornment: 12px; /* Use --salt-size-adornment */
 }


### PR DESCRIPTION
Noticed in Card that size-accent was being used which is deprecated; checked spec and it should be size-bar

This was the corresponding replacement noted in changelog - I changed all size-accent used in core components/data-grid to use size-bar

Also went ahead and changed size-unit (deprecated) to spacing-100 or corresponding multiplier