### PR TITLE
Fix checkbox and radio button hit area

### DIFF
--- a/.changeset/fast-snakes-know.md
+++ b/.changeset/fast-snakes-know.md
@@ -2,4 +2,4 @@
 "@salt-ds/core": patch
 ---
 
-Change RadioButton display to `inline-flex` so the hit area only covers the label.
+Changed RadioButton's display to `inline-flex` so the hit area only covers the label.

--- a/.changeset/fast-snakes-know.md
+++ b/.changeset/fast-snakes-know.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Change RadioButton display to `inline-flex` so the hit area only covers the label.

--- a/.changeset/violet-tomatoes-enjoy.md
+++ b/.changeset/violet-tomatoes-enjoy.md
@@ -2,4 +2,4 @@
 "@salt-ds/core": patch
 ---
 
-Change Checkbox display to `inline-flex` so the hit area only covers the label.
+Changed Checkbox's display to `inline-flex` so the hit area only covers the label.

--- a/.changeset/violet-tomatoes-enjoy.md
+++ b/.changeset/violet-tomatoes-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Change Checkbox display to `inline-flex` so the hit area only covers the label.

--- a/packages/core/src/checkbox/Checkbox.css
+++ b/packages/core/src/checkbox/Checkbox.css
@@ -1,6 +1,6 @@
 /* Styles applied to root component */
 .saltCheckbox {
-  display: flex;
+  display: inline-flex;
   gap: var(--salt-spacing-100);
   position: relative;
   cursor: var(--salt-selectable-cursor-hover);

--- a/packages/core/src/radio-button/RadioButton.css
+++ b/packages/core/src/radio-button/RadioButton.css
@@ -1,6 +1,6 @@
 /* Styles applied to RadioButton container */
 .saltRadioButton {
-  display: flex;
+  display: inline-flex;
   gap: var(--salt-spacing-100);
   cursor: var(--salt-selectable-cursor-hover);
   position: relative;


### PR DESCRIPTION
Closes #3298
Change RadioButton  and Checkbox display to `inline-flex` so the hit area only covers the label