### PR TITLE
Remove switch from ag grid theme snapshots

### DIFF
--- a/packages/ag-grid-theme/stories/examples/CheckboxSelection.tsx
+++ b/packages/ag-grid-theme/stories/examples/CheckboxSelection.tsx
@@ -1,29 +1,25 @@
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
-import { StackLayout } from "@salt-ds/core";
-import dataGridExampleData from "../dependencies/dataGridExampleData";
-import dataGridExampleColumns from "../dependencies/dataGridExampleColumns";
-import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
+import dataGridExampleColumns from "../dependencies/dataGridExampleColumns";
+import dataGridExampleData from "../dependencies/dataGridExampleData";
+import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 
 const CheckboxSelection = (props: AgGridReactProps) => {
-  const { switcher, themeName } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { agGridProps, containerProps } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
   });
 
   return (
-    <StackLayout gap={4}>
-      {switcher}
-      <div {...containerProps}>
-        <AgGridReact
-          {...agGridProps}
-          {...props}
-          rowData={dataGridExampleData}
-          columnDefs={dataGridExampleColumns}
-          rowSelection="multiple"
-        />
-      </div>
-    </StackLayout>
+    <div {...containerProps}>
+      <AgGridReact
+        {...agGridProps}
+        {...props}
+        rowData={dataGridExampleData}
+        columnDefs={dataGridExampleColumns}
+        rowSelection="multiple"
+      />
+    </div>
   );
 };
 

--- a/packages/ag-grid-theme/stories/examples/Coloration.tsx
+++ b/packages/ag-grid-theme/stories/examples/Coloration.tsx
@@ -1,28 +1,24 @@
-import { StackLayout } from "@salt-ds/core";
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
-import dataGridExampleData from "../dependencies/dataGridExampleData";
-import dataGridExampleColumnsColoration from "../dependencies/dataGridExampleColumnsColoration";
-import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
+import dataGridExampleColumnsColoration from "../dependencies/dataGridExampleColumnsColoration";
+import dataGridExampleData from "../dependencies/dataGridExampleData";
+import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 
 const Coloration = (props: AgGridReactProps) => {
-  const { themeName, switcher } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { agGridProps, containerProps } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
   });
 
   return (
-    <StackLayout gap={4}>
-      {switcher}
-      <div {...containerProps}>
-        <AgGridReact
-          {...agGridProps}
-          {...props}
-          columnDefs={dataGridExampleColumnsColoration}
-          rowData={dataGridExampleData}
-        />
-      </div>
-    </StackLayout>
+    <div {...containerProps}>
+      <AgGridReact
+        {...agGridProps}
+        {...props}
+        columnDefs={dataGridExampleColumnsColoration}
+        rowData={dataGridExampleData}
+      />
+    </div>
   );
 };
 

--- a/packages/ag-grid-theme/stories/examples/ColumnGroup.tsx
+++ b/packages/ag-grid-theme/stories/examples/ColumnGroup.tsx
@@ -1,34 +1,28 @@
+import { ColDef, ColGroupDef } from "ag-grid-community";
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
-import { StackLayout } from "@salt-ds/core";
+import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 import dataGridExampleData from "../dependencies/dataGridExampleData";
 import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
-import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
-import { ColDef, ColGroupDef } from "ag-grid-community";
 
 const ColumnGroup = (props: AgGridReactProps) => {
-  const { themeName, switcher } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { agGridProps, containerProps } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
   });
 
   return (
-    <StackLayout gap={4}>
-      {switcher}
-      <div {...containerProps}>
-        <AgGridReact
-          {...agGridProps}
-          {...props}
-          rowData={dataGridExampleData}
-          columnDefs={columnsWithGrouping("US States")}
-        />
-      </div>
-    </StackLayout>
+    <div {...containerProps}>
+      <AgGridReact
+        {...agGridProps}
+        {...props}
+        rowData={dataGridExampleData}
+        columnDefs={columnsWithGrouping("US States")}
+      />
+    </div>
   );
 };
 
