### PR TITLE
Fix ComboBox React 16 support

### DIFF
--- a/.changeset/big-pumpkins-complain.md
+++ b/.changeset/big-pumpkins-complain.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Fixed ComboBox logging event errors in React 16.

--- a/packages/core/src/combo-box/ComboBox.tsx
+++ b/packages/core/src/combo-box/ComboBox.tsx
@@ -289,17 +289,17 @@ export const ComboBox = forwardRef(function ComboBox<Item>(
 
     setValueState(value);
 
-    if (value != "") {
-      // Wait for the filter to happen
-      queueMicrotask(() => {
+    // Wait for the filter to happen
+    queueMicrotask(() => {
+      if (value != "") {
         const newOption = getOptionAtIndex(0);
         if (newOption) {
           setActive(newOption);
         }
-      });
-    } else {
-      setActive(undefined);
-    }
+      } else {
+        setActive(undefined);
+      }
+    });
 
     onChange?.(event);
   };

--- a/packages/core/src/combo-box/ComboBox.tsx
+++ b/packages/core/src/combo-box/ComboBox.tsx
@@ -272,27 +272,30 @@ export const ComboBox = forwardRef(function ComboBox<Item>(
   };
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+
     if (!openState) {
       setOpen(true, "input");
     }
 
-    if (event.target.value === "" && !multiselect) {
+    if (value === "" && !multiselect) {
       clear(event);
     }
 
-    setValueState(event.target.value);
+    setValueState(value);
 
-    // Wait for the filter to happen
-    queueMicrotask(() => {
-      if (event.target.value !== "") {
+    if (value != "") {
+      // Wait for the filter to happen
+      queueMicrotask(() => {
         const newOption = getOptionAtIndex(0);
         if (newOption) {
           setActive(newOption);
         }
-      } else {
-        setActive(undefined);
-      }
-    });
+      });
+    } else {
+      setActive(undefined);
+    }
+
     onChange?.(event);
   };
 

--- a/packages/core/src/combo-box/ComboBox.tsx
+++ b/packages/core/src/combo-box/ComboBox.tsx
@@ -271,6 +271,11 @@ export const ComboBox = forwardRef(function ComboBox<Item>(
     onFocus?.(event);
   };
 
+  const handleBlur = (event: FocusEvent<HTMLInputElement>) => {
+    event.persist();
+    onBlur?.(event);
+  };
+
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
 
@@ -420,7 +425,7 @@ export const ComboBox = forwardRef(function ComboBox<Item>(
         value={valueState}
         ref={handleRef}
         {...getReferenceProps({
-          onBlur,
+          onBlur: handleBlur,
           onFocus: handleFocus,
           ...rest,
         })}


### PR DESCRIPTION
Closes #3348

Moves reading event.target.value outside of the microtask so event is read immediately.