### PR TITLE
Date picker updates from unresolved feedback on docs and tests

### DIFF
--- a/.changeset/little-years-press.md
+++ b/.changeset/little-years-press.md
@@ -1,0 +1,6 @@
+---
+"@salt-ds/lab": patch
+---
+
+Changed `startDate` and `endDate` for `selectedDate` in DatePicker to align with Calendar props.
+Changed `defaultStartDate` and `defaultEndDate` for `defaultSelectedDate` in DatePicker to align with Calendar props.

--- a/packages/lab/src/__tests__/__e2e__/date-input/DateInput.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-input/DateInput.cy.tsx
@@ -3,12 +3,21 @@ import { ChangeEvent } from "react";
 import * as dateInputStories from "@stories/date-input/date-input.stories";
 import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
 const composedStories = composeStories(dateInputStories);
-const { Default } = composedStories;
+const { Default, Range } = composedStories;
 
 describe("GIVEN a DateInput", () => {
   checkAccessibility(composedStories);
 
   describe("WHEN mounted the component", () => {
+    it("Should have accessible text in inputs", () => {
+      cy.mount(<Range />);
+      cy.findAllByRole("textbox")
+        .eq(0)
+        .should("have.accessibleName", "Start date");
+      cy.findAllByRole("textbox")
+        .eq(1)
+        .should("have.accessibleName", "End date");
+    });
     describe("WHEN the input is updated", () => {
       it("THEN should call onChange with the new value", () => {
         const changeSpy = cy.stub().as("changeSpy");

--- a/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.cy.tsx
@@ -42,12 +42,12 @@ describe("GIVEN a DatePicker", () => {
   checkAccessibility(composedStories);
 
   describe("WHEN single datepicker is mounted", () => {
-    it("THEN it should mount with the specified defaultStartDate", () => {
-      cy.mount(<Default defaultStartDate={testDate} />);
+    it("THEN it should mount with the specified defaultSelectedDate", () => {
+      cy.mount(<Default defaultSelectedDate={testDate} />);
       cy.findByRole("textbox").should("have.value", formatInput(testDate));
     });
     it("THEN should format a valid date with a different format on blur", () => {
-      cy.mount(<Default defaultStartDate={testDate} />);
+      cy.mount(<Default defaultSelectedDate={testDate} />);
       cy.findByRole("textbox").click().clear().type(testInput);
       cy.findByRole("textbox").blur();
       cy.findByRole("textbox").should(
@@ -56,19 +56,19 @@ describe("GIVEN a DatePicker", () => {
       );
     });
     it("THEN should error and not format invalid dates on blur", () => {
-      cy.mount(<Default defaultStartDate={testDate} />);
+      cy.mount(<Default defaultSelectedDate={testDate} />);
       cy.findByRole("textbox").click().clear().type("date");
       cy.findByRole("textbox").blur();
       cy.findByRole("textbox").should("have.value", "date");
       cy.findByRole("img", { name: "error" }).should("exist");
     });
     it("THEN clicking the calendar button should open the panel", () => {
-      cy.mount(<Default defaultStartDate={testDate} />);
+      cy.mount(<Default defaultSelectedDate={testDate} />);
       cy.findByRole("button", { name: "Open Calendar" }).realClick();
       cy.findByRole("application").should("exist");
     });
     it("THEN should close the calendar panel once a date is selected", () => {
-      cy.mount(<Default defaultStartDate={testDate} />);
+      cy.mount(<Default defaultSelectedDate={testDate} />);
       cy.findByRole("button", { name: "Open Calendar" }).realClick();
       cy.findByRole("button", {
         name: formatDay(testDate.add({ days: 11 })),
@@ -79,16 +79,16 @@ describe("GIVEN a DatePicker", () => {
       cy.findByRole("application").should("not.exist");
     });
     it("THEN open button should be disabled when component is disabled", () => {
-      cy.mount(<Default defaultStartDate={testDate} disabled />);
+      cy.mount(<Default defaultSelectedDate={testDate} disabled />);
       cy.findByRole("button").should("be.disabled");
     });
     it("THEN render read only when prop is passed", () => {
-      cy.mount(<Default defaultStartDate={testDate} readOnly />);
+      cy.mount(<Default defaultSelectedDate={testDate} readOnly />);
       cy.findByRole("textbox").should("have.attr", "readonly");
       cy.findByRole("button").should("be.disabled");
     });
     it("THEN it should update the selected month when changing selected date", () => {
-      cy.mount(<Default defaultStartDate={testDate} />);
+      cy.mount(<Default defaultSelectedDate={testDate} />);
       cy.findByRole("textbox").click().clear().type(testInput);
       cy.findByRole("textbox").blur();
       cy.findByRole("button", { name: "Open Calendar" }).realClick();
@@ -99,7 +99,7 @@ describe("GIVEN a DatePicker", () => {
     it("THEN it should clear the date if an empty input is submitted", () => {
       cy.mount(
         <Default
-          defaultStartDate={testDate}
+          defaultSelectedDate={testDate}
           CalendarProps={{ visibleMonth: testDate }}
         />
       );
@@ -120,11 +120,13 @@ describe("GIVEN a DatePicker", () => {
     });
   });
   describe("WHEN range datepicker is mounted", () => {
-    it("THEN it should mount with the specified defaultStartDate and defaultEndDate", () => {
+    it("THEN it should mount with the specified defaultSelectedDate", () => {
       cy.mount(
         <Range
-          defaultStartDate={testDate}
-          defaultEndDate={testDate.add({ months: 1 })}
+          defaultSelectedDate={{
+            startDate: testDate,
+            endDate: testDate.add({ months: 1 }),
+          }}
         />
       );
       cy.findAllByRole("textbox")
@@ -176,8 +178,10 @@ describe("GIVEN a DatePicker", () => {
     it("THEN it should move both months forward if selecting a starting date in the second calendar", () => {
       cy.mount(
         <Range
-          defaultStartDate={testDate}
-          defaultEndDate={testDate.add({ months: 1 })}
+          defaultSelectedDate={{
+            startDate: testDate,
+            endDate: testDate.add({ months: 1 }),
+          }}
         />
       );
       cy.findByRole("button", { name: "Open Calendar" }).realClick();
@@ -212,12 +216,13 @@ describe("GIVEN a DatePicker", () => {
   });
   describe("WHEN mounted as a controlled component", () => {
     it("THEN should mount with specified date", () => {
-      cy.mount(<Default startDate={testDate} />);
+      cy.mount(<Default selectedDate={testDate} />);
       cy.findByRole("textbox").should("have.value", formatInput(testDate));
     });
     describe("WHEN the date is updated", () => {
       it("should call onChange with the new value", () => {
         const changeSpy = cy.stub().as("changeSpy");
+
         function ControlledPicker() {
           const [date, setDate] = useState(testDate);
           const onChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -227,8 +232,9 @@ describe("GIVEN a DatePicker", () => {
             changeSpy(event);
           };
 
-          return <Default startDate={date} onChange={onChange} />;
+          return <Default selectedDate={date} onChange={onChange} />;
         }
+
         cy.mount(<ControlledPicker />);
         cy.findByRole("textbox").click().clear().type(testInput);
         cy.get("@changeSpy").should("have.been.calledWithMatch", {

--- a/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.cy.tsx
@@ -9,6 +9,7 @@ import {
   startOfMonth,
   today,
 } from "@internationalized/date";
+import { ChangeEvent, useState } from "react";
 
 const composedStories = composeStories(datePickerStories);
 const { Default, Range } = composedStories;
@@ -111,6 +112,12 @@ describe("GIVEN a DatePicker", () => {
         "true"
       );
     });
+    it("should allow a controlled open state", () => {
+      cy.mount(<Default open />);
+      cy.findAllByRole("application").should("exist");
+      cy.realPress("Escape");
+      cy.findAllByRole("application").should("exist");
+    });
   });
   describe("WHEN range datepicker is mounted", () => {
     it("THEN it should mount with the specified defaultStartDate and defaultEndDate", () => {
@@ -201,6 +208,33 @@ describe("GIVEN a DatePicker", () => {
           "have.text",
           formatDate(testDate.add({ months: 2 }), { month: "short" })
         );
+    });
+  });
+  describe("WHEN mounted as a controlled component", () => {
+    it("THEN should mount with specified date", () => {
+      cy.mount(<Default startDate={testDate} />);
+      cy.findByRole("textbox").should("have.value", formatInput(testDate));
+    });
+    describe("WHEN the date is updated", () => {
+      it("should call onChange with the new value", () => {
+        const changeSpy = cy.stub().as("changeSpy");
+        function ControlledPicker() {
+          const [date, setDate] = useState(testDate);
+          const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+            // React 16 backwards compatibility
+            event.persist();
+            setDate(testDate);
+            changeSpy(event);
+          };
+
+          return <Default startDate={date} onChange={onChange} />;
+        }
+        cy.mount(<ControlledPicker />);
+        cy.findByRole("textbox").click().clear().type(testInput);
+        cy.get("@changeSpy").should("have.been.calledWithMatch", {
+          target: { value: testInput },
+        });
+      });
     });
   });
 });

--- a/packages/lab/src/date-input/DateInput.tsx
+++ b/packages/lab/src/date-input/DateInput.tsx
@@ -114,6 +114,10 @@ export interface DateInputProps
    * Reference for the endInput;
    */
   endInputRef?: RefObject<HTMLInputElement>;
+  /**
+   * Selection variant. Defaults to single select.
+   */
+  selectionVariant?: "default" | "range";
 }
 
 export const DateInput = forwardRef<HTMLDivElement, DateInputProps>(
@@ -122,6 +126,7 @@ export const DateInput = forwardRef<HTMLDivElement, DateInputProps>(
       className,
       ariaLabel,
       disabled,
+      selectionVariant: selectionVariantProp,
       emptyReadOnlyMarker = "—",
       inputProps = {},
       endAdornment,
@@ -154,12 +159,14 @@ export const DateInput = forwardRef<HTMLDivElement, DateInputProps>(
       endDate,
       setStartDate,
       setEndDate,
-      selectionVariant,
+      selectionVariant: pickerSelectionVariant,
       openState,
       setOpen,
       validationStatusState,
       setValidationStatus,
     } = useDatePickerContext();
+
+    const selectionVariant = selectionVariantProp ?? pickerSelectionVariant;
 
     const endDateInputID = useId();
     const startDateInputID = useId();
@@ -293,9 +300,6 @@ export const DateInput = forwardRef<HTMLDivElement, DateInputProps>(
         updateEndDate(endDateStringValue);
         setOpen(false);
       }
-      if (event.key === "Tab" && openState && startDate && endDate) {
-        setOpen(false);
-      }
     };
 
     const handleInputClick = (event: SyntheticEvent<HTMLDivElement>) => {
@@ -322,6 +326,7 @@ export const DateInput = forwardRef<HTMLDivElement, DateInputProps>(
         {...rest}
       >
         <input
+          autoComplete="off"
           aria-describedby={clsx(formFieldDescribedBy, dateInputDescribedBy)}
           aria-labelledby={clsx(
             formFieldLabelledBy,
@@ -353,6 +358,7 @@ export const DateInput = forwardRef<HTMLDivElement, DateInputProps>(
           <>
             <span>-</span>
             <input
+              autoComplete="off"
               aria-describedby={clsx(
                 formFieldDescribedBy,
                 dateInputDescribedBy

--- a/packages/lab/src/date-input/DateInput.tsx
+++ b/packages/lab/src/date-input/DateInput.tsx
@@ -293,7 +293,7 @@ export const DateInput = forwardRef<HTMLDivElement, DateInputProps>(
         updateEndDate(endDateStringValue);
         setOpen(false);
       }
-      if (event.key === "Tab" && openState) {
+      if (event.key === "Tab" && openState && startDate && endDate) {
         setOpen(false);
       }
     };

--- a/packages/lab/src/date-input/DateInput.tsx
+++ b/packages/lab/src/date-input/DateInput.tsx
@@ -11,7 +11,6 @@ import {
   SyntheticEvent,
   useCallback,
   useEffect,
-  useId,
   useRef,
   useState,
 } from "react";
@@ -24,6 +23,7 @@ import {
   StatusAdornment,
   useForkRef,
   useFormFieldProps,
+  useId,
 } from "@salt-ds/core";
 import {
   CalendarDate,

--- a/packages/lab/src/date-input/DateInput.tsx
+++ b/packages/lab/src/date-input/DateInput.tsx
@@ -11,6 +11,7 @@ import {
   SyntheticEvent,
   useCallback,
   useEffect,
+  useId,
   useRef,
   useState,
 } from "react";
@@ -75,6 +76,7 @@ const defaultDateFormatter = (date: DateValue | undefined): string => {
 export interface DateInputProps
   extends Omit<ComponentPropsWithoutRef<"div">, "defaultValue">,
     Pick<ComponentPropsWithoutRef<"input">, "disabled" | "placeholder"> {
+  ariaLabel?: string;
   /**
    * The marker to use in an empty read only DateInput.
    * Use `''` to disable this feature. Defaults to '—'.
@@ -118,6 +120,7 @@ export const DateInput = forwardRef<HTMLDivElement, DateInputProps>(
   function DateInput(
     {
       className,
+      ariaLabel,
       disabled,
       emptyReadOnlyMarker = "—",
       inputProps = {},
@@ -157,6 +160,9 @@ export const DateInput = forwardRef<HTMLDivElement, DateInputProps>(
       validationStatusState,
       setValidationStatus,
     } = useDatePickerContext();
+
+    const endDateInputID = useId();
+    const startDateInputID = useId();
 
     const [focused, setFocused] = useState(false);
     const [startDateStringValue, setStartDateStringValue] = useState<string>(
@@ -287,6 +293,9 @@ export const DateInput = forwardRef<HTMLDivElement, DateInputProps>(
         updateEndDate(endDateStringValue);
         setOpen(false);
       }
+      if (event.key === "Tab" && openState) {
+        setOpen(false);
+      }
     };
 
     const handleInputClick = (event: SyntheticEvent<HTMLDivElement>) => {
@@ -314,7 +323,13 @@ export const DateInput = forwardRef<HTMLDivElement, DateInputProps>(
       >
         <input
           aria-describedby={clsx(formFieldDescribedBy, dateInputDescribedBy)}
-          aria-labelledby={clsx(formFieldLabelledBy, dateInputLabelledBy)}
+          aria-labelledby={clsx(
+            formFieldLabelledBy,
+            dateInputLabelledBy,
+            startDateInputID
+          )}
+          aria-label={clsx("Start date", ariaLabel)}
+          id={startDateInputID}
           className={withBaseName("input")}
           disabled={isDisabled}
           readOnly={isReadOnly}
@@ -342,7 +357,13 @@ export const DateInput = forwardRef<HTMLDivElement, DateInputProps>(
                 formFieldDescribedBy,
                 dateInputDescribedBy
               )}
-              aria-labelledby={clsx(formFieldLabelledBy, dateInputLabelledBy)}
+              aria-labelledby={clsx(
+                formFieldLabelledBy,
+                dateInputLabelledBy,
+                endDateInputID
+              )}
+              aria-label={clsx("End date", ariaLabel)}
+              id={endDateInputID}
               className={withBaseName("input")}
               disabled={isDisabled}
               readOnly={isReadOnly}

--- a/packages/lab/src/date-picker/DatePicker.tsx
+++ b/packages/lab/src/date-picker/DatePicker.tsx
@@ -25,6 +25,7 @@ export interface DatePickerProps
       ComponentPropsWithoutRef<"input">,
       "disabled" | "value" | "defaultValue" | "placeholder"
     > {
+  inputAriaLabel?: string;
   /**
    * Selection variant. Defaults to single select.
    */
@@ -100,6 +101,7 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
       onOpenChange: onOpenChangeProp,
       helperText,
       readOnly: readOnlyProp,
+      inputAriaLabel,
       ...rest
     },
     ref
@@ -215,6 +217,7 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
           placeholder={placeholder}
           dateFormatter={dateFormatter}
           readOnly={isReadOnly}
+          ariaLabel={inputAriaLabel}
           endAdornment={
             <Button
               variant="secondary"

--- a/packages/lab/src/date-picker/DatePicker.tsx
+++ b/packages/lab/src/date-picker/DatePicker.tsx
@@ -15,7 +15,10 @@ import { flip, useDismiss, useInteractions } from "@floating-ui/react";
 import { DateInput } from "../date-input";
 import { DateValue, getLocalTimeZone, today } from "@internationalized/date";
 import { CalendarIcon } from "@salt-ds/icons";
-import { CalendarProps } from "../calendar";
+import {
+  CalendarProps,
+  isRangeOrOffsetSelectionWithStartDate,
+} from "../calendar";
 
 const withBaseName = makePrefixer("saltDatePicker");
 
@@ -35,21 +38,17 @@ export interface DatePickerProps
    */
   disabled?: boolean;
   /**
-   * The start date value. Use when the component is controlled.
+   * The selected date value. Use when the component is controlled.
+   * Can be a single date or an object with start and end dates for range selection.
    */
-  startDate?: DateValue;
+  selectedDate?: DateValue | { startDate: DateValue; endDate: DateValue };
   /**
-   * The default start date value. Use when the component is not controlled.
+   * The default date value. Use when the component is not controlled.
+   * Can be a single date or an object with start and end dates for range selection.
    */
-  defaultStartDate?: DateValue;
-  /**
-   * The end date value. Use when the component is controlled.
-   */
-  endDate?: DateValue;
-  /**
-   * The default end date value. Use when the component is not controlled.
-   */
-  defaultEndDate?: DateValue;
+  defaultSelectedDate?:
+    | DateValue
+    | { startDate: DateValue; endDate: DateValue };
   /**
    * Props to be passed to the Calendar component.
    */
@@ -90,10 +89,8 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
       selectionVariant = "default",
       disabled = false,
       placeholder = "dd mmm yyyy",
-      startDate: startDateProp,
-      endDate: endDateProp,
-      defaultStartDate,
-      defaultEndDate,
+      selectedDate: selectedDateProp,
+      defaultSelectedDate,
       dateFormatter,
       CalendarProps,
       className,
@@ -112,15 +109,24 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
       name: "openPanel",
       state: "openPanel",
     });
+
     const [startDate, setStartDate] = useControlled({
-      controlled: startDateProp,
-      default: defaultStartDate,
+      controlled: isRangeOrOffsetSelectionWithStartDate(selectedDateProp)
+        ? selectedDateProp.startDate
+        : selectedDateProp,
+      default: isRangeOrOffsetSelectionWithStartDate(defaultSelectedDate)
+        ? defaultSelectedDate.startDate
+        : defaultSelectedDate,
       name: "StartDate",
       state: "startDate",
     });
     const [endDate, setEndDate] = useControlled({
-      controlled: endDateProp,
-      default: defaultEndDate,
+      controlled: isRangeOrOffsetSelectionWithStartDate(selectedDateProp)
+        ? selectedDateProp.endDate
+        : selectedDateProp,
+      default: isRangeOrOffsetSelectionWithStartDate(defaultSelectedDate)
+        ? defaultSelectedDate.endDate
+        : undefined,
       name: "EndDate",
       state: "endDate",
     });
@@ -191,14 +197,20 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
       disabled,
       endDate,
       setEndDate,
-      defaultEndDate,
+      defaultEndDate: isRangeOrOffsetSelectionWithStartDate(defaultSelectedDate)
+        ? defaultSelectedDate.endDate
+        : defaultSelectedDate,
       startDate,
       setStartDate,
       startVisibleMonth,
       setStartVisibleMonth,
       endVisibleMonth,
       setEndVisibleMonth,
-      defaultStartDate,
+      defaultStartDate: isRangeOrOffsetSelectionWithStartDate(
+        defaultSelectedDate
+      )
+        ? defaultSelectedDate.startDate
+        : defaultSelectedDate,
       selectionVariant,
       context,
       getPanelPosition,

--- a/packages/lab/stories/date-input/date-input.stories.tsx
+++ b/packages/lab/stories/date-input/date-input.stories.tsx
@@ -1,6 +1,5 @@
 import { DateInput, DateInputProps } from "@salt-ds/lab";
 import { Meta, StoryFn } from "@storybook/react";
-import { DateValue, getLocalTimeZone } from "@internationalized/date";
 
 export default {
   title: "Lab/Date Input",
@@ -11,19 +10,10 @@ const DateInputTemplate: StoryFn<DateInputProps> = (args) => {
   return <DateInput {...args} />;
 };
 
-const formatter = (input: DateValue | undefined): string => {
-  return input
-    ? new Intl.DateTimeFormat("en-US", {
-        year: "numeric",
-      }).format(input.toDate(getLocalTimeZone()))
-    : "";
-};
-
 export const Default = DateInputTemplate.bind({});
 Default.args = {};
 
-export const CustomFormatter = DateInputTemplate.bind({});
-CustomFormatter.args = {
-  dateFormatter: formatter,
-  placeholder: "yyyy",
+export const Range = DateInputTemplate.bind({});
+Range.args = {
+  selectionVariant: "range",
 };

--- a/site/docs/components/date-picker/examples.mdx
+++ b/site/docs/components/date-picker/examples.mdx
@@ -17,20 +17,27 @@ The default date picker allows the user to pick a single date, which is committe
 
 </LivePreview>
 <LivePreview componentName="date-picker" exampleName="WithFormField">
+## Form field compatibility
 
-## With form field
+You can wrap date picker in a form field when it’s displayed within a form. This provides functionality built into `FormField` for increased accessibility.
 
-This date picker has a form field label and is configured with validation logic. If an invalid date is entered, the error is detected and a tooltip advises the user of the correct format.
-The default date picker format is "DD MMM YYYY"
+For more information, refer to the [form pattern](/salt/patterns/forms).
+
+We recommend using our default date picker format (DD MMM YYYY) as it provides greater clarity and avoids ambiguity when identifying the month.
 
 </LivePreview>
 <LivePreview componentName="date-picker" exampleName="Range">
 ## Date range
 
-The Date Range Picker enables selection of start and end dates, using the input fields or two calendars displayed. The range is only committed when the user clicks ‘Apply’, and can be reset if the user wants to start again.
+The Date Range Picker enables selection of start and end dates, using the input fields or two calendars displayed.
+We recommend using the form field's label and helper text to instruct the user to select a date range by choosing both a start date and an end date.
 
 </LivePreview>
 <LivePreview componentName="date-picker" exampleName="WithDisabledDates">
 ## With disabled dates
+
+You can customize the calendar by passing calendar props into `CalendarProps`.
+For more information, refer to the [calendar](/salt/components/calendar).
+
 </LivePreview>
 </LivePreviewControls>

--- a/site/src/examples/date-picker/Range.tsx
+++ b/site/src/examples/date-picker/Range.tsx
@@ -1,6 +1,17 @@
 import { ReactElement } from "react";
 import { DatePicker } from "@salt-ds/lab";
+import {
+  FormField,
+  FormFieldHelperText as FormHelperText,
+  FormFieldLabel as FormLabel,
+} from "@salt-ds/core";
 
 export const Range = (): ReactElement => (
-  <DatePicker selectionVariant="range" style={{ width: "250px" }} />
+  <FormField style={{ width: "250px" }}>
+    <FormLabel>Pick a range</FormLabel>
+    <DatePicker selectionVariant="range" style={{ width: "250px" }} />
+    <FormHelperText>
+      Select a start and end date, format DD MMM YYYY (e.g. 09 Jun 2021)
+    </FormHelperText>
+  </FormField>
 );

--- a/site/src/examples/date-picker/Range.tsx
+++ b/site/src/examples/date-picker/Range.tsx
@@ -9,7 +9,7 @@ import {
 export const Range = (): ReactElement => (
   <FormField style={{ width: "250px" }}>
     <FormLabel>Pick a range</FormLabel>
-    <DatePicker selectionVariant="range" style={{ width: "250px" }} />
+    <DatePicker selectionVariant="range" />
     <FormHelperText>
       Select a start and end date, format DD MMM YYYY (e.g. 09 Jun 2021)
     </FormHelperText>


### PR DESCRIPTION
updates to date picker from unresolved feedback:
https://github.com/jpmorganchase/salt-ds/pull/3234

in this PR, #discussion_ :

- [x] r1604668383 - justify the usage of default formatter in docs
- [x] r1604694793, r1604713656, r1604715324 - add controlled tests
- [x] r1604701297 - updated docs around labels
- [x] r1604686057 - use "selectedDate" instead of "startDate" and "endDate"

for following PR:
- [ ] r1604705847 - fix input end date selection not closing calendar