-const columnsWithGrouping = (
-  groupName: string
-): Array<ColGroupDef | ColDef> => [
+const columnsWithGrouping = (groupName: string): (ColGroupDef | ColDef)[] => [
   {
     headerName: "",
     field: "on",

--- a/packages/ag-grid-theme/stories/examples/ColumnSpanning.tsx
+++ b/packages/ag-grid-theme/stories/examples/ColumnSpanning.tsx
@@ -1,28 +1,24 @@
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
-import { StackLayout } from "@salt-ds/core";
-import dataGridExampleData from "../dependencies/dataGridExampleData";
-import columnSpanningExampleColumns from "../dependencies/columnSpanningExampleColumns";
-import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
+import columnSpanningExampleColumns from "../dependencies/columnSpanningExampleColumns";
+import dataGridExampleData from "../dependencies/dataGridExampleData";
+import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 
 const ColumnSpanning = (props: AgGridReactProps) => {
-  const { themeName, switcher } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { agGridProps, containerProps } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
   });
 
   return (
-    <StackLayout gap={4}>
-      {switcher}
-      <div {...containerProps}>
-        <AgGridReact
-          {...agGridProps}
-          {...props}
-          columnDefs={columnSpanningExampleColumns}
-          rowData={dataGridExampleData}
-        />
-      </div>
-    </StackLayout>
+    <div {...containerProps}>
+      <AgGridReact
+        {...agGridProps}
+        {...props}
+        columnDefs={columnSpanningExampleColumns}
+        rowData={dataGridExampleData}
+      />
+    </div>
   );
 };
 

--- a/packages/ag-grid-theme/stories/examples/ContextMenu.tsx
+++ b/packages/ag-grid-theme/stories/examples/ContextMenu.tsx
@@ -1,15 +1,14 @@
 import { GetContextMenuItemsParams } from "ag-grid-community";
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
-import { StackLayout } from "@salt-ds/core";
-import dataGridExampleData from "../dependencies/dataGridExampleData";
+import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 import dataGridExampleColumns from "../dependencies/dataGridExampleColumns";
-import windows from "../dependencies/windows.png";
+import dataGridExampleData from "../dependencies/dataGridExampleData";
 import mac from "../dependencies/mac.png";
 import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
-import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
+import windows from "../dependencies/windows.png";
 
 const ContextMenu = (props: AgGridReactProps) => {
-  const { themeName, switcher } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { agGridProps, containerProps } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
   });
@@ -145,19 +144,16 @@ const ContextMenu = (props: AgGridReactProps) => {
   };
 
   return (
-    <StackLayout gap={4}>
-      {switcher}
-      <div {...containerProps}>
-        <AgGridReact
-          allowContextMenuWithControlKey
-          getContextMenuItems={getContextMenuItems}
-          columnDefs={dataGridExampleColumns}
-          rowData={dataGridExampleData}
-          {...agGridProps}
-          {...props}
-        />
-      </div>
-    </StackLayout>
+    <div {...containerProps}>
+      <AgGridReact
+        allowContextMenuWithControlKey
+        getContextMenuItems={getContextMenuItems}
+        columnDefs={dataGridExampleColumns}
+        rowData={dataGridExampleData}
+        {...agGridProps}
+        {...props}
+      />
+    </div>
   );
 };
 

