### PR TITLE
Stepped Tracker: compact variant

### DIFF
--- a/.changeset/strong-ravens-share.md
+++ b/.changeset/strong-ravens-share.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/lab": patch
+---
+
+horizontal-compact variant for Stepped Tracker

--- a/.changeset/strong-ravens-share.md
+++ b/.changeset/strong-ravens-share.md
@@ -2,4 +2,4 @@
 "@salt-ds/lab": patch
 ---
 
-horizontal-compact variant for Stepped Tracker
+Added "horizontal-compact" variant for Stepped Tracker

--- a/packages/lab/src/stepped-tracker/SteppedTracker.css
+++ b/packages/lab/src/stepped-tracker/SteppedTracker.css
@@ -12,6 +12,9 @@
 .saltSteppedTracker.saltSteppedTracker-horizontal-compact {
   flex-direction: row;
 }
+.saltSteppedTracker.saltSteppedTracker-horizontal-compact {
+  padding-bottom: var(--salt-spacing-50);
+}
 
 .saltSteppedTracker.saltSteppedTracker-vertical {
   flex-direction: column;

--- a/packages/lab/src/stepped-tracker/SteppedTracker.css
+++ b/packages/lab/src/stepped-tracker/SteppedTracker.css
@@ -8,7 +8,8 @@
   position: relative;
 }
 
