### PR TITLE
Add support for multiple themes to be passed to `SaltProvider`

### DIFF
--- a/.changeset/fresh-brooms-explain.md
+++ b/.changeset/fresh-brooms-explain.md
@@ -1,0 +1,9 @@
+---
+"@salt-ds/core": minor
+---
+
+Added support for multiple themes to be passed to `SaltProvider`, e.g.,
+
+```
+<SaltProvider theme="theme-1 theme-2">
+```

--- a/packages/core/src/__tests__/__e2e__/salt-provider/SaltProvider.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/salt-provider/SaltProvider.cy.tsx
@@ -91,7 +91,7 @@ describe("Given a SaltProvider", () => {
   });
 
   describe("with props set", () => {
-    it("should apply correct default value for Density and add an AriaAnnouncer", () => {
+    it("should apply correct default value for density and add an AriaAnnouncer", () => {
       mount(
         <SaltProvider mode="dark">
           <TestComponent />
@@ -104,7 +104,7 @@ describe("Given a SaltProvider", () => {
         .and("have.attr", "data-announcer", "true");
     });
 
-    it("should apply correct default value for Theme and add an AriaAnnouncer", () => {
+    it("should apply correct default value for mode and add an AriaAnnouncer", () => {
       mount(
         <SaltProvider density="high">
           <TestComponent />
@@ -119,7 +119,7 @@ describe("Given a SaltProvider", () => {
 
     it("should apply values specified in props", () => {
       mount(
-        <SaltProvider density="high" mode="dark">
+        <SaltProvider density="high" mode="dark" theme="custom-theme">
           <TestComponent />
         </SaltProvider>
       );
@@ -127,6 +127,32 @@ describe("Given a SaltProvider", () => {
         .should("exist")
         .and("have.attr", "data-density", "high")
         .and("have.attr", "data-mode", "dark")
+        .and("have.attr", "data-theme", "custom-theme")
+        .and("have.attr", "data-announcer", "true");
+    });
+
+    it("should allow pass in multiple theme names", () => {
+      mount(
+        <SaltProvider
+          density="high"
+          mode="dark"
+          theme="custom-theme-1 custom-theme-2"
+        >
+          <TestComponent />
+        </SaltProvider>
+      );
+
+      cy.get("html")
+        .should("exist")
+        .and("have.attr", "data-mode", "dark")
+        .and("have.class", "custom-theme-1 custom-theme-2")
+        .and("have.class", "salt-density-high");
+
+      cy.get("#test-1")
+        .should("exist")
+        .and("have.attr", "data-density", "high")
+        .and("have.attr", "data-mode", "dark")
+        .and("have.attr", "data-theme", "custom-theme-1 custom-theme-2")
         .and("have.attr", "data-announcer", "true");
     });
   });
@@ -189,7 +215,12 @@ describe("Given a SaltProvider", () => {
   describe("when root is passed to applyClassesTo", () => {
     it("should apply the given theme and density class names to the html element", () => {
       mount(
-        <SaltProvider density="high" mode="dark" applyClassesTo={"root"}>
+        <SaltProvider
+          density="high"
+          mode="dark"
+          theme="custom-theme"
+          applyClassesTo={"root"}
+        >
           <TestComponent />
         </SaltProvider>
       );
@@ -199,6 +230,7 @@ describe("Given a SaltProvider", () => {
       cy.get("html")
         .should("exist")
         .and("have.attr", "data-mode", "dark")
+        .and("have.class", "custom-theme")
         .and("have.class", "salt-density-high");
     });
   });
@@ -206,7 +238,12 @@ describe("Given a SaltProvider", () => {
   describe("when scope is passed to applyClassesTo", () => {
     it("should create div element with correct classes applied even if it is the root level provider", () => {
       mount(
-        <SaltProvider density="high" mode="dark" applyClassesTo={"scope"}>
+        <SaltProvider
+          density="high"
+          mode="dark"
+          theme="custom-theme"
+          applyClassesTo="scope"
+        >
           <TestComponent />
         </SaltProvider>
       );
@@ -214,6 +251,7 @@ describe("Given a SaltProvider", () => {
       cy.get("div.salt-provider")
         .should("have.length", 1)
         .and("have.attr", "data-mode", "dark")
+        .and("have.class", "custom-theme")
         .and("have.class", "salt-density-high");
     });
   });
@@ -288,6 +326,7 @@ describe("Given a SaltProviderNext", () => {
         .and("have.attr", "data-accent", "blue")
         .and("have.attr", "data-heading-font", "Open Sans")
         .and("have.attr", "data-action-font", "Open Sans")
+        .and("have.class", "salt-theme")
         .and("have.class", "salt-theme-next")
         .and("have.class", "salt-density-medium");
     });
@@ -308,6 +347,42 @@ describe("Given a SaltProviderNext", () => {
         .and("have.attr", "data-action-font", "Open Sans")
         .and("have.attr", "data-themeNext", "true");
       cy.get("[aria-live]").should("exist");
+    });
+  });
+
+  describe("with props set", () => {
+    it("should allow pass in multiple theme names", () => {
+      mount(
+        <UNSTABLE_SaltProviderNext
+          density="high"
+          mode="dark"
+          corner="rounded"
+          accent="teal"
+          theme="custom-theme-1 custom-theme-2"
+        >
+          <TestComponent />
+        </UNSTABLE_SaltProviderNext>
+      );
+
+      cy.get("html")
+        .should("exist")
+        .and("have.attr", "data-mode", "dark")
+        .and("have.attr", "data-accent", "teal")
+        .and("have.attr", "data-corner", "rounded")
+        .and("have.class", "salt-theme")
+        .and("have.class", "salt-theme-next")
+        .and("have.class", "custom-theme-1")
+        .and("have.class", "custom-theme-2")
+        .and("have.class", "salt-density-high");
+
+      cy.get("#test-1")
+        .should("exist")
+        .and("have.attr", "data-density", "high")
+        .and("have.attr", "data-mode", "dark")
+        .and("have.attr", "data-accent", "teal")
+        .and("have.attr", "data-corner", "rounded")
+        .and("have.attr", "data-theme", "custom-theme-1 custom-theme-2")
+        .and("have.attr", "data-announcer", "true");
     });
   });
 

--- a/packages/core/src/salt-provider/SaltProvider.tsx
+++ b/packages/core/src/salt-provider/SaltProvider.tsx
@@ -68,17 +68,18 @@ export const BreakpointContext =
 /**
  * We're relying `DEFAULT_THEME_NAME` to determine whether the provider is a root.
  */
-const getThemeNames = (themeName: ThemeName, themeNext?: boolean) => {
+const getThemeNames = (
+  themeName: ThemeName,
+  themeNext?: boolean
+): ThemeName => {
   if (themeNext) {
     return themeName === DEFAULT_THEME_NAME
-      ? [DEFAULT_THEME_NAME, UNSTABLE_ADDITIONAL_THEME_NAME]
-      : [DEFAULT_THEME_NAME, UNSTABLE_ADDITIONAL_THEME_NAME, themeName];
+      ? clsx(DEFAULT_THEME_NAME, UNSTABLE_ADDITIONAL_THEME_NAME)
+      : clsx(DEFAULT_THEME_NAME, UNSTABLE_ADDITIONAL_THEME_NAME, themeName);
   } else {
-    {
-      return themeName === DEFAULT_THEME_NAME
-        ? [DEFAULT_THEME_NAME]
-        : [DEFAULT_THEME_NAME, themeName];
-    }
+    return themeName === DEFAULT_THEME_NAME
+      ? themeName
+      : clsx(DEFAULT_THEME_NAME, themeName);
   }
 };
 
@@ -105,7 +106,7 @@ const createThemedChildren = ({
   applyClassesTo?: TargetElement;
 } & ThemeNextProps &
   UNSTABLE_SaltProviderNextAdditionalProps) => {
-  const themeNames = getThemeNames(themeName, themeNext);
+  const themeNamesString = getThemeNames(themeName, themeNext);
   const themeNextProps = {
     "data-corner": corner,
     "data-heading-font": headingFont,
@@ -119,7 +120,7 @@ const createThemedChildren = ({
       return React.cloneElement(children, {
         className: clsx(
           children.props?.className,
-          ...themeNames,
+          themeNamesString,
           `salt-density-${density}`
         ),
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -139,8 +140,8 @@ const createThemedChildren = ({
     return (
       <div
         className={clsx(
-          `salt-provider`,
-          ...themeNames,
+          "salt-provider",
+          themeNamesString,
           `salt-density-${density}`
         )}
         data-mode={mode}
@@ -155,11 +156,44 @@ const createThemedChildren = ({
 type TargetElement = "root" | "scope" | "child";
 
 interface SaltProviderBaseProps {
+  /**
+   * Either "root", "scope" or "child".
+   * Specifies the location of salt theme class and attributes should be applied to.
+   *
+   * Defaults to "root" for a root provider, otherwise "scope".
+   */
   applyClassesTo?: TargetElement;
+  /**
+   * Either "high", "medium", "low" or "touch".
+   * Determines the amount of content that can fit on a screen based on the size and spacing of components.
+   * Refer to [density](https://www.saltdesignsystem.com/salt/foundations/density) doc for more detail.
+   *
+   * @default "medium"
+   */
   density?: Density;
+  /**
+   * A string. Specifies custom theme name(s) you want to apply, similar to `className`.
+   */
   theme?: ThemeName;
+  /**
+   * Either "light" or "dark". Enable the color palette to change from light to dark.
+   * Refer to [modes](https://www.saltdesignsystem.com/salt/foundations/modes) doc for more detail.
+   *
+   * @default "light"
+   */
   mode?: Mode;
+  /**
+   * Shape of `{ xs: number; sm: number; md: number; lg: number; xl: number; }`.
+   * Determins breakpoints used in responsive calulation for layout components.
+   */
   breakpoints?: Breakpoints;
+  /**
+   * A boolean. Enables dynamic style injection for each component.
+   *
+   * If `false`, you'll need to include component CSS yourself.
+   *
+   * @default true
+   */
   enableStyleInjection?: boolean;
 }
 
@@ -269,7 +303,8 @@ function InternalSaltProvider({
   });
 
   useIsomorphicLayoutEffect(() => {
-    const themeNames = getThemeNames(themeName, themeNext);
+    const themeNamesString = getThemeNames(themeName, themeNext);
+    const themeNames = themeNamesString.split(" ");
 
     if (applyClassesTo === "root" && targetWindow) {
       if (inheritedWindow != targetWindow) {

--- a/site/docs/components/salt-provider/examples.mdx
+++ b/site/docs/components/salt-provider/examples.mdx
@@ -14,7 +14,7 @@ data:
 
 ## Theme
 
-Use `SaltProvider` to change the theme of your application with the `theme` prop. The default setting is `salt-theme`.
+Use `SaltProvider` to change the theme of your application with the `theme` prop. You can pass in multiple theme names if needed, just like `className`.
 
 Use the `useTheme` hook to access the currently active theme.
 

--- a/site/src/examples/salt-provider/Theme.tsx
+++ b/site/src/examples/salt-provider/Theme.tsx
@@ -1,8 +1,20 @@
 import { ReactElement } from "react";
-import { SaltProvider, useTheme } from "@salt-ds/core";
+import { Card, SaltProvider, StackLayout, useTheme } from "@salt-ds/core";
 
-export const Theme = (): ReactElement => {
+const ThemeCard = (): ReactElement => {
   const { theme } = useTheme();
 
-  return <SaltProvider theme="salt-theme">Current theme: {theme}</SaltProvider>;
+  return (
+    <Card style={{ minHeight: "unset" }}>
+      <StackLayout>Current theme: {theme}</StackLayout>
+    </Card>
+  );
+};
+
+export const Theme = (): ReactElement => {
+  return (
+    <SaltProvider theme="custom-theme">
+      <ThemeCard />
+    </SaltProvider>
+  );
 };


### PR DESCRIPTION
Uses `clsx` approach.

Added some doc for Salt provider props