--- a/packages/ag-grid-theme/stories/examples/CustomFilter.tsx
+++ b/packages/ag-grid-theme/stories/examples/CustomFilter.tsx
@@ -8,7 +8,7 @@ import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 
 const CustomFilter = (props: AgGridReactProps) => {
-  const { switcher, themeName } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
 
   const [hasSavedState, setHasSavedState] = useState(true);
   const { api, isGridReady, agGridProps, containerProps } = useAgGridHelpers({
@@ -80,7 +80,6 @@ const CustomFilter = (props: AgGridReactProps) => {
 
   return (
     <StackLayout gap={4}>
-      {switcher}
       <FlowLayout gap={2}>
         <Button onClick={handlePopLt100kClick}>Pop &gt; 100k</Button>
         <Button onClick={handlePopMt100kClick}>Pop &lt; 100k</Button>

--- a/packages/ag-grid-theme/stories/examples/Default.tsx
+++ b/packages/ag-grid-theme/stories/examples/Default.tsx
@@ -1,46 +1,42 @@
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
-import { StackLayout } from "@salt-ds/core";
+import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 import dataGridExampleData from "../dependencies/dataGridExampleData";
 import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
-import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 
 const Default = (props: AgGridReactProps) => {
-  const { themeName, switcher } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { agGridProps, containerProps } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
   });
 
   return (
-    <StackLayout gap={4}>
-      {switcher}
-      <div {...containerProps}>
-        <AgGridReact
-          columnDefs={[
-            {
-              headerName: "Name",
-              field: "name",
-              filterParams: {
-                buttons: ["reset", "apply"],
-              },
-              editable: false,
+    <div {...containerProps}>
+      <AgGridReact
+        columnDefs={[
+          {
+            headerName: "Name",
+            field: "name",
+            filterParams: {
+              buttons: ["reset", "apply"],
             },
-            {
-              headerName: "Code",
-              field: "code",
-            },
-            {
-              headerName: "Capital",
-              field: "capital",
-            },
-          ]}
-          rowData={dataGridExampleData}
-          rowSelection="single"
-          enableRangeSelection={true}
-          {...agGridProps}
-          {...props}
-        />
-      </div>
-    </StackLayout>
+            editable: false,
+          },
+          {
+            headerName: "Code",
+            field: "code",
+          },
+          {
+            headerName: "Capital",
+            field: "capital",
+          },
+        ]}
+        rowData={dataGridExampleData}
+        rowSelection="single"
+        enableRangeSelection={true}
+        {...agGridProps}
+        {...props}
+      />
+    </div>
   );
 };
 

--- a/packages/ag-grid-theme/stories/examples/DragRowOrder.tsx
+++ b/packages/ag-grid-theme/stories/examples/DragRowOrder.tsx
@@ -1,30 +1,26 @@
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
-import { StackLayout } from "@salt-ds/core";
+import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 import dataGridExampleData from "../dependencies/dataGridExampleData";
 import rowDragColumns from "../dependencies/rowDragColumns";
 import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
-import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 
 const DragRowOrder = (props: AgGridReactProps) => {
-  const { switcher, themeName } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { agGridProps, containerProps } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
   });
 
   return (
-    <StackLayout gap={4}>
-      {switcher}
-      <div {...containerProps}>
-        <AgGridReact
-          animateRows
-          rowDragManaged
-          {...agGridProps}
-          {...props}
-          columnDefs={rowDragColumns}
-          rowData={dataGridExampleData}
-        />
-      </div>
-    </StackLayout>
+    <div {...containerProps}>
+      <AgGridReact
+        animateRows
+        rowDragManaged
+        {...agGridProps}
+        {...props}
+        columnDefs={rowDragColumns}
+        rowData={dataGridExampleData}
+      />
+    </div>
   );
 };
 

--- a/packages/ag-grid-theme/stories/examples/FloatingFilter.tsx
+++ b/packages/ag-grid-theme/stories/examples/FloatingFilter.tsx
@@ -1,29 +1,25 @@
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
-import { StackLayout } from "@salt-ds/core";
-import dataGridExampleData from "../dependencies/dataGridExampleData";
-import customFilterExampleColumns from "../dependencies/customFilterExampleColumns";
-import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
+import customFilterExampleColumns from "../dependencies/customFilterExampleColumns";
+import dataGridExampleData from "../dependencies/dataGridExampleData";
+import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 
 const FloatingFilter = (props: AgGridReactProps) => {
-  const { switcher, themeName } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { agGridProps, containerProps } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
   });
 
   return (
-    <StackLayout gap={4}>
-      {switcher}
-      <div {...containerProps}>
-        <AgGridReact
-          defaultColDef={{ floatingFilter: true }}
-          columnDefs={customFilterExampleColumns}
-          rowData={dataGridExampleData}
-          {...agGridProps}
-          {...props}
-        />
-      </div>
-    </StackLayout>
+    <div {...containerProps}>
+      <AgGridReact
+        defaultColDef={{ floatingFilter: true }}
+        columnDefs={customFilterExampleColumns}
+        rowData={dataGridExampleData}
+        {...agGridProps}
+        {...props}
+      />
+    </div>
   );
 };
 

--- a/packages/ag-grid-theme/stories/examples/HDCompact.tsx
+++ b/packages/ag-grid-theme/stories/examples/HDCompact.tsx
@@ -1,8 +1,8 @@
+import { SaltProvider } from "@salt-ds/core";
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
-import { FlexLayout, SaltProvider, StackLayout } from "@salt-ds/core";
+import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 import dataGridExampleColumns from "../dependencies/dataGridExampleColumns";
 import dataGridExampleData from "../dependencies/dataGridExampleData";
