### PR TITLE
Try StackBlitz SDK on site

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -36,6 +36,7 @@
     "@jpmorganchase/mosaic-store": "^0.1.0-beta.65",
     "@jpmorganchase/mosaic-theme": "^0.1.0-beta.65",
     "@philpl/buble": "^0.19.7",
+    "@stackblitz/sdk": "^1.10.0",
     "@types/react": "^18.0.26",
     "lodash-es": "^4.17.21",
     "next": "^14.0.4",

--- a/site/src/components/components/LivePreview.tsx
+++ b/site/src/components/components/LivePreview.tsx
@@ -8,11 +8,12 @@ import {
   ElementType,
 } from "react";
 import clsx from "clsx";
-import { Switch } from "@salt-ds/core";
+import { Button, Switch } from "@salt-ds/core";
 import { SaltProvider } from "@salt-ds/core";
 import { Pre } from "../mdx/pre";
 import { useLivePreviewControls } from "./useLivePreviewControls";
 import useIsMobileView from "../../utils/useIsMobileView";
+import StackBlitzSDK from "@stackblitz/sdk";
 
 import styles from "./LivePreview.module.css";
 
@@ -92,6 +93,98 @@ export const LivePreview: FC<LivePreviewProps> = ({
   // somewhere), then fallback to using own state
   const showCode = contextOnShowCodeToggle ? contextShowCode : ownShowCode;
 
+  const editInStackBlitz = () => {
+    const PACKAGE_JSON = {
+      name: "react-ts",
+      version: "0.0.0",
+      private: true,
+      dependencies: {
+        "@fontsource/open-sans": "^4.5.13",
+        "@fontsource/pt-mono": "^4.5.11",
+        "@salt-ds/core": "latest",
+        "@salt-ds/countries": "latest",
+        "@salt-ds/icons": "latest",
+        "@salt-ds/lab": "latest",
+        "@salt-ds/theme": "latest",
+        "@types/react": "^18.3.0",
+        "@types/react-dom": "^18.3.0",
+        react: "^18.3.0",
+        "react-dom": "^18.3.0",
+      },
+      scripts: {
+        start: "react-scripts start",
+        build: "react-scripts build",
+        test: "react-scripts test --env=jsdom",
+        eject: "react-scripts eject",
+      },
+      devDependencies: {
+        "react-scripts": "latest",
+      },
+    };
+    StackBlitzSDK.openProject(
+      // Payload
+      {
+        // REQUIRED: specify dependencies
+        dependencies: PACKAGE_JSON.dependencies,
+        files: {
+          "index.html": `<div id="root"></div>`,
+          "index.tsx": `import * as React from 'react';
+          import { StrictMode } from 'react';
+          import { createRoot } from 'react-dom/client';
+          
+          import '@salt-ds/theme/index.css';
+          import '@fontsource/open-sans/300.css';
+          import '@fontsource/open-sans/300-italic.css';
+          import '@fontsource/open-sans/400.css';
+          import '@fontsource/open-sans/400-italic.css';
+          import '@fontsource/open-sans/500.css';
+          import '@fontsource/open-sans/500-italic.css';
+          import '@fontsource/open-sans/600.css';
+          import '@fontsource/open-sans/600-italic.css';
+          import '@fontsource/open-sans/700.css';
+          import '@fontsource/open-sans/700-italic.css';
+          import '@fontsource/open-sans/800.css';
+          import '@fontsource/open-sans/800-italic.css';
+          import '@fontsource/pt-mono';
+          
+          import App from './App';
+          import { SaltProvider } from '@salt-ds/core';
+          
+          const rootElement = document.getElementById('root');
+          const root = createRoot(rootElement);
+          
+          root.render(
+            <StrictMode>
+              <SaltProvider>
+                <App />
+              </SaltProvider>
+            </StrictMode>
+          );
+          `,
+          "App.tsx":
+            `import * as React from 'react';
+` +
+            ComponentExample.sourceCode +
+            `
+          
+          export default ${exampleName};
+          `,
+          // Recommended: provide a package.json file with the same dependencies
+          "package.json": JSON.stringify(PACKAGE_JSON, null, 2),
+        },
+        // EngineBlock
+        template: "create-react-app",
+        title: `Salt example`,
+        description: `This is an example of salt component`,
+      },
+      // Options
+      {
+        newWindow: true,
+        openFile: "App.tsx",
+      }
+    );
+  };
+
   return (
     <>
       {children}
@@ -122,9 +215,12 @@ export const LivePreview: FC<LivePreviewProps> = ({
         </div>
 
         {showCode && (
-          <Pre className={styles.codePreview}>
-            <div className="language-tsx">{ComponentExample.sourceCode}</div>
-          </Pre>
+          <>
+            <Pre className={styles.codePreview}>
+              <div className="language-tsx">{ComponentExample.sourceCode}</div>
+            </Pre>
+            <Button onClick={editInStackBlitz}>Edit in StackBlitz</Button>
+          </>
         )}
       </div>
     </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5810,6 +5810,7 @@ __metadata:
     "@jpmorganchase/mosaic-theme": "npm:^0.1.0-beta.65"
     "@next/eslint-plugin-next": "npm:^14.0.4"
     "@philpl/buble": "npm:^0.19.7"
+    "@stackblitz/sdk": "npm:^1.10.0"
     "@types/node": "npm:^16.0.0"
     "@types/react": "npm:^18.0.26"
     concurrently: "npm:^8.0.0"
@@ -6420,6 +6421,13 @@ __metadata:
     "@smithy/types": "npm:^2.1.0"
     tslib: "npm:^2.5.0"
   checksum: 10/fc675be539dd07899ad1829bec333ee4049c24dc82251a60c252d3c7e03aa97108539707f2ba4ad4e5d8fdf80479df24b52e7abd16b3262f9551a09eb146930e
+  languageName: node
+  linkType: hard
+
+"@stackblitz/sdk@npm:^1.10.0":
+  version: 1.10.0
+  resolution: "@stackblitz/sdk@npm:1.10.0"
+  checksum: 10/ae9857ebd877683de6b864266d4eac1610b5e958a8fe9582d9ab83a0f3aeebc7b515497d8e4320e579f11d674239be10e4e9908680e62cfd12ac01b6d96f54f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Works in examples without additional dependencies. Couple of notes

- Where to put it the best (design wise), currently copy button is separate implementation from Mosaic
- White space of source issue
- Dependency issue (css, data, hook), will likely need to change implementation to include those. Or enforce 0 dependency on site example.
- React missing in StackBlitz, thus needing `import * as React from 'react'`

https://developer.stackblitz.com/platform/api/javascript-sdk#generate-and-embed-new-projects

