### PR TITLE
Fix site date picker calendar dropdown css

### DIFF
--- a/site/src/css/utilities/patches.css
+++ b/site/src/css/utilities/patches.css
@@ -4,3 +4,14 @@
 .salt-theme[data-mode="dark"] main img:not(.no-filter) {
   filter: none;
 }
+
+/* 
+ * Prevent css from Dropdown in lab impacting date picker's date picker.
+ * Doing low impacted selector for now.
+ */
+.salt-theme div[data-floating-ui-portal] .saltDropdown {
+  --saltIcon-margin: unset;
+  display: flex;
+  line-height: inherit;
+  position: relative;
+}


### PR DESCRIPTION
Currently site date picker year dropdown is shown as truncated  
https://www.saltdesignsystem.com/salt/components/date-picker/examples