-import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 
 const statusBar = {
@@ -18,7 +18,7 @@ const statusBar = {
 };
 
 const HDCompact = (props: AgGridReactProps) => {
-  const { switcher, themeName } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { agGridProps, containerProps } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
     compact: true,
@@ -27,29 +27,26 @@ const HDCompact = (props: AgGridReactProps) => {
 
   return (
     <SaltProvider density="high">
-      <StackLayout gap={4}>
-        <FlexLayout direction="row">{switcher}</FlexLayout>
-        <div {...containerProps}>
-          <AgGridReact
-            columnDefs={dataGridExampleColumns}
-            rowData={dataGridExampleData}
-            statusBar={statusBar}
-            rowSelection="multiple"
-            {...agGridProps}
-            {...props}
-            enableRangeSelection={true}
-            onFirstDataRendered={(params) => {
-              params.api.forEachNode((node, index) => {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                if (node.data && index < 3) {
-                  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                  node.setSelected(true);
-                }
-              });
-            }}
-          />
-        </div>
-      </StackLayout>
+      <div {...containerProps}>
+        <AgGridReact
+          columnDefs={dataGridExampleColumns}
+          rowData={dataGridExampleData}
+          statusBar={statusBar}
+          rowSelection="multiple"
+          {...agGridProps}
+          {...props}
+          enableRangeSelection={true}
+          onFirstDataRendered={(params) => {
+            params.api.forEachNode((node, index) => {
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+              if (node.data && index < 3) {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                node.setSelected(true);
+              }
+            });
+          }}
+        />
+      </div>
     </SaltProvider>
   );
 };

--- a/packages/ag-grid-theme/stories/examples/Icons.tsx
+++ b/packages/ag-grid-theme/stories/examples/Icons.tsx
@@ -1,12 +1,12 @@
 import { useComponentCssInjection } from "@salt-ds/styles";
 import { useWindow } from "@salt-ds/window";
-import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
-import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 import saltStyles from "../../css/_export-salt-icons.module.scss";
 import uitkStyles from "../../css/_export-uitk-icons.module.scss";
+import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
+import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 
-import iconCss from "./Icons.css";
 import { CSSProperties } from "react";
+import iconCss from "./Icons.css";
 
 const Icons = () => {
   const targetWindow = useWindow();
@@ -15,7 +15,7 @@ const Icons = () => {
     css: iconCss,
     window: targetWindow,
   });
-  const { switcher, themeName } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
 
   const { containerProps } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
@@ -24,7 +24,6 @@ const Icons = () => {
 
   return (
     <>
-      {switcher}
       {Object.keys(styles).map((key) => {
         if (styles[key].startsWith('"')) {
           return (

--- a/packages/ag-grid-theme/stories/examples/InfiniteScroll.tsx
+++ b/packages/ag-grid-theme/stories/examples/InfiniteScroll.tsx
@@ -1,10 +1,10 @@
-import { useEffect } from "react";
+import { Spinner } from "@salt-ds/core";
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
-import { Spinner, StackLayout } from "@salt-ds/core";
+import { useEffect } from "react";
+import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 import dataGridExampleData from "../dependencies/dataGridExampleData";
 import dataGridInfiniteScrollExampleColumns from "../dependencies/dataGridInfiniteScrollExampleColumns";
 import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
-import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 
 const generateData = function generateData<T extends { name: string }>(
   lst: T[]
@@ -23,7 +23,7 @@ const generateData = function generateData<T extends { name: string }>(
 const dataSourceRows = generateData(dataGridExampleData);
 
 const InfiniteScroll = (props: AgGridReactProps) => {
-  const { switcher, themeName } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { isGridReady, agGridProps, containerProps, api } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
   });
@@ -46,19 +46,16 @@ const InfiniteScroll = (props: AgGridReactProps) => {
   }, [api, isGridReady]);
 
   return (
-    <StackLayout gap={4}>
-      {switcher}
-      <div {...containerProps}>
-        <AgGridReact
-          {...agGridProps}
-          {...props}
-          columnDefs={dataGridInfiniteScrollExampleColumns}
-          rowModelType="infinite"
-          infiniteInitialRowCount={100}
-          components={infiniteScrollComponents}
-        />
-      </div>
-    </StackLayout>
+    <div {...containerProps}>
+      <AgGridReact
+        {...agGridProps}
+        {...props}
+        columnDefs={dataGridInfiniteScrollExampleColumns}
+        rowModelType="infinite"
+        infiniteInitialRowCount={100}
+        components={infiniteScrollComponents}
+      />
+    </div>
   );
 };
 

--- a/packages/ag-grid-theme/stories/examples/LoadingOverlay.tsx
+++ b/packages/ag-grid-theme/stories/examples/LoadingOverlay.tsx
@@ -16,24 +16,21 @@ const CustomOverlay = () => (
 );
 
 const LoadingOverlay = (props: AgGridReactProps) => {
-  const { switcher, themeName } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { agGridProps, containerProps } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
   });
 
   return (
-    <StackLayout gap={4}>
-      {switcher}
-      <div {...containerProps} tabIndex={-1}>
-        <AgGridReact
-          {...agGridProps}
-          {...props}
-          columnDefs={dataGridExampleColumns}
-          rowData={null}
-          loadingOverlayComponent={CustomOverlay}
-        />
-      </div>
-    </StackLayout>
+    <div {...containerProps} tabIndex={-1}>
+      <AgGridReact
+        {...agGridProps}
+        {...props}
+        columnDefs={dataGridExampleColumns}
+        rowData={null}
+        loadingOverlayComponent={CustomOverlay}
+      />
+    </div>
   );
 };
 

--- a/packages/ag-grid-theme/stories/examples/MasterDetail.tsx
+++ b/packages/ag-grid-theme/stories/examples/MasterDetail.tsx
@@ -1,13 +1,12 @@
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
 import { useCallback, useRef } from "react";
-import { StackLayout } from "@salt-ds/core";
-import columnDefs from "../dependencies/masterDetailExampleData";
-import rowData from "../dependencies/dataGridExampleData";
-import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
+import rowData from "../dependencies/dataGridExampleData";
+import columnDefs from "../dependencies/masterDetailExampleData";
+import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 
 const MasterDetail = (props: AgGridReactProps) => {
-  const { switcher, themeName } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { agGridProps, containerProps } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
   });
@@ -24,26 +23,23 @@ const MasterDetail = (props: AgGridReactProps) => {
   }, []);
 
   return (
-    <StackLayout gap={4}>
-      {switcher}
-      <div {...containerProps}>
-        <AgGridReact
-          ref={gridRef}
-          columnDefs={columnDefs}
-          detailCellRendererParams={{
-            detailGridOptions: { columnDefs },
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
-            getDetailRowData: (params: any) => params.successCallback(rowData),
-          }}
-          masterDetail={true}
-          detailRowHeight={300}
-          rowData={rowData}
-          {...agGridProps}
-          {...props}
-          onFirstDataRendered={onFirstDataRendered}
-        />
-      </div>
-    </StackLayout>
+    <div {...containerProps}>
+      <AgGridReact
+        ref={gridRef}
+        columnDefs={columnDefs}
+        detailCellRendererParams={{
+          detailGridOptions: { columnDefs },
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
+          getDetailRowData: (params: any) => params.successCallback(rowData),
+        }}
+        masterDetail={true}
+        detailRowHeight={300}
+        rowData={rowData}
+        {...agGridProps}
+        {...props}
+        onFirstDataRendered={onFirstDataRendered}
+      />
+    </div>
   );
 };
 

--- a/packages/ag-grid-theme/stories/examples/NoDataOverlay.tsx
+++ b/packages/ag-grid-theme/stories/examples/NoDataOverlay.tsx
@@ -20,7 +20,7 @@ const CustomDialog = () => {
     >
       <DialogHeader status="error" header="Can`t move file" />
       <DialogContent>
-        You don't have permission to move or delete this file.
+        You don&#39;t have permission to move or delete this file.
       </DialogContent>
       <DialogActions>
         <Button>Help Desk</Button>
@@ -31,23 +31,20 @@ const CustomDialog = () => {
 };
 
 const NoDataOverlay = (props: AgGridReactProps) => {
-  const { switcher, themeName } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { agGridProps, containerProps } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
   });
 
   return (
-    <div>
-      {switcher}
-      <div style={{ height: 800, width: 800 }} {...containerProps}>
-        <AgGridReact
-          {...agGridProps}
-          {...props}
-          columnDefs={dataGridExampleColumns}
-          rowData={[]}
-          noRowsOverlayComponent={CustomDialog}
-        />
-      </div>
+    <div style={{ height: 800, width: 800 }} {...containerProps}>
+      <AgGridReact
+        {...agGridProps}
+        {...props}
+        columnDefs={dataGridExampleColumns}
+        rowData={[]}
+        noRowsOverlayComponent={CustomDialog}
+      />
     </div>
   );
 };

--- a/packages/ag-grid-theme/stories/examples/Pagination.tsx
+++ b/packages/ag-grid-theme/stories/examples/Pagination.tsx
@@ -1,9 +1,8 @@
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
-import { StackLayout } from "@salt-ds/core";
-import dataGridExampleData from "../dependencies/dataGridExampleData";
-import dataGridExampleColumns from "../dependencies/dataGridExampleColumns";
-import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
+import dataGridExampleColumns from "../dependencies/dataGridExampleColumns";
+import dataGridExampleData from "../dependencies/dataGridExampleData";
+import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 
 const generateData = (states: typeof dataGridExampleData) =>
   states.reduce((result, row) => {
@@ -16,25 +15,22 @@ const generateData = (states: typeof dataGridExampleData) =>
   }, [] as typeof dataGridExampleData);
 
 const PagedGrid = (props: AgGridReactProps) => {
-  const { switcher, themeName } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { agGridProps, containerProps } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
   });
 
   return (
-    <StackLayout gap={4}>
-      {switcher}
-      <div {...containerProps}>
-        <AgGridReact
-          columnDefs={dataGridExampleColumns}
-          pagination
-          paginationPageSize={100}
-          rowData={generateData(dataGridExampleData)}
-          {...agGridProps}
-          {...props}
-        />
-      </div>
-    </StackLayout>
+    <div {...containerProps}>
+      <AgGridReact
+        columnDefs={dataGridExampleColumns}
+        pagination
+        paginationPageSize={100}
+        rowData={generateData(dataGridExampleData)}
+        {...agGridProps}
+        {...props}
+      />
+    </div>
   );
 };
 

