### PR TITLE
Date picker updates from feedback

### DIFF
--- a/.changeset/fluffy-snails-camp.md
+++ b/.changeset/fluffy-snails-camp.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/lab": patch
+---
+
+Fix Range date picker cursor position after selection

--- a/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.cy.tsx
@@ -57,9 +57,15 @@ describe("GIVEN a DatePicker", () => {
     });
     it("THEN should not format invalid dates on blur", () => {
       cy.mount(<Default defaultSelectedDate={testDate} />);
-      cy.findByRole("textbox").click().clear().type("date");
+      cy.findByRole("textbox").click().clear().type("2 fev");
       cy.findByRole("textbox").blur();
-      cy.findByRole("textbox").should("have.value", "date");
+      cy.findByRole("textbox").should("have.value", "2 fev");
+    });
+    it("THEN should not format invalid dates on blur if controlled", () => {
+      cy.mount(<Default selectedDate={testDate} />);
+      cy.findByRole("textbox").click().clear().type("2 fev");
+      cy.findByRole("textbox").blur();
+      cy.findByRole("textbox").should("have.value", "2 fev");
     });
     it("THEN clicking the calendar button should open the panel", () => {
       cy.mount(<Default defaultSelectedDate={testDate} />);
@@ -79,6 +85,7 @@ describe("GIVEN a DatePicker", () => {
         name: formatDay(testDate.add({ days: 11 })),
       }).realClick();
       cy.findByRole("application").should("not.exist");
+      cy.findByRole("textbox").should("have.focus");
     });
     it("THEN open button should be disabled when component is disabled", () => {
       cy.mount(<Default defaultSelectedDate={testDate} disabled />);
@@ -94,9 +101,12 @@ describe("GIVEN a DatePicker", () => {
       cy.findByRole("textbox").click().clear().type(testInput);
       cy.findByRole("textbox").blur();
       cy.findByRole("button", { name: "Open Calendar" }).realClick();
-      cy.findByRole("button", {
-        name: "Next Month",
-      }).focus();
+      cy.findAllByRole("combobox")
+        .eq(0)
+        .should("have.text", formatDate(testDate, { month: "short" }));
+      cy.findAllByRole("combobox")
+        .eq(1)
+        .should("have.text", formatDate(testDate, { year: "numeric" }));
     });
     it("THEN it should clear the date if an empty input is submitted", () => {
       cy.mount(
@@ -119,6 +129,31 @@ describe("GIVEN a DatePicker", () => {
       cy.findAllByRole("application").should("exist");
       cy.realPress("Escape");
       cy.findAllByRole("application").should("exist");
+    });
+    it("THEN should mount with specified date if controlled", () => {
+      cy.mount(<Default selectedDate={testDate} />);
+      cy.findByRole("textbox").should("have.value", formatInput(testDate));
+    });
+    it("should call onChange with the new controlled value", () => {
+      const changeSpy = cy.stub().as("changeSpy");
+
+      function ControlledPicker() {
+        const [date, setDate] = useState(testDate);
+        const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+          // React 16 backwards compatibility
+          event.persist();
+          setDate(testDate);
+          changeSpy(event);
+        };
+
+        return <Default selectedDate={date} onChange={onChange} />;
+      }
+
+      cy.mount(<ControlledPicker />);
+      cy.findByRole("textbox").click().clear().type(testInput);
+      cy.get("@changeSpy").should("have.been.calledWithMatch", {
+        target: { value: testInput },
+      });
     });
   });
 
@@ -170,6 +205,7 @@ describe("GIVEN a DatePicker", () => {
         name: formatDay(startOfMonth(today(localTimeZone)).add({ days: 12 })),
       }).realClick();
       cy.findByRole("application").should("not.exist");
+      cy.findAllByRole("textbox").eq(1).should("have.focus");
     });
     it("THEN it should move both months forward if selecting a starting date in the second calendar", () => {
       cy.mount(
@@ -253,38 +289,7 @@ describe("GIVEN a DatePicker", () => {
         "true"
       );
     });
-  });
-  describe("WHEN mounted as a controlled component", () => {
-    it("THEN should mount with specified date", () => {
-      cy.mount(<Default selectedDate={testDate} />);
-      cy.findByRole("textbox").should("have.value", formatInput(testDate));
-    });
-    describe("WHEN the date is updated", () => {
-      it("should call onChange with the new value", () => {
-        const changeSpy = cy.stub().as("changeSpy");
-
-        function ControlledPicker() {
-          const [date, setDate] = useState(testDate);
-          const onChange = (event: ChangeEvent<HTMLInputElement>) => {
-            // React 16 backwards compatibility
-            event.persist();
-            setDate(testDate);
-            changeSpy(event);
-          };
-
-          return <Default selectedDate={date} onChange={onChange} />;
-        }
-
-        cy.mount(<ControlledPicker />);
-        cy.findByRole("textbox").click().clear().type(testInput);
-        cy.get("@changeSpy").should("have.been.calledWithMatch", {
-          target: { value: testInput },
-        });
-      });
-    });
-  });
-  describe("WHEN range is mounted as a controlled component", () => {
-    it("THEN should mount with specified date", () => {
+    it("THEN should mount with specified date if controlled", () => {
       cy.mount(
         <Range
           selectedDate={{
@@ -300,35 +305,46 @@ describe("GIVEN a DatePicker", () => {
         .eq(1)
         .should("have.value", formatInput(testDate.add({ months: 1 })));
     });
-    describe("WHEN the date is updated", () => {
-      it("should call onChange with the new value", () => {
-        const changeSpy = cy.stub().as("changeSpy");
+    it("THEN should not format invalid dates on blur if controlled", () => {
+      cy.mount(
+        <Range
+          selectedDate={{
+            startDate: testDate,
+            endDate: testDate.add({ months: 1 }),
+          }}
+        />
+      );
+      cy.findAllByRole("textbox").eq(0).clear().click().type("2 fev");
+      cy.findAllByRole("textbox").eq(0).blur();
+      cy.findAllByRole("textbox").eq(0).should("have.value", "2 fev");
+    });
+    it("should call onChange with the new controlled value", () => {
+      const changeSpy = cy.stub().as("changeSpy");
 
-        function ControlledRangePicker() {
-          const [date, setDate] = useState(testDate);
-          const onChange = (
-            event: ChangeEvent<HTMLInputElement>,
-            startDate?: string,
-            endDate?: string
-          ) => {
-            // React 16 backwards compatibility
-            event.persist();
-            setDate(testDate);
-            changeSpy(startDate, endDate);
-          };
+      function ControlledRangePicker() {
+        const [date, setDate] = useState(testDate);
+        const onChange = (
+          event: ChangeEvent<HTMLInputElement>,
+          startDate?: string,
+          endDate?: string
+        ) => {
+          // React 16 backwards compatibility
+          event.persist();
+          setDate(testDate);
+          changeSpy(startDate, endDate);
+        };
 
-          return <Range selectedDate={date} onChange={onChange} />;
-        }
+        return <Range selectedDate={date} onChange={onChange} />;
+      }
 
-        cy.mount(<ControlledRangePicker />);
-        cy.findAllByRole("textbox").eq(0).click().clear().type(testInput);
-        cy.findAllByRole("textbox").eq(1).click().clear().type(rangeTestInput);
-        cy.get("@changeSpy").should(
-          "have.been.calledWith",
-          testInput,
-          rangeTestInput
-        );
-      });
+      cy.mount(<ControlledRangePicker />);
+      cy.findAllByRole("textbox").eq(0).click().clear().type(testInput);
+      cy.findAllByRole("textbox").eq(1).click().clear().type(rangeTestInput);
+      cy.get("@changeSpy").should(
+        "have.been.calledWith",
+        testInput,
+        rangeTestInput
+      );
     });
   });
 });

--- a/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.cy.tsx
@@ -339,6 +339,7 @@ describe("GIVEN a DatePicker", () => {
 
       cy.mount(<ControlledRangePicker />);
       cy.findAllByRole("textbox").eq(0).click().clear().type(testInput);
+      cy.get("@changeSpy").should("have.been.calledWith", testInput);
       cy.findAllByRole("textbox").eq(1).click().clear().type(rangeTestInput);
       cy.get("@changeSpy").should(
         "have.been.calledWith",

--- a/packages/lab/src/date-input/DateInput.tsx
+++ b/packages/lab/src/date-input/DateInput.tsx
@@ -239,8 +239,10 @@ export const DateInput = forwardRef<
   // Update date strings when dates change
   useEffect(() => {
     if (isRangeOrOffsetSelectionWithStartDate(selectedDate)) {
-      setStartDateStringValue(dateFormatter(selectedDate?.startDate));
-      setEndDateStringValue(dateFormatter(selectedDate?.endDate));
+      selectedDate?.startDate &&
+        setStartDateStringValue(dateFormatter(selectedDate?.startDate));
+      selectedDate?.endDate &&
+        setEndDateStringValue(dateFormatter(selectedDate?.endDate));
     } else {
       setStartDateStringValue(dateFormatter(selectedDate));
     }

--- a/packages/lab/src/date-picker/DatePicker.tsx
+++ b/packages/lab/src/date-picker/DatePicker.tsx
@@ -210,6 +210,13 @@ export const DatePicker = forwardRef<
     if (selectionVariant === "default" && selectedDate) {
       startInputRef?.current?.focus();
     }
+
+    if (
+      isRangeOrOffsetSelectionWithStartDate(selectedDate) &&
+      selectedDate.endDate
+    ) {
+      endInputRef?.current?.focus();
+    }
     onSelectionChange?.(event, selectedDate);
   };
   const handleCalendarButton = () => {

--- a/packages/lab/stories/date-picker/date-picker.stories.tsx
+++ b/packages/lab/stories/date-picker/date-picker.stories.tsx
@@ -98,8 +98,11 @@ export const WithValidation: StoryFn<
           setInputValue(event.target.value)
         }
         onSelectionChange={(_, date) => {
-          setValidationStatus(getDateValidationStatus(inputValue));
-          setSelectedDate(date);
+          const validationStatus = getDateValidationStatus(inputValue);
+          setValidationStatus(validationStatus);
+          if (!validationStatus) {
+            setSelectedDate(date);
+          }
         }}
       />
       <FormHelperText>{helperText}</FormHelperText>
@@ -136,11 +139,14 @@ export const RangeWithValidation: StoryFn<
           setEndString(endDateInputValue);
         }}
         onSelectionChange={(_, date) => {
-          setValidationStatus(
+          const validationStatus =
             getDateValidationStatus(startString) ??
-              getDateValidationStatus(endString)
-          );
-          setSelectedDate(date as RangeSelectionValueType);
+            getDateValidationStatus(endString);
+
+          setValidationStatus(validationStatus);
+          if (!validationStatus) {
+            setSelectedDate(date as RangeSelectionValueType);
+          }
         }}
       />
       <FormHelperText>{helperText}</FormHelperText>

--- a/site/docs/components/date-picker/examples.mdx
+++ b/site/docs/components/date-picker/examples.mdx
@@ -40,6 +40,7 @@ The Date Range Picker enables selection of start and end dates, using the input 
 ## With custom formatter
 
 You can customize the date picker's placeholder and formatter by changing the `placeholder` and `dateFormatter` props.
+Make sure `dateFormatter` is stable to avoid it triggering unintended state resets.
 We recommend using our default date picker format (DD MMM YYYY) as it provides greater clarity and avoids ambiguity when identifying the month.
 
 </LivePreview>

--- a/site/src/examples/date-picker/WithValidation.tsx
+++ b/site/src/examples/date-picker/WithValidation.tsx
@@ -30,8 +30,11 @@ export const WithValidation = (): ReactElement => {
           setInputValue(event.target.value)
         }
         onSelectionChange={(_, date) => {
-          setValidationStatus(getDateValidationStatus(inputValue));
-          setSelectedDate(date);
+          const validationStatus = getDateValidationStatus(inputValue);
+          setValidationStatus(validationStatus);
+          if (!validationStatus) {
+            setSelectedDate(date);
+          }
         }}
       />
       <FormHelperText>{helperText}</FormHelperText>


### PR DESCRIPTION
The following changes from feedback are addressed in this PR: 


- [x] Add docs paragraph about date formatter, if non-stable will reset state
- [x] Fix cursor position when selection happens
~~- [ ] need an example for a custom placeholder~~
- [x] Fix validation example, where retyping a valid date doesn't clear
- [x] check docs (props) inputAriaLabel removed