### PR TITLE
Adds v2 to ag grid theme doc

### DIFF
--- a/site/docs/components/ag-grid-theme/index.mdx
+++ b/site/docs/components/ag-grid-theme/index.mdx
@@ -6,5 +6,6 @@ data:
   package:
     name: "@salt-ds/ag-grid-theme"
     initialVersion: "1.0.0"
+  status: "v2"
 layout: DetailComponent
 ---


### PR DESCRIPTION
Adds v2 label to the site, to make it more obvious.

~~Maybe also a 'new' in the side bar?~~