--- a/packages/ag-grid-theme/stories/examples/ParentChildRows.tsx
+++ b/packages/ag-grid-theme/stories/examples/ParentChildRows.tsx
@@ -1,36 +1,32 @@
-import { StackLayout } from "@salt-ds/core";
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
+import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 import parentChildExampleColumns from "../dependencies/parentChildExampleColumns";
 import parentChildExampleData from "../dependencies/parentChildExampleData";
 import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
-import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 
 const ParentChildRows = (props: AgGridReactProps) => {
-  const { switcher, themeName } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { agGridProps, containerProps } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
   });
 
   return (
-    <StackLayout gap={4}>
-      {switcher}
-      <div {...containerProps}>
-        <AgGridReact
-          animateRows
-          treeData
-          {...agGridProps}
-          {...props}
-          columnDefs={parentChildExampleColumns}
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          getDataPath={(data: any) => {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
-            return data.orgHierarchy;
-          }}
-          groupDefaultExpanded={-1}
-          rowData={parentChildExampleData}
-        />
-      </div>
-    </StackLayout>
+    <div {...containerProps}>
+      <AgGridReact
+        animateRows
+        treeData
+        {...agGridProps}
+        {...props}
+        columnDefs={parentChildExampleColumns}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        getDataPath={(data: any) => {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
+          return data.orgHierarchy;
+        }}
+        groupDefaultExpanded={-1}
+        rowData={parentChildExampleData}
+      />
+    </div>
   );
 };
 