-.saltSteppedTracker.saltSteppedTracker-horizontal {
+.saltSteppedTracker.saltSteppedTracker-horizontal,
+.saltSteppedTracker.saltSteppedTracker-horizontal-compact {
   flex-direction: row;
 }
 

--- a/packages/lab/src/stepped-tracker/SteppedTracker.tsx
+++ b/packages/lab/src/stepped-tracker/SteppedTracker.tsx
@@ -33,11 +33,7 @@ export interface SteppedTrackerProps extends ComponentPropsWithoutRef<"ul"> {
   /**
    * The orientation of the SteppedTracker. Defaults to `horizontal`
    */
-  orientation?: "horizontal" | "vertical";
-  /**
-   * Render in visually compact mode.
-   */
-  compact?: boolean;
+  orientation?: "horizontal" | "horizontal-compact" | "vertical";
 }
 
 const useCheckInvalidChildren = (children: ReactNode) => {
@@ -66,7 +62,6 @@ export const SteppedTracker = forwardRef<HTMLUListElement, SteppedTrackerProps>(
       className,
       activeStep,
       orientation = "horizontal",
-      compact = false,
       ...restProps
     },
     ref
@@ -84,12 +79,7 @@ export const SteppedTracker = forwardRef<HTMLUListElement, SteppedTrackerProps>(
     return (
       <SteppedTrackerProvider totalSteps={totalSteps} activeStep={activeStep}>
         <ul
-          className={clsx(
-            withBaseName(),
-            className,
-            withBaseName(orientation),
-            compact && orientation === "horizontal" && withBaseName("compact")
-          )}
+          className={clsx(withBaseName(), className, withBaseName(orientation))}
           ref={ref}
           {...restProps}
         >

--- a/packages/lab/src/stepped-tracker/SteppedTracker.tsx
+++ b/packages/lab/src/stepped-tracker/SteppedTracker.tsx
@@ -34,6 +34,10 @@ export interface SteppedTrackerProps extends ComponentPropsWithoutRef<"ul"> {
    * The orientation of the SteppedTracker. Defaults to `horizontal`
    */
   orientation?: "horizontal" | "vertical";
+  /**
+   * Render in visually compact mode.
+   */
+  compact?: boolean;
 }
 
 const useCheckInvalidChildren = (children: ReactNode) => {
@@ -62,6 +66,7 @@ export const SteppedTracker = forwardRef<HTMLUListElement, SteppedTrackerProps>(
       className,
       activeStep,
       orientation = "horizontal",
+      compact = false,
       ...restProps
     },
     ref
@@ -79,7 +84,12 @@ export const SteppedTracker = forwardRef<HTMLUListElement, SteppedTrackerProps>(
     return (
       <SteppedTrackerProvider totalSteps={totalSteps} activeStep={activeStep}>
         <ul
-          className={clsx(withBaseName(), className, withBaseName(orientation))}
+          className={clsx(
+            withBaseName(),
+            className,
+            withBaseName(orientation),
+            compact && orientation === "horizontal" && withBaseName("compact")
+          )}
           ref={ref}
           {...restProps}
         >

--- a/packages/lab/src/stepped-tracker/TrackerConnector/TrackerConnector.css
+++ b/packages/lab/src/stepped-tracker/TrackerConnector/TrackerConnector.css
@@ -30,6 +30,10 @@
   border-left-color: var(--trackerConnector-color);
 }
 
+.saltSteppedTracker.saltSteppedTracker-compact .saltTrackerConnector {
+  left: calc(var(--saltIcon-size) + var(--trackerConnector-margin));
+}
+
 .saltTrackerConnector.saltTrackerConnector-active {
   --trackerConnector-style-border: var(--trackerConnector-style-active);
 }

--- a/packages/lab/src/stepped-tracker/TrackerConnector/TrackerConnector.css
+++ b/packages/lab/src/stepped-tracker/TrackerConnector/TrackerConnector.css
@@ -11,7 +11,8 @@
   position: absolute;
 }
 
-.saltSteppedTracker.saltSteppedTracker-horizontal .saltTrackerConnector {
+.saltSteppedTracker.saltSteppedTracker-horizontal .saltTrackerConnector,
+.saltSteppedTracker.saltSteppedTracker-horizontal-compact .saltTrackerConnector {
   border-top-width: var(--trackerConnector-thickness);
   border-top-style: var(--trackerConnector-style-border);
   border-top-color: var(--trackerConnector-color);
@@ -30,7 +31,7 @@
   border-left-color: var(--trackerConnector-color);
 }
 
-.saltSteppedTracker.saltSteppedTracker-compact .saltTrackerConnector {
+.saltSteppedTracker.saltSteppedTracker-horizontal-compact .saltTrackerConnector {
   left: calc(var(--saltIcon-size) + var(--trackerConnector-margin));
 }
 

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
@@ -35,6 +35,11 @@
   width: 100%;
 }
 
+.saltSteppedTracker.saltSteppedTracker-compact .saltTrackerStep {
+  display: block;
+  padding: 0;
+}
+
 /* Pseudo-class applied to the root element on focus */
 .saltTrackerStep:focus-visible {
   outline-style: var(--salt-focused-outlineStyle);

--- a/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
+++ b/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import { SteppedTracker, TrackerStep, StepLabel } from "@salt-ds/lab";
-import { Button, StackLayout, FlexLayout, Tooltip } from "@salt-ds/core";
+import { Button, StackLayout, FlexLayout, Tooltip, Label } from "@salt-ds/core";
 import { RefreshIcon } from "@salt-ds/icons";
 import { StoryFn, Meta } from "@storybook/react";
 
@@ -87,6 +87,49 @@ export const Basic: StoryFn<typeof SteppedTracker> = () => {
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>
+    </StackLayout>
+  );
+};
+
+export const BasicCompact: StoryFn<typeof SteppedTracker> = () => {
+  return (
+    <StackLayout
+      direction="column"
+      align="stretch"
+      gap={10}
+      style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
+    >
+      <div>
+        <SteppedTracker activeStep={0} compact>
+          <TrackerStep />
+          <TrackerStep />
+          <TrackerStep />
+          <TrackerStep />
+        </SteppedTracker>
+        <Label>
+          Step 1 of 4: <StepLabel>Step Name</StepLabel>
+        </Label>
+      </div>
+      <div>
+        <SteppedTracker activeStep={2} compact>
+          <TrackerStep state="completed" />
+          <TrackerStep state="completed" />
+          <TrackerStep state="default" />
+          <TrackerStep state="default" />
+        </SteppedTracker>
+        <Label>
+          Step 3 of 4: <StepLabel>Step Name</StepLabel>
+        </Label>
+      </div>
+      <div>
+        <SteppedTracker activeStep={3} compact>
+          <TrackerStep state="completed" />
+          <TrackerStep state="completed" />
+          <TrackerStep state="completed" />
+          <TrackerStep state="completed" />
+        </SteppedTracker>
+        <StepLabel>All steps complete</StepLabel>
+      </div>
     </StackLayout>
   );
 };

--- a/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
+++ b/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
@@ -91,7 +91,7 @@ export const Basic: StoryFn<typeof SteppedTracker> = () => {
   );
 };
 
-export const BasicCompact: StoryFn<typeof SteppedTracker> = () => {
+export const Compact: StoryFn<typeof SteppedTracker> = () => {
   const [activeStep, setActiveStep] = useState(0);
   const [steps, setSteps] = useState(sampleSteps);
   const totalSteps = steps.length;

--- a/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
+++ b/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import { SteppedTracker, TrackerStep, StepLabel } from "@salt-ds/lab";
-import { Button, StackLayout, FlexLayout, Tooltip, Label } from "@salt-ds/core";
+import { Button, StackLayout, FlexLayout, Tooltip, Text } from "@salt-ds/core";
 import { RefreshIcon } from "@salt-ds/icons";
 import { StoryFn, Meta } from "@storybook/react";
 
@@ -92,44 +92,60 @@ export const Basic: StoryFn<typeof SteppedTracker> = () => {
 };
 
 export const BasicCompact: StoryFn<typeof SteppedTracker> = () => {
+  const [activeStep, setActiveStep] = useState(0);
+  const [steps, setSteps] = useState(sampleSteps);
+  const totalSteps = steps.length;
+
+  const onComplete = () => {
+    if (activeStep < totalSteps - 1) {
+      setActiveStep((old) => old + 1);
+    }
+
+    setSteps((old) =>
+      old.map((step, i) =>
+        i === activeStep
+          ? {
+              ...step,
+              state: "completed",
+            }
+          : step
+      )
+    );
+  };
+
+  const onRefresh = () => {
+    setActiveStep(0);
+    setSteps(sampleSteps);
+  };
+
   return (
     <StackLayout
       direction="column"
       align="stretch"
-      gap={10}
       style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
     >
       <div>
-        <SteppedTracker activeStep={0} compact>
-          <TrackerStep />
-          <TrackerStep />
-          <TrackerStep />
-          <TrackerStep />
+        <SteppedTracker
+          activeStep={activeStep}
+          orientation="horizontal-compact"
+        >
+          {steps.map(({ state }, key) => (
+            <TrackerStep state={state} key={key} />
+          ))}
         </SteppedTracker>
-        <Label>
-          Step 1 of 4: <StepLabel>Step Name</StepLabel>
-        </Label>
+        <Text>
+          Step {activeStep + 1} of {steps.length}:{" "}
+          <strong>{steps[activeStep].label}</strong>
+        </Text>
       </div>
-      <div>
-        <SteppedTracker activeStep={2} compact>
-          <TrackerStep state="completed" />
-          <TrackerStep state="completed" />
-          <TrackerStep state="default" />
-          <TrackerStep state="default" />
-        </SteppedTracker>
-        <Label>
-          Step 3 of 4: <StepLabel>Step Name</StepLabel>
-        </Label>
-      </div>
-      <div>
-        <SteppedTracker activeStep={3} compact>
-          <TrackerStep state="completed" />
-          <TrackerStep state="completed" />
-          <TrackerStep state="completed" />
-          <TrackerStep state="completed" />
-        </SteppedTracker>
-        <StepLabel>All steps complete</StepLabel>
-      </div>
+      <FlexLayout justify="center" gap={1}>
+        <Button onClick={onComplete}>Complete Step</Button>
+        <Tooltip content="Reset">
+          <Button onClick={onRefresh}>
+            <RefreshIcon />
+          </Button>
+        </Tooltip>
+      </FlexLayout>
     </StackLayout>
   );
 };

--- a/site/docs/components/stepped-tracker/examples.mdx
+++ b/site/docs/components/stepped-tracker/examples.mdx
@@ -20,6 +20,20 @@ You can add a label to the `TrackerStep` using the `StepLabel` component.
 
   </LivePreview>
 
+  <LivePreview componentName="stepped-tracker" exampleName="Compact" >
+
+## Compact
+
+`SteppedTracker` can be displayed in a compact format using the `orientation` prop value `"horizontal-compact"`. This reduces the padding around the step nodes and left-aligns the `SteppedTracker` within its container.
+
+### Best practices
+
+Compact mode is useful when horizontal space is limited in the context of the application.
+
+When using the `SteppedTracker`in "compact" mode, avoid using individual `StepLabel` component for each step. Instead, use a single `Text` component to label the entire `SteppedTracker`.
+
+  </LivePreview>
+
   <LivePreview componentName="stepped-tracker" exampleName="Vertical" >
 
 ## Vertical

--- a/site/src/examples/stepped-tracker/Compact.tsx
+++ b/site/src/examples/stepped-tracker/Compact.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+
+import { SteppedTracker, TrackerStep } from "@salt-ds/lab";
+import { Button, StackLayout, FlexLayout, Tooltip, Text } from "@salt-ds/core";
+import { RefreshIcon } from "@salt-ds/icons";
+import { StoryFn } from "@storybook/react";
+
+interface Step {
+  label: string;
+  state: "default" | "completed";
+}
+
+type Steps = Step[];
+
+const sampleSteps: Steps = [
+  {
+    label: "Step One",
+    state: "default",
+  },
+  {
+    label: "Step Two",
+    state: "default",
+  },
+  {
+    label: "Step Three",
+    state: "default",
+  },
+  {
+    label: "Step Four",
+    state: "default",
+  },
+];
+
+export const Compact: StoryFn<typeof SteppedTracker> = () => {
+  const [activeStep, setActiveStep] = useState(0);
+  const [steps, setSteps] = useState(sampleSteps);
+  const totalSteps = steps.length;
+
+  const onComplete = () => {
+    if (activeStep < totalSteps - 1) {
+      setActiveStep((old) => old + 1);
+    }
+
+    setSteps((old) =>
+      old.map((step, i) =>
+        i === activeStep
+          ? {
+              ...step,
+              state: "completed",
+            }
+          : step
+      )
+    );
+  };
+
+  const onRefresh = () => {
+    setActiveStep(0);
+    setSteps(sampleSteps);
+  };
+
+  return (
+    <StackLayout
+      direction="column"
+      align="stretch"
+      style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
+    >
+      <div>
+        <SteppedTracker
+          activeStep={activeStep}
+          orientation="horizontal-compact"
+        >
+          {steps.map(({ state }, key) => (
+            <TrackerStep state={state} key={key} />
+          ))}
+        </SteppedTracker>
+        <Text>
+          Step {activeStep + 1} of {steps.length}:{" "}
+          <strong>{steps[activeStep].label}</strong>
+        </Text>
+      </div>
+      <FlexLayout justify="center" gap={1}>
+        <Button onClick={onComplete}>Complete Step</Button>
+        <Tooltip content="Reset">
+          <Button onClick={onRefresh}>
+            <RefreshIcon />
+          </Button>
+        </Tooltip>
+      </FlexLayout>
+    </StackLayout>
+  );
+};

--- a/site/src/examples/stepped-tracker/index.ts
+++ b/site/src/examples/stepped-tracker/index.ts
@@ -1,4 +1,5 @@
 export * from "./Basic";
+export * from "./Compact";
 export * from "./Vertical";
 export * from "./StepProgression";
 export * from "./NonSequentialProgress";


### PR DESCRIPTION
Adds a `compact` prop to `<SteppedTracker />`

<img width="985" alt="Screenshot 2024-05-30 at 11 39 06" src="https://github.com/jpmorganchase/salt-ds/assets/5412181/d13d7e4f-8a10-4599-8b48-e813ef0630a6">

---

Currently WIP because of question around variant prop naming (changeset and docs to follow once approach is finalised):

**Qs.** The "compact" styles are only applicable to the horizontal variant of the Stepped Tracker. This means there's some logic to only apply the relevant className when both the `component` prop is `true` and `orientation` prop is `"horizontal"`.

1. Would it be cleaner to have just the single "orientation" prop, and add `horizontal-compact` as a option there?
2. Higher-level question: is a `compact` prop a pattern we want to reuse in other components? AFICT the only other places where there is a compact version are Paginator and Input, which each have discrete compact components to export (i.e. `<CompactPaginator />`)