--- a/packages/ag-grid-theme/stories/examples/PinnedRows.tsx
+++ b/packages/ag-grid-theme/stories/examples/PinnedRows.tsx
@@ -1,9 +1,8 @@
-import { StackLayout } from "@salt-ds/core";
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
-import dataGridExampleData from "../dependencies/dataGridExampleData";
-import dataGridExampleColumns from "../dependencies/dataGridExampleColumns";
-import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
+import dataGridExampleColumns from "../dependencies/dataGridExampleColumns";
+import dataGridExampleData from "../dependencies/dataGridExampleData";
+import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 
 const sumReducer = (acc: number, n: number) => acc + n;
 const minReducer = (acc: number, n: number) => (n < acc ? n : acc);
@@ -49,7 +48,7 @@ const PinnedRowsExample = function PinnedRowsExample({
   showHeader = true,
   ...rest
 }: PinnedRowsExampleProps) {
-  const { switcher, themeName } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { agGridProps, containerProps } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
   });
@@ -81,19 +80,16 @@ const PinnedRowsExample = function PinnedRowsExample({
   const pinnedBottomRowData = showFooter ? footerRow() : undefined;
   const pinnedTopRowData = showHeader ? getHeaderRow() : undefined;
   return (
-    <StackLayout gap={4}>
-      {switcher}
-      <div {...containerProps}>
-        <AgGridReact
-          {...agGridProps}
-          {...rest}
-          columnDefs={columnDefs}
-          rowData={rowData}
-          pinnedBottomRowData={pinnedBottomRowData}
-          pinnedTopRowData={pinnedTopRowData}
-        />
-      </div>
-    </StackLayout>
+    <div {...containerProps}>
+      <AgGridReact
+        {...agGridProps}
+        {...rest}
+        columnDefs={columnDefs}
+        rowData={rowData}
+        pinnedBottomRowData={pinnedBottomRowData}
+        pinnedTopRowData={pinnedTopRowData}
+      />
+    </div>
   );
 };
 

--- a/packages/ag-grid-theme/stories/examples/RowGroupPanel.tsx
+++ b/packages/ag-grid-theme/stories/examples/RowGroupPanel.tsx
@@ -1,32 +1,28 @@
-import { StackLayout } from "@salt-ds/core";
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
+import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 import dataGridExampleData from "../dependencies/dataGridExampleData";
 import dataGridExampleRowGroupPanel from "../dependencies/dataGridExampleRowGroupPanel";
 import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
-import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 
 const RowGroupPanel = (props: AgGridReactProps) => {
-  const { switcher, themeName } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { agGridProps, containerProps } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
   });
 
   return (
-    <StackLayout gap={4}>
-      {switcher}
-      <div {...containerProps}>
-        <AgGridReact
-          columnDefs={dataGridExampleRowGroupPanel}
-          defaultColDef={{
-            enableRowGroup: true,
-          }}
-          rowData={dataGridExampleData}
-          rowGroupPanelShow="always"
-          {...agGridProps}
-          {...props}
-        />
-      </div>
-    </StackLayout>
+    <div {...containerProps}>
+      <AgGridReact
+        columnDefs={dataGridExampleRowGroupPanel}
+        defaultColDef={{
+          enableRowGroup: true,
+        }}
+        rowData={dataGridExampleData}
+        rowGroupPanelShow="always"
+        {...agGridProps}
+        {...props}
+      />
+    </div>
   );
 };
 

--- a/packages/ag-grid-theme/stories/examples/RowGrouping.tsx
+++ b/packages/ag-grid-theme/stories/examples/RowGrouping.tsx
@@ -1,28 +1,24 @@
-import { StackLayout } from "@salt-ds/core";
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
+import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 import dataGridExampleData from "../dependencies/dataGridExampleData";
 import dataGridExampleRowGrouping from "../dependencies/dataGridExampleRowGrouping";
 import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
-import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 
 const RowGrouping = (props: AgGridReactProps) => {
-  const { switcher, themeName } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { agGridProps, containerProps } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
   });
 
   return (
-    <StackLayout gap={4}>
-      {switcher}
-      <div {...containerProps}>
-        <AgGridReact
-          columnDefs={dataGridExampleRowGrouping}
-          rowData={dataGridExampleData}
-          {...agGridProps}
-          {...props}
-        />
-      </div>
-    </StackLayout>
+    <div {...containerProps}>
+      <AgGridReact
+        columnDefs={dataGridExampleRowGrouping}
+        rowData={dataGridExampleData}
+        {...agGridProps}
+        {...props}
+      />
+    </div>
   );
 };
 

--- a/packages/ag-grid-theme/stories/examples/SortAndFilter.tsx
+++ b/packages/ag-grid-theme/stories/examples/SortAndFilter.tsx
@@ -1,4 +1,3 @@
-import { StackLayout } from "@salt-ds/core";
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
 import { useEffect } from "react";
 import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
@@ -29,7 +28,7 @@ const colDef = [
 ];
 
 const SortAndFilter = (props: AgGridReactProps) => {
-  const { switcher, themeName } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { agGridProps, containerProps, isGridReady, api } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
   });
@@ -53,17 +52,14 @@ const SortAndFilter = (props: AgGridReactProps) => {
   }, [api, isGridReady]);
 
   return (
-    <StackLayout gap={4}>
-      {switcher}
-      <div {...containerProps}>
-        <AgGridReact
-          columnDefs={colDef}
-          rowData={rowData}
-          {...agGridProps}
-          {...props}
-        />
-      </div>
-    </StackLayout>
+    <div {...containerProps}>
+      <AgGridReact
+        columnDefs={colDef}
+        rowData={rowData}
+        {...agGridProps}
+        {...props}
+      />
+    </div>
   );
 };
 

--- a/packages/ag-grid-theme/stories/examples/StatusBar.tsx
+++ b/packages/ag-grid-theme/stories/examples/StatusBar.tsx
@@ -1,9 +1,9 @@
 import { StackLayout, Text } from "@salt-ds/core";
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
-import dataGridExampleData from "../dependencies/dataGridExampleData";
-import dataGridExampleColumns from "../dependencies/dataGridExampleColumns";
-import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
+import dataGridExampleColumns from "../dependencies/dataGridExampleColumns";
+import dataGridExampleData from "../dependencies/dataGridExampleData";
+import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 
 const statusBar = {
   statusPanels: [
@@ -18,37 +18,34 @@ const statusBar = {
 };
 
 const StatusBar = (props: AgGridReactProps) => {
-  const { switcher, themeName } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { agGridProps, containerProps } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
   });
 
   return (
-    <StackLayout gap={4}>
-      {switcher}
-      <StackLayout gap={2}>
-        <Text>Select rows to enable status bar display</Text>
-        <div {...containerProps}>
-          <AgGridReact
-            enableRangeSelection
-            rowSelection="multiple"
-            statusBar={statusBar}
-            columnDefs={dataGridExampleColumns}
-            rowData={dataGridExampleData}
-            {...agGridProps}
-            {...props}
-            onFirstDataRendered={(params) => {
-              params.api.forEachNode((node, index) => {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                if (node.data && index < 3) {
-                  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                  node.setSelected(true);
-                }
-              });
-            }}
-          />
-        </div>
-      </StackLayout>
+    <StackLayout gap={2}>
+      <Text>Select rows to enable status bar display</Text>
+      <div {...containerProps}>
+        <AgGridReact
+          enableRangeSelection
+          rowSelection="multiple"
+          statusBar={statusBar}
+          columnDefs={dataGridExampleColumns}
+          rowData={dataGridExampleData}
+          {...agGridProps}
+          {...props}
+          onFirstDataRendered={(params) => {
+            params.api.forEachNode((node, index) => {
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+              if (node.data && index < 3) {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                node.setSelected(true);
+              }
+            });
+          }}
+        />
+      </div>
     </StackLayout>
   );
 };

--- a/packages/ag-grid-theme/stories/examples/WrappedCell.tsx
+++ b/packages/ag-grid-theme/stories/examples/WrappedCell.tsx
@@ -1,14 +1,8 @@
-import { ChangeEvent, useEffect, useState } from "react";
+import { Checkbox, FlexItem, StackLayout, useDensity } from "@salt-ds/core";
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
-import {
-  StackLayout,
-  FlexItem,
-  FlexLayout,
-  Checkbox,
-  useDensity,
-} from "@salt-ds/core";
-import dataGridExampleData from "../dependencies/dataGridExampleData";
+import { ChangeEvent, useEffect, useState } from "react";
 import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
+import dataGridExampleData from "../dependencies/dataGridExampleData";
 import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 
 const longNamesData = dataGridExampleData.map((d) => ({
@@ -18,7 +12,7 @@ const longNamesData = dataGridExampleData.map((d) => ({
 
 const WrappedCell = (props: AgGridReactProps) => {
   const [compact, setCompact] = useState(false);
-  const { switcher, themeName } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { api, agGridProps, containerProps, isGridReady } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
     compact,
@@ -39,17 +33,14 @@ const WrappedCell = (props: AgGridReactProps) => {
 
   return (
     <StackLayout gap={4}>
-      <FlexLayout direction="row">
-        {switcher}
-        <FlexItem>
-          <Checkbox
-            checked={compact && density === "high"}
-            label="Compact (for high density only)"
-            onChange={handleCompactChange}
-            disabled={density !== "high"}
-          />
-        </FlexItem>
-      </FlexLayout>
+      <FlexItem>
+        <Checkbox
+          checked={compact && density === "high"}
+          label="Compact (for high density only)"
+          onChange={handleCompactChange}
+          disabled={density !== "high"}
+        />
+      </FlexItem>
       <div {...containerProps} style={{ height: "400px", width: "500px" }}>
         <AgGridReact
           columnDefs={[

--- a/packages/ag-grid-theme/stories/examples/WrappedHeader.tsx
+++ b/packages/ag-grid-theme/stories/examples/WrappedHeader.tsx
@@ -1,15 +1,9 @@
-import { ChangeEvent, useEffect, useState } from "react";
+import { Checkbox, FlexItem, StackLayout, useDensity } from "@salt-ds/core";
 import { AgGridReact, AgGridReactProps } from "ag-grid-react";
-import {
-  StackLayout,
-  FlexItem,
-  FlexLayout,
-  Checkbox,
-  useDensity,
-} from "@salt-ds/core";
+import { ChangeEvent, useEffect, useState } from "react";
+import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 import dataGridExampleColumnsWrap from "../dependencies/dataGridExampleColumnsWrap";
 import dataGridExampleData from "../dependencies/dataGridExampleData";
-import { useAgGridThemeSwitcher } from "../dependencies/ThemeSwitcher";
 import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 
 const statusBar = {
@@ -26,7 +20,7 @@ const statusBar = {
 
 const WrappedHeader = (props: AgGridReactProps) => {
   const [compact, setCompact] = useState(false);
-  const { switcher, themeName } = useAgGridThemeSwitcher();
+  const { themeName } = useAgGridThemeSwitcher();
   const { api, agGridProps, containerProps, isGridReady } = useAgGridHelpers({
     agThemeName: `ag-theme-${themeName}`,
     compact,
@@ -47,17 +41,14 @@ const WrappedHeader = (props: AgGridReactProps) => {
 
   return (
     <StackLayout gap={4}>
-      <FlexLayout direction="row">
-        {switcher}
-        <FlexItem>
-          <Checkbox
-            checked={compact && density === "high"}
-            label="Compact (for high density only)"
-            onChange={handleCompactChange}
-            disabled={density !== "high"}
-          />
-        </FlexItem>
-      </FlexLayout>
+      <FlexItem>
+        <Checkbox
+          checked={compact && density === "high"}
+          label="Compact (for high density only)"
+          onChange={handleCompactChange}
+          disabled={density !== "high"}
+        />
+      </FlexItem>
       <div {...containerProps} style={{ height: "400px", width: "500px" }}>
         <AgGridReact
           columnDefs={dataGridExampleColumnsWrap}


### PR DESCRIPTION
Prepare snapshot for #3195, where UITK ag grid theme is removed. Remove the switch in snapshot so there's some meaningful diff we can use.