### PR TITLE
Add `status` prop and rename `state` prop to `stage` for steps in SteppedTracker

### DIFF
--- a/.changeset/short-plants-own.md
+++ b/.changeset/short-plants-own.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/lab": minor
+---
+
+Added `error` and `warning` status options to TrackerStep's `state` prop.

--- a/.changeset/short-plants-own.md
+++ b/.changeset/short-plants-own.md
@@ -2,4 +2,4 @@
 "@salt-ds/lab": minor
 ---
 
-Added `error` and `warning` status options to TrackerStep's `state` prop.
+Replaced TrackerStep's `state` prop with new `TBC_PROP_NAME` prop, and added `error` and `warning` to the options.

--- a/.changeset/short-plants-own.md
+++ b/.changeset/short-plants-own.md
@@ -2,4 +2,4 @@
 "@salt-ds/lab": minor
 ---
 
-Replaced TrackerStep's `state` prop with new `TBC_PROP_NAME` prop, and added `error` and `warning` to the options.
+Replaced TrackerStep's `state` prop with new `stage` and `status` props. Valid `stage` values are `"pending"` and `"completed"`. Valid `status` values are `"error"` and `"warning"`.

--- a/packages/lab/src/__tests__/__e2e__/stepped-tracker/SteppedTracker.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/stepped-tracker/SteppedTracker.cy.tsx
@@ -143,4 +143,61 @@ describe("GIVEN a SteppedTracker", () => {
       .findByTestId("StepActiveIcon")
       .should("not.exist");
   });
+
+  it("should show warning icon if a state is warning", () => {
+    const labels = ["Step 1", "Step 2", "Step 3"];
+
+    const stepNum = 1;
+
+    const TestComponent = (
+      <SteppedTracker activeStep={stepNum} style={{ width: 300 }}>
+        {labels.map((label, key) => (
+          <TrackerStep
+            key={key}
+            state={key === stepNum ? "warning" : undefined}
+          >
+            <StepLabel>{label}</StepLabel>
+          </TrackerStep>
+        ))}
+      </SteppedTracker>
+    );
+
+    cy.mount(TestComponent);
+
+    cy.findAllByRole("listitem")
+      .filter(`:nth-child(${stepNum + 1})`)
+      .findByTestId("WarningSolidIcon")
+      .should("exist");
+    cy.findAllByRole("listitem")
+      .not(`:nth-child(${stepNum + 1})`)
+      .findByTestId("StepActiveIcon")
+      .should("not.exist");
+  });
+
+  it("should show error icon if a state is error", () => {
+    const labels = ["Step 1", "Step 2", "Step 3"];
+
+    const stepNum = 1;
+
+    const TestComponent = (
+      <SteppedTracker activeStep={stepNum} style={{ width: 300 }}>
+        {labels.map((label, key) => (
+          <TrackerStep key={key} state={key === stepNum ? "error" : undefined}>
+            <StepLabel>{label}</StepLabel>
+          </TrackerStep>
+        ))}
+      </SteppedTracker>
+    );
+
+    cy.mount(TestComponent);
+
+    cy.findAllByRole("listitem")
+      .filter(`:nth-child(${stepNum + 1})`)
+      .findByTestId("ErrorSolidIcon")
+      .should("exist");
+    cy.findAllByRole("listitem")
+      .not(`:nth-child(${stepNum + 1})`)
+      .findByTestId("StepActiveIcon")
+      .should("not.exist");
+  });
 });

--- a/packages/lab/src/__tests__/__e2e__/stepped-tracker/SteppedTracker.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/stepped-tracker/SteppedTracker.cy.tsx
@@ -94,7 +94,7 @@ describe("GIVEN a SteppedTracker", () => {
         {labels.map((label, key) => (
           <TrackerStep
             key={key}
-            state={key === completedStep ? "completed" : undefined}
+            TBC_PROP_NAME={key === completedStep ? "completed" : undefined}
           >
             <StepLabel>{label}</StepLabel>
           </TrackerStep>
@@ -114,7 +114,7 @@ describe("GIVEN a SteppedTracker", () => {
       .should("not.exist");
   });
 
-  it("should show completed icon if a state is completed and active", () => {
+  it("should show completed icon if icon prop is completed and active", () => {
     const labels = ["Step 1", "Step 2", "Step 3"];
 
     const stepNum = 1;
@@ -124,7 +124,7 @@ describe("GIVEN a SteppedTracker", () => {
         {labels.map((label, key) => (
           <TrackerStep
             key={key}
-            state={key === stepNum ? "completed" : undefined}
+            TBC_PROP_NAME={key === stepNum ? "completed" : undefined}
           >
             <StepLabel>{label}</StepLabel>
           </TrackerStep>
@@ -144,17 +144,15 @@ describe("GIVEN a SteppedTracker", () => {
       .should("not.exist");
   });
 
-  it("should show warning icon if a state is warning", () => {
+  it("should show warning icon if icon prop is warning", () => {
     const labels = ["Step 1", "Step 2", "Step 3"];
 
-    const stepNum = 1;
-
     const TestComponent = (
-      <SteppedTracker activeStep={stepNum} style={{ width: 300 }}>
+      <SteppedTracker activeStep={0} style={{ width: 300 }}>
         {labels.map((label, key) => (
           <TrackerStep
             key={key}
-            state={key === stepNum ? "warning" : undefined}
+            TBC_PROP_NAME={key === 1 ? "warning" : undefined}
           >
             <StepLabel>{label}</StepLabel>
           </TrackerStep>
@@ -165,24 +163,21 @@ describe("GIVEN a SteppedTracker", () => {
     cy.mount(TestComponent);
 
     cy.findAllByRole("listitem")
-      .filter(`:nth-child(${stepNum + 1})`)
+      .filter(`:nth-child(${2})`)
       .findByTestId("WarningSolidIcon")
       .should("exist");
-    cy.findAllByRole("listitem")
-      .not(`:nth-child(${stepNum + 1})`)
-      .findByTestId("StepActiveIcon")
-      .should("not.exist");
   });
 
-  it("should show error icon if a state is error", () => {
+  it("should show error icon if icon prop is error", () => {
     const labels = ["Step 1", "Step 2", "Step 3"];
 
-    const stepNum = 1;
-
     const TestComponent = (
-      <SteppedTracker activeStep={stepNum} style={{ width: 300 }}>
+      <SteppedTracker activeStep={0} style={{ width: 300 }}>
         {labels.map((label, key) => (
-          <TrackerStep key={key} state={key === stepNum ? "error" : undefined}>
+          <TrackerStep
+            key={key}
+            TBC_PROP_NAME={key === 1 ? "error" : undefined}
+          >
             <StepLabel>{label}</StepLabel>
           </TrackerStep>
         ))}
@@ -192,12 +187,8 @@ describe("GIVEN a SteppedTracker", () => {
     cy.mount(TestComponent);
 
     cy.findAllByRole("listitem")
-      .filter(`:nth-child(${stepNum + 1})`)
+      .filter(`:nth-child(${2})`)
       .findByTestId("ErrorSolidIcon")
       .should("exist");
-    cy.findAllByRole("listitem")
-      .not(`:nth-child(${stepNum + 1})`)
-      .findByTestId("StepActiveIcon")
-      .should("not.exist");
   });
 });

--- a/packages/lab/src/__tests__/__e2e__/stepped-tracker/SteppedTracker.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/stepped-tracker/SteppedTracker.cy.tsx
@@ -94,7 +94,7 @@ describe("GIVEN a SteppedTracker", () => {
         {labels.map((label, key) => (
           <TrackerStep
             key={key}
-            TBC_PROP_NAME={key === completedStep ? "completed" : undefined}
+            stage={key === completedStep ? "completed" : undefined}
           >
             <StepLabel>{label}</StepLabel>
           </TrackerStep>
@@ -114,7 +114,7 @@ describe("GIVEN a SteppedTracker", () => {
       .should("not.exist");
   });
 
-  it("should show completed icon if icon prop is completed and active", () => {
+  it("should show completed icon if stage prop is completed and step is active", () => {
     const labels = ["Step 1", "Step 2", "Step 3"];
 
     const stepNum = 1;
@@ -124,7 +124,7 @@ describe("GIVEN a SteppedTracker", () => {
         {labels.map((label, key) => (
           <TrackerStep
             key={key}
-            TBC_PROP_NAME={key === stepNum ? "completed" : undefined}
+            stage={key === stepNum ? "completed" : undefined}
           >
             <StepLabel>{label}</StepLabel>
           </TrackerStep>
@@ -144,16 +144,13 @@ describe("GIVEN a SteppedTracker", () => {
       .should("not.exist");
   });
 
-  it("should show warning icon if icon prop is warning", () => {
+  it("should show warning icon if status prop is warning", () => {
     const labels = ["Step 1", "Step 2", "Step 3"];
 
     const TestComponent = (
       <SteppedTracker activeStep={0} style={{ width: 300 }}>
         {labels.map((label, key) => (
-          <TrackerStep
-            key={key}
-            TBC_PROP_NAME={key === 1 ? "warning" : undefined}
-          >
+          <TrackerStep key={key} status={key === 1 ? "warning" : undefined}>
             <StepLabel>{label}</StepLabel>
           </TrackerStep>
         ))}
@@ -168,7 +165,7 @@ describe("GIVEN a SteppedTracker", () => {
       .should("exist");
   });
 
-  it("should show error icon if icon prop is error", () => {
+  it("should show completed icon if status prop is warning but stage prop is completed", () => {
     const labels = ["Step 1", "Step 2", "Step 3"];
 
     const TestComponent = (
@@ -176,8 +173,51 @@ describe("GIVEN a SteppedTracker", () => {
         {labels.map((label, key) => (
           <TrackerStep
             key={key}
-            TBC_PROP_NAME={key === 1 ? "error" : undefined}
+            stage={key <= 1 ? "completed" : undefined}
+            status={key === 1 ? "warning" : undefined}
           >
+            <StepLabel>{label}</StepLabel>
+          </TrackerStep>
+        ))}
+      </SteppedTracker>
+    );
+
+    cy.mount(TestComponent);
+
+    cy.findAllByRole("listitem")
+      .filter(`:nth-child(${2})`)
+      .findByTestId("StepSuccessIcon")
+      .should("exist");
+  });
+
+  it("should show active icon if status prop is warning but step is active", () => {
+    const labels = ["Step 1", "Step 2", "Step 3"];
+
+    const TestComponent = (
+      <SteppedTracker activeStep={1} style={{ width: 300 }}>
+        {labels.map((label, key) => (
+          <TrackerStep key={key} status={key === 1 ? "warning" : undefined}>
+            <StepLabel>{label}</StepLabel>
+          </TrackerStep>
+        ))}
+      </SteppedTracker>
+    );
+
+    cy.mount(TestComponent);
+
+    cy.findAllByRole("listitem")
+      .filter(`:nth-child(${2})`)
+      .findByTestId("StepActiveIcon")
+      .should("exist");
+  });
+
+  it("should show error icon if status prop is error", () => {
+    const labels = ["Step 1", "Step 2", "Step 3"];
+
+    const TestComponent = (
+      <SteppedTracker activeStep={0} style={{ width: 300 }}>
+        {labels.map((label, key) => (
+          <TrackerStep key={key} status={key === 1 ? "error" : undefined}>
             <StepLabel>{label}</StepLabel>
           </TrackerStep>
         ))}

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
@@ -1,6 +1,8 @@
 .saltTrackerStep {
   --trackerStep-icon-color-active: var(--saltTrackerStep-icon-color-active, var(--salt-status-info-foreground-decorative));
   --trackerStep-icon-color-completed: var(--saltTrackerStep-icon-color-completed, var(--salt-status-success-foreground-decorative));
+  --trackerStep-icon-color-warning: var(--saltTrackerStep-icon-color-completed, var(--salt-status-warning-foreground-decorative));
+  --trackerStep-icon-color-error: var(--saltTrackerStep-icon-color-completed, var(--salt-status-error-foreground-decorative));
 
   --trackerStep-icon-color: var(--saltTrackerStep-icon-color, var(--salt-status-static-foreground));
 
@@ -56,4 +58,10 @@
 
 .saltTrackerStep.saltTrackerStep-completed {
   --trackerStep-icon-color: var(--trackerStep-icon-color-completed);
+}
+.saltTrackerStep.saltTrackerStep-warning {
+  --trackerStep-icon-color: var(--trackerStep-icon-color-warning);
+}
+.saltTrackerStep.saltTrackerStep-error {
+  --trackerStep-icon-color: var(--trackerStep-icon-color-error);
 }

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
@@ -1,8 +1,8 @@
 .saltTrackerStep {
   --trackerStep-icon-color-active: var(--saltTrackerStep-icon-color-active, var(--salt-status-info-foreground-decorative));
   --trackerStep-icon-color-completed: var(--saltTrackerStep-icon-color-completed, var(--salt-status-success-foreground-decorative));
-  --trackerStep-icon-color-warning: var(--saltTrackerStep-icon-color-completed, var(--salt-status-warning-foreground-decorative));
-  --trackerStep-icon-color-error: var(--saltTrackerStep-icon-color-completed, var(--salt-status-error-foreground-decorative));
+  --trackerStep-icon-color-warning: var(--saltTrackerStep-icon-color-warning, var(--salt-status-warning-foreground-decorative));
+  --trackerStep-icon-color-error: var(--saltTrackerStep-icon-color-error, var(--salt-status-error-foreground-decorative));
 
   --trackerStep-icon-color: var(--saltTrackerStep-icon-color, var(--salt-status-static-foreground));
 

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
@@ -52,16 +52,18 @@
   flex-direction: column;
 }
 
+.saltTrackerStep.saltTrackerStep-status-warning {
+  --trackerStep-icon-color: var(--trackerStep-icon-color-warning);
+}
+
+.saltTrackerStep.saltTrackerStep-status-error {
+  --trackerStep-icon-color: var(--trackerStep-icon-color-error);
+}
+
 .saltTrackerStep.saltTrackerStep-active {
   --trackerStep-icon-color: var(--trackerStep-icon-color-active);
 }
 
-.saltTrackerStep.saltTrackerStep-completed {
+.saltTrackerStep.saltTrackerStep-stage-completed {
   --trackerStep-icon-color: var(--trackerStep-icon-color-completed);
-}
-.saltTrackerStep.saltTrackerStep-warning {
-  --trackerStep-icon-color: var(--trackerStep-icon-color-warning);
-}
-.saltTrackerStep.saltTrackerStep-error {
-  --trackerStep-icon-color: var(--trackerStep-icon-color-error);
 }

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
@@ -21,48 +21,21 @@ import trackerStepCss from "./TrackerStep.css";
 
 const withBaseName = makePrefixer("saltTrackerStep");
 
-type State = "default" | "completed" | "warning" | "error";
-
-type StateWithActive = State | "active";
+type TBC_PROP_NAMEOptions = "pending" | "completed" | "warning" | "error";
 
 export interface TrackerStepProps extends ComponentPropsWithoutRef<"li"> {
   /**
-   * The state of the TrackerStep
+   * The slug of the icon to be displayed in the TrackerStep
    */
-  state?: State;
+  TBC_PROP_NAME?: TBC_PROP_NAMEOptions;
 }
 
 const iconMap = {
-  default: StepDefaultIcon,
+  pending: StepDefaultIcon,
+  active: StepActiveIcon,
   completed: StepSuccessIcon,
   warning: WarningSolidIcon,
   error: ErrorSolidIcon,
-};
-
-const getStateIcon = ({
-  isActive,
-  state,
-}: {
-  isActive: boolean;
-  state: State;
-}) => {
-  if (state === "default" && isActive) {
-    return StepActiveIcon;
-  }
-  return iconMap[state];
-};
-
-const getState = ({
-  isActive,
-  state,
-}: {
-  isActive: boolean;
-  state: State;
-}): StateWithActive => {
-  if (state === "default" && isActive) {
-    return "active";
-  }
-  return state;
 };
 
 const useCheckWithinSteppedTracker = (isWithinSteppedTracker: boolean) => {
@@ -77,10 +50,16 @@ const useCheckWithinSteppedTracker = (isWithinSteppedTracker: boolean) => {
   }, [isWithinSteppedTracker]);
 };
 
+const parseIconSlug = (iconSlug: TBC_PROP_NAMEOptions, active: boolean) => {
+  if (iconSlug === "completed") return iconSlug;
+  if (active) return "active";
+  return iconSlug;
+};
+
 export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
   function TrackerStep(props, ref) {
     const {
-      state = "default",
+      TBC_PROP_NAME = "pending",
       style,
       className,
       children,
@@ -101,8 +80,9 @@ export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
     useCheckWithinSteppedTracker(isWithinSteppedTracker);
 
     const isActive = activeStep === stepNumber;
-    const Icon = getStateIcon({ isActive, state });
-    const resolvedState = getState({ isActive, state });
+    const iconSlug = parseIconSlug(TBC_PROP_NAME, isActive);
+
+    const Icon = iconMap[iconSlug];
     const connectorState = activeStep > stepNumber ? "active" : "default";
     const hasConnector = stepNumber < totalSteps - 1;
 
@@ -113,10 +93,10 @@ export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
 
     return (
       <li
-        className={clsx(withBaseName(), withBaseName(resolvedState), className)}
+        className={clsx(withBaseName(), withBaseName(iconSlug), className)}
         style={innerStyle}
         aria-current={isActive ? "step" : undefined}
-        data-state={state}
+        data-state={iconSlug}
         ref={ref}
         {...restProps}
       >

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
@@ -21,13 +21,15 @@ import trackerStepCss from "./TrackerStep.css";
 
 const withBaseName = makePrefixer("saltTrackerStep");
 
-type TBC_PROP_NAMEOptions = "pending" | "completed" | "warning" | "error";
+type StageOptions = "pending" | "completed";
+type StatusOptions = "warning" | "error" | undefined;
 
 export interface TrackerStepProps extends ComponentPropsWithoutRef<"li"> {
   /**
    * The slug of the icon to be displayed in the TrackerStep
    */
-  TBC_PROP_NAME?: TBC_PROP_NAMEOptions;
+  stage?: StageOptions;
+  status?: StatusOptions;
 }
 
 const iconMap = {
@@ -50,16 +52,22 @@ const useCheckWithinSteppedTracker = (isWithinSteppedTracker: boolean) => {
   }, [isWithinSteppedTracker]);
 };
 
-const parseIconSlug = (iconSlug: TBC_PROP_NAMEOptions, active: boolean) => {
-  if (iconSlug === "completed") return iconSlug;
+const parseState = (
+  stage: StageOptions,
+  status: StatusOptions,
+  active: boolean
+) => {
+  if (stage === "completed") return "completed";
   if (active) return "active";
-  return iconSlug;
+  if (status) return status;
+  return stage;
 };
 
 export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
   function TrackerStep(props, ref) {
     const {
-      TBC_PROP_NAME = "pending",
+      stage = "pending",
+      status,
       style,
       className,
       children,
@@ -80,9 +88,9 @@ export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
     useCheckWithinSteppedTracker(isWithinSteppedTracker);
 
     const isActive = activeStep === stepNumber;
-    const iconSlug = parseIconSlug(TBC_PROP_NAME, isActive);
+    const state = parseState(stage, status, isActive);
 
-    const Icon = iconMap[iconSlug];
+    const Icon = iconMap[state];
     const connectorState = activeStep > stepNumber ? "active" : "default";
     const hasConnector = stepNumber < totalSteps - 1;
 
@@ -93,10 +101,10 @@ export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
 
     return (
       <li
-        className={clsx(withBaseName(), withBaseName(iconSlug), className)}
+        className={clsx(withBaseName(), withBaseName(state), className)}
         style={innerStyle}
         aria-current={isActive ? "step" : undefined}
-        data-state={iconSlug}
+        data-state={state}
         ref={ref}
         {...restProps}
       >

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
@@ -22,7 +22,13 @@ import trackerStepCss from "./TrackerStep.css";
 const withBaseName = makePrefixer("saltTrackerStep");
 
 type StageOptions = "pending" | "completed";
-type StatusOptions = "warning" | "error" | undefined;
+type StatusOptions = "warning" | "error";
+
+interface ParseStateProps {
+  stage: StageOptions;
+  status?: StatusOptions;
+  active: boolean;
+}
 
 export interface TrackerStepProps extends ComponentPropsWithoutRef<"li"> {
   /**
@@ -57,11 +63,7 @@ const useCheckWithinSteppedTracker = (isWithinSteppedTracker: boolean) => {
   }, [isWithinSteppedTracker]);
 };
 
-const parseState = (
-  stage: StageOptions,
-  status: StatusOptions,
-  active: boolean
-) => {
+const parseState = ({ stage, status, active }: ParseStateProps) => {
   if (stage === "completed") return "completed";
   if (active) return "active";
   if (status) return status;
@@ -93,7 +95,7 @@ export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
     useCheckWithinSteppedTracker(isWithinSteppedTracker);
 
     const isActive = activeStep === stepNumber;
-    const state = parseState(stage, status, isActive);
+    const state = parseState({ stage, status, active: isActive });
 
     const Icon = iconMap[state];
     const connectorState = activeStep > stepNumber ? "active" : "default";

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
@@ -24,7 +24,7 @@ const withBaseName = makePrefixer("saltTrackerStep");
 type StageOptions = "pending" | "completed";
 type StatusOptions = Extract<ValidationStatus, "warning" | "error">;
 
-interface ParseStateProps {
+interface ParseIconNameProps {
   stage: StageOptions;
   status?: StatusOptions;
   active: boolean;
@@ -63,7 +63,7 @@ const useCheckWithinSteppedTracker = (isWithinSteppedTracker: boolean) => {
   }, [isWithinSteppedTracker]);
 };
 
-const parseState = ({ stage, status, active }: ParseStateProps) => {
+const parseIconName = ({ stage, status, active }: ParseIconNameProps) => {
   if (stage === "completed") return "completed";
   if (active) return "active";
   if (status) return status;
@@ -95,9 +95,9 @@ export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
     useCheckWithinSteppedTracker(isWithinSteppedTracker);
 
     const isActive = activeStep === stepNumber;
-    const state = parseState({ stage, status, active: isActive });
+    const iconName = parseIconName({ stage, status, active: isActive });
 
-    const Icon = iconMap[state];
+    const Icon = iconMap[iconName];
     const connectorState = activeStep > stepNumber ? "active" : "default";
     const hasConnector = stepNumber < totalSteps - 1;
 
@@ -108,10 +108,9 @@ export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
 
     return (
       <li
-        className={clsx(withBaseName(), withBaseName(state), className)}
+        className={clsx(withBaseName(), withBaseName(iconName), className)}
         style={innerStyle}
         aria-current={isActive ? "step" : undefined}
-        data-state={state}
         ref={ref}
         {...restProps}
       >

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
@@ -110,7 +110,13 @@ export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
 
     return (
       <li
-        className={clsx(withBaseName(), withBaseName(iconName), className)}
+        className={clsx(
+          className,
+          withBaseName(),
+          withBaseName(`stage-${stage}`),
+          withBaseName(`status-${status}`),
+          { [withBaseName("active")]: isActive },
+        )}
         style={innerStyle}
         aria-current={isActive ? "step" : undefined}
         ref={ref}

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
@@ -24,12 +24,6 @@ const withBaseName = makePrefixer("saltTrackerStep");
 type StageOptions = "pending" | "completed";
 type StatusOptions = Extract<ValidationStatus, "warning" | "error">;
 
-interface ParseIconNameProps {
-  stage: StageOptions;
-  status?: StatusOptions;
-  active: boolean;
-}
-
 export interface TrackerStepProps extends ComponentPropsWithoutRef<"li"> {
   /**
    * The stage of the step: "pending" or "completed" (note, "active" is derived from "activeStep" in parent SteppedTracker component)
@@ -63,7 +57,15 @@ const useCheckWithinSteppedTracker = (isWithinSteppedTracker: boolean) => {
   }, [isWithinSteppedTracker]);
 };
 
-const parseIconName = ({ stage, status, active }: ParseIconNameProps) => {
+const parseIconName = ({
+  stage,
+  status,
+  active,
+}: {
+  stage: StageOptions;
+  status?: StatusOptions;
+  active: boolean;
+}) => {
   if (stage === "completed") return "completed";
   if (active) return "active";
   if (status) return status;

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
@@ -111,11 +111,11 @@ export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
     return (
       <li
         className={clsx(
-          className,
           withBaseName(),
           withBaseName(`stage-${stage}`),
           withBaseName(`status-${status}`),
           { [withBaseName("active")]: isActive },
+          className,
         )}
         style={innerStyle}
         aria-current={isActive ? "step" : undefined}

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
@@ -26,9 +26,14 @@ type StatusOptions = "warning" | "error" | undefined;
 
 export interface TrackerStepProps extends ComponentPropsWithoutRef<"li"> {
   /**
-   * The slug of the icon to be displayed in the TrackerStep
+   * The stage of the step: "pending" or "completed" (note, "active" is derived from "activeStep" in parent SteppedTracker component)
    */
   stage?: StageOptions;
+  /**
+   * The status of the step: warning or error
+   *
+   * If the stage is completed or active, the status prop will be ignored
+   */
   status?: StatusOptions;
 }
 

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
@@ -3,6 +3,8 @@ import {
   StepActiveIcon,
   StepDefaultIcon,
   StepSuccessIcon,
+  WarningSolidIcon,
+  ErrorSolidIcon,
 } from "@salt-ds/icons";
 import { useComponentCssInjection } from "@salt-ds/styles";
 import { useWindow } from "@salt-ds/window";
@@ -19,7 +21,7 @@ import trackerStepCss from "./TrackerStep.css";
 
 const withBaseName = makePrefixer("saltTrackerStep");
 
-type State = "default" | "completed";
+type State = "default" | "completed" | "warning" | "error";
 
 type StateWithActive = State | "active";
 
@@ -33,6 +35,8 @@ export interface TrackerStepProps extends ComponentPropsWithoutRef<"li"> {
 const iconMap = {
   default: StepDefaultIcon,
   completed: StepSuccessIcon,
+  warning: WarningSolidIcon,
+  error: ErrorSolidIcon,
 };
 
 const getStateIcon = ({

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
@@ -1,4 +1,4 @@
-import { makePrefixer } from "@salt-ds/core";
+import { makePrefixer, type ValidationStatus } from "@salt-ds/core";
 import {
   StepActiveIcon,
   StepDefaultIcon,
@@ -22,7 +22,7 @@ import trackerStepCss from "./TrackerStep.css";
 const withBaseName = makePrefixer("saltTrackerStep");
 
 type StageOptions = "pending" | "completed";
-type StatusOptions = "warning" | "error";
+type StatusOptions = Extract<ValidationStatus, "warning" | "error">;
 
 interface ParseStateProps {
   stage: StageOptions;

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
@@ -1,10 +1,10 @@
-import { makePrefixer, type ValidationStatus } from "@salt-ds/core";
+import { type ValidationStatus, makePrefixer } from "@salt-ds/core";
 import {
+  ErrorSolidIcon,
   StepActiveIcon,
   StepDefaultIcon,
   StepSuccessIcon,
   WarningSolidIcon,
-  ErrorSolidIcon,
 } from "@salt-ds/icons";
 import { useComponentCssInjection } from "@salt-ds/styles";
 import { useWindow } from "@salt-ds/window";

--- a/packages/lab/stories/stepped-tracker/stepped-tracker.qa.stories.tsx
+++ b/packages/lab/stories/stepped-tracker/stepped-tracker.qa.stories.tsx
@@ -36,41 +36,41 @@ export const Basic: StoryFn<QAContainerProps> = (props) => {
           </TrackerStep>
         </SteppedTracker>
         <SteppedTracker orientation="horizontal" activeStep={2}>
-          <TrackerStep state="completed">
+          <TrackerStep TBC_PROP_NAME="completed">
             <StepLabel>Step One</StepLabel>
           </TrackerStep>
-          <TrackerStep state="completed">
+          <TrackerStep TBC_PROP_NAME="completed">
             <StepLabel>Step Two</StepLabel>
           </TrackerStep>
-          <TrackerStep state="default">
+          <TrackerStep TBC_PROP_NAME="pending">
             <StepLabel>Step Three</StepLabel>
           </TrackerStep>
-          <TrackerStep state="default">
+          <TrackerStep TBC_PROP_NAME="pending">
             <StepLabel>Step Four</StepLabel>
           </TrackerStep>
         </SteppedTracker>
         <SteppedTracker orientation="horizontal" activeStep={3}>
-          <TrackerStep state="completed">
+          <TrackerStep TBC_PROP_NAME="completed">
             <StepLabel>Step One</StepLabel>
           </TrackerStep>
-          <TrackerStep state="completed">
+          <TrackerStep TBC_PROP_NAME="completed">
             <StepLabel>Step Two</StepLabel>
           </TrackerStep>
-          <TrackerStep state="completed">
+          <TrackerStep TBC_PROP_NAME="completed">
             <StepLabel>Step Three</StepLabel>
           </TrackerStep>
-          <TrackerStep state="completed">
+          <TrackerStep TBC_PROP_NAME="completed">
             <StepLabel>Step Four</StepLabel>
           </TrackerStep>
         </SteppedTracker>
         <SteppedTracker activeStep={0}>
-          <TrackerStep state="completed">
+          <TrackerStep TBC_PROP_NAME="completed">
             <StepLabel>Completed</StepLabel>
           </TrackerStep>
-          <TrackerStep state="warning">
+          <TrackerStep TBC_PROP_NAME="warning">
             <StepLabel>Warning</StepLabel>
           </TrackerStep>
-          <TrackerStep state="error">
+          <TrackerStep TBC_PROP_NAME="error">
             <StepLabel>Error</StepLabel>
           </TrackerStep>
           <TrackerStep>
@@ -113,41 +113,41 @@ export const Vertical: StoryFn<QAContainerProps> = (props) => {
           </TrackerStep>
         </SteppedTracker>
         <SteppedTracker orientation="vertical" activeStep={2}>
-          <TrackerStep state="completed">
+          <TrackerStep TBC_PROP_NAME="completed">
             <StepLabel>Step One</StepLabel>
           </TrackerStep>
-          <TrackerStep state="completed">
+          <TrackerStep TBC_PROP_NAME="completed">
             <StepLabel>Step Two</StepLabel>
           </TrackerStep>
-          <TrackerStep state="default">
+          <TrackerStep TBC_PROP_NAME="pending">
             <StepLabel>Step Three</StepLabel>
           </TrackerStep>
-          <TrackerStep state="default">
+          <TrackerStep TBC_PROP_NAME="pending">
             <StepLabel>Step Four</StepLabel>
           </TrackerStep>
         </SteppedTracker>
         <SteppedTracker orientation="vertical" activeStep={3}>
-          <TrackerStep state="completed">
+          <TrackerStep TBC_PROP_NAME="completed">
             <StepLabel>Step One</StepLabel>
           </TrackerStep>
-          <TrackerStep state="completed">
+          <TrackerStep TBC_PROP_NAME="completed">
             <StepLabel>Step Two</StepLabel>
           </TrackerStep>
-          <TrackerStep state="completed">
+          <TrackerStep TBC_PROP_NAME="completed">
             <StepLabel>Step Three</StepLabel>
           </TrackerStep>
-          <TrackerStep state="completed">
+          <TrackerStep TBC_PROP_NAME="completed">
             <StepLabel>Step Four</StepLabel>
           </TrackerStep>
         </SteppedTracker>
         <SteppedTracker orientation="vertical" activeStep={0}>
-          <TrackerStep state="completed">
+          <TrackerStep TBC_PROP_NAME="completed">
             <StepLabel>Completed</StepLabel>
           </TrackerStep>
-          <TrackerStep state="warning">
+          <TrackerStep TBC_PROP_NAME="warning">
             <StepLabel>Warning</StepLabel>
           </TrackerStep>
-          <TrackerStep state="error">
+          <TrackerStep TBC_PROP_NAME="error">
             <StepLabel>Error</StepLabel>
           </TrackerStep>
           <TrackerStep>

--- a/packages/lab/stories/stepped-tracker/stepped-tracker.qa.stories.tsx
+++ b/packages/lab/stories/stepped-tracker/stepped-tracker.qa.stories.tsx
@@ -63,6 +63,20 @@ export const Basic: StoryFn<QAContainerProps> = (props) => {
             <StepLabel>Step Four</StepLabel>
           </TrackerStep>
         </SteppedTracker>
+        <SteppedTracker activeStep={0}>
+          <TrackerStep state="completed">
+            <StepLabel>Completed</StepLabel>
+          </TrackerStep>
+          <TrackerStep state="warning">
+            <StepLabel>Warning</StepLabel>
+          </TrackerStep>
+          <TrackerStep state="error">
+            <StepLabel>Error</StepLabel>
+          </TrackerStep>
+          <TrackerStep>
+            <StepLabel>Default</StepLabel>
+          </TrackerStep>
+        </SteppedTracker>
       </StackLayout>
     </QAContainer>
   );
@@ -124,6 +138,20 @@ export const Vertical: StoryFn<QAContainerProps> = (props) => {
           </TrackerStep>
           <TrackerStep state="completed">
             <StepLabel>Step Four</StepLabel>
+          </TrackerStep>
+        </SteppedTracker>
+        <SteppedTracker orientation="vertical" activeStep={0}>
+          <TrackerStep state="completed">
+            <StepLabel>Completed</StepLabel>
+          </TrackerStep>
+          <TrackerStep state="warning">
+            <StepLabel>Warning</StepLabel>
+          </TrackerStep>
+          <TrackerStep state="error">
+            <StepLabel>Error</StepLabel>
+          </TrackerStep>
+          <TrackerStep>
+            <StepLabel>Default</StepLabel>
           </TrackerStep>
         </SteppedTracker>
       </StackLayout>

--- a/packages/lab/stories/stepped-tracker/stepped-tracker.qa.stories.tsx
+++ b/packages/lab/stories/stepped-tracker/stepped-tracker.qa.stories.tsx
@@ -49,23 +49,23 @@ export const Basic: StoryFn<QAContainerProps> = (props) => {
             <StepLabel>Step Four</StepLabel>
           </TrackerStep>
         </SteppedTracker>
-        <SteppedTracker orientation="horizontal" activeStep={3}>
-          <TrackerStep stage="completed">
-            <StepLabel>Step One</StepLabel>
+        <SteppedTracker activeStep={1}>
+          <TrackerStep stage="completed" status="warning">
+            <StepLabel>Completed with warning</StepLabel>
+          </TrackerStep>
+          <TrackerStep status="warning">
+            <StepLabel>Active with warning</StepLabel>
+          </TrackerStep>
+          <TrackerStep stage="completed" status="error">
+            <StepLabel>Completed with error</StepLabel>
           </TrackerStep>
           <TrackerStep stage="completed">
-            <StepLabel>Step Two</StepLabel>
-          </TrackerStep>
-          <TrackerStep stage="completed">
-            <StepLabel>Step Three</StepLabel>
-          </TrackerStep>
-          <TrackerStep stage="completed">
-            <StepLabel>Step Four</StepLabel>
+            <StepLabel>Completed</StepLabel>
           </TrackerStep>
         </SteppedTracker>
         <SteppedTracker activeStep={0}>
           <TrackerStep stage="completed">
-            <StepLabel>Completed</StepLabel>
+            <StepLabel>Completed and active</StepLabel>
           </TrackerStep>
           <TrackerStep status="warning">
             <StepLabel>Warning</StepLabel>

--- a/packages/lab/stories/stepped-tracker/stepped-tracker.qa.stories.tsx
+++ b/packages/lab/stories/stepped-tracker/stepped-tracker.qa.stories.tsx
@@ -36,41 +36,41 @@ export const Basic: StoryFn<QAContainerProps> = (props) => {
           </TrackerStep>
         </SteppedTracker>
         <SteppedTracker orientation="horizontal" activeStep={2}>
-          <TrackerStep TBC_PROP_NAME="completed">
+          <TrackerStep stage="completed">
             <StepLabel>Step One</StepLabel>
           </TrackerStep>
-          <TrackerStep TBC_PROP_NAME="completed">
+          <TrackerStep stage="completed">
             <StepLabel>Step Two</StepLabel>
           </TrackerStep>
-          <TrackerStep TBC_PROP_NAME="pending">
+          <TrackerStep stage="pending">
             <StepLabel>Step Three</StepLabel>
           </TrackerStep>
-          <TrackerStep TBC_PROP_NAME="pending">
+          <TrackerStep stage="pending">
             <StepLabel>Step Four</StepLabel>
           </TrackerStep>
         </SteppedTracker>
         <SteppedTracker orientation="horizontal" activeStep={3}>
-          <TrackerStep TBC_PROP_NAME="completed">
+          <TrackerStep stage="completed">
             <StepLabel>Step One</StepLabel>
           </TrackerStep>
-          <TrackerStep TBC_PROP_NAME="completed">
+          <TrackerStep stage="completed">
             <StepLabel>Step Two</StepLabel>
           </TrackerStep>
-          <TrackerStep TBC_PROP_NAME="completed">
+          <TrackerStep stage="completed">
             <StepLabel>Step Three</StepLabel>
           </TrackerStep>
-          <TrackerStep TBC_PROP_NAME="completed">
+          <TrackerStep stage="completed">
             <StepLabel>Step Four</StepLabel>
           </TrackerStep>
         </SteppedTracker>
         <SteppedTracker activeStep={0}>
-          <TrackerStep TBC_PROP_NAME="completed">
+          <TrackerStep stage="completed">
             <StepLabel>Completed</StepLabel>
           </TrackerStep>
-          <TrackerStep TBC_PROP_NAME="warning">
+          <TrackerStep status="warning">
             <StepLabel>Warning</StepLabel>
           </TrackerStep>
-          <TrackerStep TBC_PROP_NAME="error">
+          <TrackerStep status="error">
             <StepLabel>Error</StepLabel>
           </TrackerStep>
           <TrackerStep>
@@ -113,41 +113,41 @@ export const Vertical: StoryFn<QAContainerProps> = (props) => {
           </TrackerStep>
         </SteppedTracker>
         <SteppedTracker orientation="vertical" activeStep={2}>
-          <TrackerStep TBC_PROP_NAME="completed">
+          <TrackerStep stage="completed">
             <StepLabel>Step One</StepLabel>
           </TrackerStep>
-          <TrackerStep TBC_PROP_NAME="completed">
+          <TrackerStep stage="completed">
             <StepLabel>Step Two</StepLabel>
           </TrackerStep>
-          <TrackerStep TBC_PROP_NAME="pending">
+          <TrackerStep stage="pending">
             <StepLabel>Step Three</StepLabel>
           </TrackerStep>
-          <TrackerStep TBC_PROP_NAME="pending">
+          <TrackerStep stage="pending">
             <StepLabel>Step Four</StepLabel>
           </TrackerStep>
         </SteppedTracker>
         <SteppedTracker orientation="vertical" activeStep={3}>
-          <TrackerStep TBC_PROP_NAME="completed">
+          <TrackerStep stage="completed">
             <StepLabel>Step One</StepLabel>
           </TrackerStep>
-          <TrackerStep TBC_PROP_NAME="completed">
+          <TrackerStep stage="completed">
             <StepLabel>Step Two</StepLabel>
           </TrackerStep>
-          <TrackerStep TBC_PROP_NAME="completed">
+          <TrackerStep stage="completed">
             <StepLabel>Step Three</StepLabel>
           </TrackerStep>
-          <TrackerStep TBC_PROP_NAME="completed">
+          <TrackerStep stage="completed">
             <StepLabel>Step Four</StepLabel>
           </TrackerStep>
         </SteppedTracker>
         <SteppedTracker orientation="vertical" activeStep={0}>
-          <TrackerStep TBC_PROP_NAME="completed">
+          <TrackerStep stage="completed">
             <StepLabel>Completed</StepLabel>
           </TrackerStep>
-          <TrackerStep TBC_PROP_NAME="warning">
+          <TrackerStep status="warning">
             <StepLabel>Warning</StepLabel>
           </TrackerStep>
-          <TrackerStep TBC_PROP_NAME="error">
+          <TrackerStep status="error">
             <StepLabel>Error</StepLabel>
           </TrackerStep>
           <TrackerStep>

--- a/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
+++ b/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
@@ -91,9 +91,38 @@ export const Basic: StoryFn<typeof SteppedTracker> = () => {
   );
 };
 
+export const Statuses: StoryFn<typeof SteppedTracker> = () => {
+  return (
+    <StackLayout
+      direction="column"
+      align="stretch"
+      gap={10}
+      style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
+    >
+      <SteppedTracker activeStep={1}>
+        <TrackerStep state="completed">
+          <StepLabel>Completed</StepLabel>
+        </TrackerStep>
+        <TrackerStep>
+          <StepLabel>Active</StepLabel>
+        </TrackerStep>
+        <TrackerStep state="warning">
+          <StepLabel>Warning</StepLabel>
+        </TrackerStep>
+        <TrackerStep state="error">
+          <StepLabel>Error</StepLabel>
+        </TrackerStep>
+        <TrackerStep>
+          <StepLabel>Default</StepLabel>
+        </TrackerStep>
+      </SteppedTracker>
+    </StackLayout>
+  );
+};
+
 export const SingleVertical: StoryFn<typeof SteppedTracker> = () => {
   return (
-    <SteppedTracker orientation="vertical" activeStep={2}>
+    <SteppedTracker orientation="vertical" activeStep={1}>
       <TrackerStep state="completed">
         <StepLabel>Step One</StepLabel>
       </TrackerStep>

--- a/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
+++ b/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
@@ -91,7 +91,7 @@ export const Basic: StoryFn<typeof SteppedTracker> = () => {
   );
 };
 
-export const Statuses: StoryFn<typeof SteppedTracker> = () => {
+export const Status: StoryFn<typeof SteppedTracker> = () => {
   return (
     <StackLayout
       direction="column"

--- a/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
+++ b/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
@@ -13,7 +13,7 @@ export default {
 
 interface Step {
   label: string;
-  state: "default" | "completed";
+  state: "pending" | "completed";
 }
 
 type Steps = Step[];
@@ -21,19 +21,19 @@ type Steps = Step[];
 const sampleSteps: Steps = [
   {
     label: "Step One",
-    state: "default",
+    state: "pending",
   },
   {
     label: "Step Two",
-    state: "default",
+    state: "pending",
   },
   {
     label: "Step Three",
-    state: "default",
+    state: "pending",
   },
   {
     label: "Step Four",
-    state: "default",
+    state: "pending",
   },
 ];
 
@@ -60,30 +60,30 @@ export const Basic: StoryFn<typeof SteppedTracker> = () => {
         </TrackerStep>
       </SteppedTracker>
       <SteppedTracker activeStep={2}>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step Two</StepLabel>
         </TrackerStep>
-        <TrackerStep state="default">
+        <TrackerStep>
           <StepLabel>Step Three</StepLabel>
         </TrackerStep>
-        <TrackerStep state="default">
+        <TrackerStep>
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>
       <SteppedTracker activeStep={3}>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step Two</StepLabel>
         </TrackerStep>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step Three</StepLabel>
         </TrackerStep>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>
@@ -100,16 +100,16 @@ export const Status: StoryFn<typeof SteppedTracker> = () => {
       style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
     >
       <SteppedTracker activeStep={1}>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Completed</StepLabel>
         </TrackerStep>
         <TrackerStep>
           <StepLabel>Active</StepLabel>
         </TrackerStep>
-        <TrackerStep state="warning">
+        <TrackerStep TBC_PROP_NAME="warning">
           <StepLabel>Warning</StepLabel>
         </TrackerStep>
-        <TrackerStep state="error">
+        <TrackerStep TBC_PROP_NAME="error">
           <StepLabel>Error</StepLabel>
         </TrackerStep>
         <TrackerStep>
@@ -123,16 +123,16 @@ export const Status: StoryFn<typeof SteppedTracker> = () => {
 export const SingleVertical: StoryFn<typeof SteppedTracker> = () => {
   return (
     <SteppedTracker orientation="vertical" activeStep={1}>
-      <TrackerStep state="completed">
+      <TrackerStep TBC_PROP_NAME="completed">
         <StepLabel>Step One</StepLabel>
       </TrackerStep>
-      <TrackerStep state="completed">
+      <TrackerStep TBC_PROP_NAME="completed">
         <StepLabel>Step Two</StepLabel>
       </TrackerStep>
-      <TrackerStep state="default">
+      <TrackerStep>
         <StepLabel>Step Three</StepLabel>
       </TrackerStep>
-      <TrackerStep state="default">
+      <TrackerStep>
         <StepLabel>Step Four</StepLabel>
       </TrackerStep>
     </SteppedTracker>
@@ -162,30 +162,30 @@ export const BasicVertical: StoryFn<typeof SteppedTracker> = () => {
         </TrackerStep>
       </SteppedTracker>
       <SteppedTracker orientation="vertical" activeStep={2}>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step Two</StepLabel>
         </TrackerStep>
-        <TrackerStep state="default">
+        <TrackerStep>
           <StepLabel>Step Three</StepLabel>
         </TrackerStep>
-        <TrackerStep state="default">
+        <TrackerStep>
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>
       <SteppedTracker orientation="vertical" activeStep={3}>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step Two</StepLabel>
         </TrackerStep>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step Three</StepLabel>
         </TrackerStep>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>
@@ -227,8 +227,8 @@ export const AutoProgress: StoryFn<typeof SteppedTracker> = () => {
       style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
     >
       <SteppedTracker activeStep={activeStep}>
-        {steps.map(({ label, state }) => (
-          <TrackerStep state={state} key={label}>
+        {steps.map(({ label, state }, key) => (
+          <TrackerStep TBC_PROP_NAME={state} key={key}>
             <StepLabel>{label}</StepLabel>
           </TrackerStep>
         ))}
@@ -253,20 +253,20 @@ export const WrappingLabel: StoryFn<typeof SteppedTracker> = () => {
       style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
     >
       <SteppedTracker activeStep={0}>
-        <TrackerStep state="default">
+        <TrackerStep>
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
-        <TrackerStep state="default">
+        <TrackerStep>
           <StepLabel>
             Step Two: I am a label that wraps on smaller screen sizes
           </StepLabel>
         </TrackerStep>
-        <TrackerStep state="default">
+        <TrackerStep>
           <StepLabel>
             Step Three: I am a label that wraps on smaller screen sizes
           </StepLabel>
         </TrackerStep>
-        <TrackerStep state="default">
+        <TrackerStep>
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>
@@ -293,7 +293,7 @@ export const NonSequentialProgress: StoryFn<typeof SteppedTracker> = () => {
         i === activeStep
           ? {
               ...step,
-              state: step.state === "default" ? "completed" : "default",
+              state: step.state === "pending" ? "completed" : "pending",
             }
           : step,
       ),
@@ -307,8 +307,8 @@ export const NonSequentialProgress: StoryFn<typeof SteppedTracker> = () => {
       style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
     >
       <SteppedTracker activeStep={activeStep}>
-        {steps.map(({ label, state }) => (
-          <TrackerStep state={state} key={label}>
+        {steps.map(({ label, state }, key) => (
+          <TrackerStep TBC_PROP_NAME={state} key={key}>
             <StepLabel>{label}</StepLabel>
           </TrackerStep>
         ))}

--- a/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
+++ b/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
@@ -93,10 +93,7 @@ export const Basic: StoryFn<typeof SteppedTracker> = () => {
 
 export const Status: StoryFn<typeof SteppedTracker> = () => {
   return (
-    <StackLayout
-      direction="column"
-      align="stretch"
-      gap={10}
+    <div
       style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
     >
       <SteppedTracker activeStep={1}>
@@ -116,7 +113,7 @@ export const Status: StoryFn<typeof SteppedTracker> = () => {
           <StepLabel>Default</StepLabel>
         </TrackerStep>
       </SteppedTracker>
-    </StackLayout>
+    </div>
   );
 };
 

--- a/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
+++ b/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
@@ -224,8 +224,8 @@ export const AutoProgress: StoryFn<typeof SteppedTracker> = () => {
       style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
     >
       <SteppedTracker activeStep={activeStep}>
-        {steps.map(({ label, state }, key) => (
-          <TrackerStep stage={state} key={key}>
+        {steps.map(({ label, state }) => (
+          <TrackerStep stage={state} key={label}>
             <StepLabel>{label}</StepLabel>
           </TrackerStep>
         ))}
@@ -304,8 +304,8 @@ export const NonSequentialProgress: StoryFn<typeof SteppedTracker> = () => {
       style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
     >
       <SteppedTracker activeStep={activeStep}>
-        {steps.map(({ label, state }, key) => (
-          <TrackerStep stage={state} key={key}>
+        {steps.map(({ label, state }) => (
+          <TrackerStep stage={state} key={label}>
             <StepLabel>{label}</StepLabel>
           </TrackerStep>
         ))}

--- a/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
+++ b/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
@@ -60,10 +60,10 @@ export const Basic: StoryFn<typeof SteppedTracker> = () => {
         </TrackerStep>
       </SteppedTracker>
       <SteppedTracker activeStep={2}>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step Two</StepLabel>
         </TrackerStep>
         <TrackerStep>
@@ -74,16 +74,16 @@ export const Basic: StoryFn<typeof SteppedTracker> = () => {
         </TrackerStep>
       </SteppedTracker>
       <SteppedTracker activeStep={3}>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step Two</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step Three</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>
@@ -100,16 +100,16 @@ export const Status: StoryFn<typeof SteppedTracker> = () => {
       style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
     >
       <SteppedTracker activeStep={1}>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Completed</StepLabel>
         </TrackerStep>
         <TrackerStep>
           <StepLabel>Active</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="warning">
+        <TrackerStep status="warning">
           <StepLabel>Warning</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="error">
+        <TrackerStep status="error">
           <StepLabel>Error</StepLabel>
         </TrackerStep>
         <TrackerStep>
@@ -123,10 +123,10 @@ export const Status: StoryFn<typeof SteppedTracker> = () => {
 export const SingleVertical: StoryFn<typeof SteppedTracker> = () => {
   return (
     <SteppedTracker orientation="vertical" activeStep={1}>
-      <TrackerStep TBC_PROP_NAME="completed">
+      <TrackerStep stage="completed">
         <StepLabel>Step One</StepLabel>
       </TrackerStep>
-      <TrackerStep TBC_PROP_NAME="completed">
+      <TrackerStep stage="completed">
         <StepLabel>Step Two</StepLabel>
       </TrackerStep>
       <TrackerStep>
@@ -162,10 +162,10 @@ export const BasicVertical: StoryFn<typeof SteppedTracker> = () => {
         </TrackerStep>
       </SteppedTracker>
       <SteppedTracker orientation="vertical" activeStep={2}>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step Two</StepLabel>
         </TrackerStep>
         <TrackerStep>
@@ -176,16 +176,16 @@ export const BasicVertical: StoryFn<typeof SteppedTracker> = () => {
         </TrackerStep>
       </SteppedTracker>
       <SteppedTracker orientation="vertical" activeStep={3}>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step Two</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step Three</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>
@@ -228,7 +228,7 @@ export const AutoProgress: StoryFn<typeof SteppedTracker> = () => {
     >
       <SteppedTracker activeStep={activeStep}>
         {steps.map(({ label, state }, key) => (
-          <TrackerStep TBC_PROP_NAME={state} key={key}>
+          <TrackerStep stage={state} key={key}>
             <StepLabel>{label}</StepLabel>
           </TrackerStep>
         ))}
@@ -308,7 +308,7 @@ export const NonSequentialProgress: StoryFn<typeof SteppedTracker> = () => {
     >
       <SteppedTracker activeStep={activeStep}>
         {steps.map(({ label, state }, key) => (
-          <TrackerStep TBC_PROP_NAME={state} key={key}>
+          <TrackerStep stage={state} key={key}>
             <StepLabel>{label}</StepLabel>
           </TrackerStep>
         ))}

--- a/site/docs/components/stepped-tracker/examples.mdx
+++ b/site/docs/components/stepped-tracker/examples.mdx
@@ -22,11 +22,11 @@ You can add a label to the `TrackerStep` using the `StepLabel` component.
 
   <LivePreview componentName="stepped-tracker" exampleName="Status" >
 
-## Status
+## Icon
 
-`SteppedTracker` supports multiple statuses for each `TrackerStep` child component using the `state` prop.
+`SteppedTracker` supports multiple icons for each `TrackerStep` child component using the `TBC_PROP_NAME` prop.
 
-Available status values are: `"default"`, `"completed"`, `"warning"`, and `"error"`. _Note that `"active"` is not a valid status value: the active step is defined by the `activeStep` prop on the `SteppedTracker` component._
+Available icon values are: `"pending"`, `"completed"`, `"warning"`, and `"error"`. _Note that `"active"` is not a valid value: the active step is defined by the `activeStep` prop on the `SteppedTracker` component._
 
   </LivePreview>
 

--- a/site/docs/components/stepped-tracker/examples.mdx
+++ b/site/docs/components/stepped-tracker/examples.mdx
@@ -26,7 +26,7 @@ You can add a label to the `TrackerStep` using the `StepLabel` component.
 
 `SteppedTracker` supports multiple statuses for each `TrackerStep` child component using the `state` prop.
 
-Available status values are: `"default"`, `"complete"`, `"warning"`, and `"error"`. _Note that `"active"` is not a valid status value: the active step is defined by the `activeStep` prop on the `SteppedTracker` component._
+Available status values are: `"default"`, `"completed"`, `"warning"`, and `"error"`. _Note that `"active"` is not a valid status value: the active step is defined by the `activeStep` prop on the `SteppedTracker` component._
 
   </LivePreview>
 

--- a/site/docs/components/stepped-tracker/examples.mdx
+++ b/site/docs/components/stepped-tracker/examples.mdx
@@ -20,6 +20,16 @@ You can add a label to the `TrackerStep` using the `StepLabel` component.
 
   </LivePreview>
 
+  <LivePreview componentName="stepped-tracker" exampleName="Status" >
+
+## Status
+
+`SteppedTracker` supports multiple statuses for each `TrackerStep` child component using the `state` prop.
+
+Available status values are: `"default"`, `"complete"`, `"warning"`, and `"error"`. _Note that `"active"` is not a valid status value: the active step is defined by the `activeStep` prop on the `SteppedTracker` component._
+
+  </LivePreview>
+
   <LivePreview componentName="stepped-tracker" exampleName="Vertical" >
 
 ## Vertical

--- a/site/docs/components/stepped-tracker/examples.mdx
+++ b/site/docs/components/stepped-tracker/examples.mdx
@@ -24,7 +24,7 @@ You can add a label to the `TrackerStep` using the `StepLabel` component.
 
 ## Stage and Status
 
-`SteppedTracker` supports multiple icons for each `TrackerStep` child component which are set using the `stage` and `status` props.
+`SteppedTracker` supports multiple `stage` and `status` values for each `TrackerStep` child component.
 
 Available `stage` values are `"pending"` and `"completed"`. _Note that `"active"` is not a valid value: the active step is defined by the `activeStep` prop on the `SteppedTracker` component._
 

--- a/site/docs/components/stepped-tracker/examples.mdx
+++ b/site/docs/components/stepped-tracker/examples.mdx
@@ -20,7 +20,7 @@ You can add a label to the `TrackerStep` using the `StepLabel` component.
 
   </LivePreview>
 
-  <LivePreview componentName="stepped-tracker" exampleName="Status" >
+  <LivePreview componentName="stepped-tracker" exampleName="StageAndStatus" >
 
 ## Stage and Status
 

--- a/site/docs/components/stepped-tracker/examples.mdx
+++ b/site/docs/components/stepped-tracker/examples.mdx
@@ -26,7 +26,7 @@ You can add a label to the `TrackerStep` using the `StepLabel` component.
 
 `SteppedTracker` supports multiple `stage` and `status` values for each `TrackerStep` child component.
 
-Available `stage` values are `"pending"` and `"completed"`. _Note that `"active"` is not a valid value: the active step is defined by the `activeStep` prop on the `SteppedTracker` component._
+Available `stage` values are `"pending"` and `"completed"`. **Note:** `"active"` is not a valid value: the active step is defined by the `activeStep` prop on the `SteppedTracker` component.
 
 Available `status` values are `"warning"` and `"error"`.
 

--- a/site/docs/components/stepped-tracker/examples.mdx
+++ b/site/docs/components/stepped-tracker/examples.mdx
@@ -22,11 +22,15 @@ You can add a label to the `TrackerStep` using the `StepLabel` component.
 
   <LivePreview componentName="stepped-tracker" exampleName="Status" >
 
-## Icon
+## Stage and Status
 
-`SteppedTracker` supports multiple icons for each `TrackerStep` child component using the `TBC_PROP_NAME` prop.
+`SteppedTracker` supports multiple icons for each `TrackerStep` child component which are set using the `stage` and `status` props.
 
-Available icon values are: `"pending"`, `"completed"`, `"warning"`, and `"error"`. _Note that `"active"` is not a valid value: the active step is defined by the `activeStep` prop on the `SteppedTracker` component._
+Available `stage` values are `"pending"` and `"completed"`. _Note that `"active"` is not a valid value: the active step is defined by the `activeStep` prop on the `SteppedTracker` component._
+
+Available `status` values are `"warning"` and `"error"`.
+
+When stage and status are both set, the order of precedence for which icon is show is as follows: "completed" > "active" > "error|warning" > "pending"
 
   </LivePreview>
 

--- a/site/src/examples/stepped-tracker/Basic.tsx
+++ b/site/src/examples/stepped-tracker/Basic.tsx
@@ -25,47 +25,47 @@ export const Basic = (): ReactElement => {
         </TrackerStep>
       </SteppedTracker>
       <SteppedTracker activeStep={2}>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step Two</StepLabel>
         </TrackerStep>
-        <TrackerStep state="default">
+        <TrackerStep TBC_PROP_NAME="pending">
           <StepLabel>Step Three</StepLabel>
         </TrackerStep>
-        <TrackerStep state="default">
+        <TrackerStep TBC_PROP_NAME="pending">
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>
       <SteppedTracker activeStep={3}>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step Two</StepLabel>
         </TrackerStep>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step Three</StepLabel>
         </TrackerStep>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>
       <SteppedTracker activeStep={2}>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Completed</StepLabel>
         </TrackerStep>
-        <TrackerStep state="default">
+        <TrackerStep TBC_PROP_NAME="pending">
           <StepLabel>Active</StepLabel>
         </TrackerStep>
-        <TrackerStep state="warning">
+        <TrackerStep TBC_PROP_NAME="warning">
           <StepLabel>Warning</StepLabel>
         </TrackerStep>
-        <TrackerStep state="error">
+        <TrackerStep TBC_PROP_NAME="error">
           <StepLabel>Error</StepLabel>
         </TrackerStep>
-        <TrackerStep state="default">
+        <TrackerStep TBC_PROP_NAME="pending">
           <StepLabel>Default</StepLabel>
         </TrackerStep>
       </SteppedTracker>

--- a/site/src/examples/stepped-tracker/Basic.tsx
+++ b/site/src/examples/stepped-tracker/Basic.tsx
@@ -52,6 +52,23 @@ export const Basic = (): ReactElement => {
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>
+      <SteppedTracker activeStep={2}>
+        <TrackerStep state="completed">
+          <StepLabel>Completed</StepLabel>
+        </TrackerStep>
+        <TrackerStep state="default">
+          <StepLabel>Active</StepLabel>
+        </TrackerStep>
+        <TrackerStep state="warning">
+          <StepLabel>Warning</StepLabel>
+        </TrackerStep>
+        <TrackerStep state="error">
+          <StepLabel>Error</StepLabel>
+        </TrackerStep>
+        <TrackerStep state="default">
+          <StepLabel>Default</StepLabel>
+        </TrackerStep>
+      </SteppedTracker>
     </StackLayout>
   );
 };

--- a/site/src/examples/stepped-tracker/Basic.tsx
+++ b/site/src/examples/stepped-tracker/Basic.tsx
@@ -25,47 +25,47 @@ export const Basic = (): ReactElement => {
         </TrackerStep>
       </SteppedTracker>
       <SteppedTracker activeStep={2}>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step Two</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="pending">
+        <TrackerStep stage="pending">
           <StepLabel>Step Three</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="pending">
+        <TrackerStep stage="pending">
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>
       <SteppedTracker activeStep={3}>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step Two</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step Three</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>
       <SteppedTracker activeStep={2}>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Completed</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="pending">
+        <TrackerStep stage="pending">
           <StepLabel>Active</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="warning">
+        <TrackerStep status="warning">
           <StepLabel>Warning</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="error">
+        <TrackerStep status="error">
           <StepLabel>Error</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="pending">
+        <TrackerStep stage="pending">
           <StepLabel>Default</StepLabel>
         </TrackerStep>
       </SteppedTracker>

--- a/site/src/examples/stepped-tracker/NonSequentialProgress.tsx
+++ b/site/src/examples/stepped-tracker/NonSequentialProgress.tsx
@@ -4,7 +4,7 @@ import { type ReactElement, useState } from "react";
 
 type Step = {
   label: string;
-  state: "default" | "completed";
+  state: "pending" | "completed";
 };
 
 type Steps = Step[];
@@ -12,19 +12,19 @@ type Steps = Step[];
 const sampleSteps: Steps = [
   {
     label: "Step One",
-    state: "default",
+    state: "pending",
   },
   {
     label: "Step Two",
-    state: "default",
+    state: "pending",
   },
   {
     label: "Step Three",
-    state: "default",
+    state: "pending",
   },
   {
     label: "Step Four",
-    state: "default",
+    state: "pending",
   },
 ];
 
@@ -47,7 +47,7 @@ export const NonSequentialProgress = (): ReactElement => {
         i === activeStep
           ? {
               ...step,
-              state: step.state === "default" ? "completed" : "default",
+              state: step.state === "pending" ? "completed" : "pending",
             }
           : step,
       ),
@@ -62,7 +62,7 @@ export const NonSequentialProgress = (): ReactElement => {
     >
       <SteppedTracker activeStep={activeStep}>
         {steps.map(({ label, state }, key) => (
-          <TrackerStep state={state} key={label}>
+          <TrackerStep TBC_PROP_NAME={state} key={key}>
             <StepLabel>{label}</StepLabel>
           </TrackerStep>
         ))}

--- a/site/src/examples/stepped-tracker/NonSequentialProgress.tsx
+++ b/site/src/examples/stepped-tracker/NonSequentialProgress.tsx
@@ -62,7 +62,7 @@ export const NonSequentialProgress = (): ReactElement => {
     >
       <SteppedTracker activeStep={activeStep}>
         {steps.map(({ label, state }, key) => (
-          <TrackerStep TBC_PROP_NAME={state} key={key}>
+          <TrackerStep stage={state} key={key}>
             <StepLabel>{label}</StepLabel>
           </TrackerStep>
         ))}

--- a/site/src/examples/stepped-tracker/NonSequentialProgress.tsx
+++ b/site/src/examples/stepped-tracker/NonSequentialProgress.tsx
@@ -4,7 +4,7 @@ import { type ReactElement, useState } from "react";
 
 type Step = {
   label: string;
-  state: "pending" | "completed";
+  stage: "pending" | "completed";
 };
 
 type Steps = Step[];
@@ -12,19 +12,19 @@ type Steps = Step[];
 const sampleSteps: Steps = [
   {
     label: "Step One",
-    state: "pending",
+    stage: "pending",
   },
   {
     label: "Step Two",
-    state: "pending",
+    stage: "pending",
   },
   {
     label: "Step Three",
-    state: "pending",
+    stage: "pending",
   },
   {
     label: "Step Four",
-    state: "pending",
+    stage: "pending",
   },
 ];
 
@@ -47,7 +47,7 @@ export const NonSequentialProgress = (): ReactElement => {
         i === activeStep
           ? {
               ...step,
-              state: step.state === "pending" ? "completed" : "pending",
+              stage: step.stage === "pending" ? "completed" : "pending",
             }
           : step,
       ),
@@ -61,8 +61,8 @@ export const NonSequentialProgress = (): ReactElement => {
       style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
     >
       <SteppedTracker activeStep={activeStep}>
-        {steps.map(({ label, state }, key) => (
-          <TrackerStep stage={state} key={key}>
+        {steps.map(({ label, stage }, key) => (
+          <TrackerStep stage={stage} key={key}>
             <StepLabel>{label}</StepLabel>
           </TrackerStep>
         ))}

--- a/site/src/examples/stepped-tracker/StageAndStatus.tsx
+++ b/site/src/examples/stepped-tracker/StageAndStatus.tsx
@@ -2,7 +2,7 @@ import { StackLayout } from "@salt-ds/core";
 import { StepLabel, SteppedTracker, TrackerStep } from "@salt-ds/lab";
 import type { ReactElement } from "react";
 
-export const Status = (): ReactElement => {
+export const StageAndStatus = (): ReactElement => {
   return (
     <StackLayout
       direction="column"

--- a/site/src/examples/stepped-tracker/Status.tsx
+++ b/site/src/examples/stepped-tracker/Status.tsx
@@ -11,16 +11,16 @@ export const Status = (): ReactElement => {
       style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
     >
       <SteppedTracker activeStep={1}>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Completed</StepLabel>
         </TrackerStep>
         <TrackerStep>
           <StepLabel>Active</StepLabel>
         </TrackerStep>
-        <TrackerStep state="warning">
+        <TrackerStep TBC_PROP_NAME="warning">
           <StepLabel>Warning</StepLabel>
         </TrackerStep>
-        <TrackerStep state="error">
+        <TrackerStep TBC_PROP_NAME="error">
           <StepLabel>Error</StepLabel>
         </TrackerStep>
         <TrackerStep>

--- a/site/src/examples/stepped-tracker/Status.tsx
+++ b/site/src/examples/stepped-tracker/Status.tsx
@@ -1,0 +1,32 @@
+import { ReactElement } from "react";
+import { StackLayout } from "@salt-ds/core";
+import { SteppedTracker, TrackerStep, StepLabel } from "@salt-ds/lab";
+
+export const Status = (): ReactElement => {
+  return (
+    <StackLayout
+      direction="column"
+      align="stretch"
+      gap={10}
+      style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
+    >
+      <SteppedTracker activeStep={1}>
+        <TrackerStep state="completed">
+          <StepLabel>Completed</StepLabel>
+        </TrackerStep>
+        <TrackerStep>
+          <StepLabel>Active</StepLabel>
+        </TrackerStep>
+        <TrackerStep state="warning">
+          <StepLabel>Warning</StepLabel>
+        </TrackerStep>
+        <TrackerStep state="error">
+          <StepLabel>Error</StepLabel>
+        </TrackerStep>
+        <TrackerStep>
+          <StepLabel>Default</StepLabel>
+        </TrackerStep>
+      </SteppedTracker>
+    </StackLayout>
+  );
+};

--- a/site/src/examples/stepped-tracker/Status.tsx
+++ b/site/src/examples/stepped-tracker/Status.tsx
@@ -11,16 +11,16 @@ export const Status = (): ReactElement => {
       style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
     >
       <SteppedTracker activeStep={1}>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Completed</StepLabel>
         </TrackerStep>
         <TrackerStep>
           <StepLabel>Active</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="warning">
+        <TrackerStep status="warning">
           <StepLabel>Warning</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="error">
+        <TrackerStep status="error">
           <StepLabel>Error</StepLabel>
         </TrackerStep>
         <TrackerStep>

--- a/site/src/examples/stepped-tracker/Status.tsx
+++ b/site/src/examples/stepped-tracker/Status.tsx
@@ -1,6 +1,6 @@
-import { ReactElement } from "react";
 import { StackLayout } from "@salt-ds/core";
-import { SteppedTracker, TrackerStep, StepLabel } from "@salt-ds/lab";
+import { StepLabel, SteppedTracker, TrackerStep } from "@salt-ds/lab";
+import type { ReactElement } from "react";
 
 export const Status = (): ReactElement => {
   return (

--- a/site/src/examples/stepped-tracker/StepProgression.tsx
+++ b/site/src/examples/stepped-tracker/StepProgression.tsx
@@ -5,7 +5,7 @@ import { type ReactElement, useState } from "react";
 
 type Step = {
   label: string;
-  state: "default" | "completed";
+  state: "pending" | "completed";
 };
 
 type Steps = Step[];
@@ -13,19 +13,19 @@ type Steps = Step[];
 const sampleSteps: Steps = [
   {
     label: "Step One",
-    state: "default",
+    state: "pending",
   },
   {
     label: "Step Two",
-    state: "default",
+    state: "pending",
   },
   {
     label: "Step Three",
-    state: "default",
+    state: "pending",
   },
   {
     label: "Step Four",
-    state: "default",
+    state: "pending",
   },
 ];
 
@@ -63,8 +63,8 @@ export const StepProgression = (): ReactElement => {
       style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
     >
       <SteppedTracker activeStep={activeStep}>
-        {steps.map(({ label, state }) => (
-          <TrackerStep state={state} key={label}>
+        {steps.map(({ label, state }, key) => (
+          <TrackerStep TBC_PROP_NAME={state} key={key}>
             <StepLabel>{label}</StepLabel>
           </TrackerStep>
         ))}

--- a/site/src/examples/stepped-tracker/StepProgression.tsx
+++ b/site/src/examples/stepped-tracker/StepProgression.tsx
@@ -64,7 +64,7 @@ export const StepProgression = (): ReactElement => {
     >
       <SteppedTracker activeStep={activeStep}>
         {steps.map(({ label, state }, key) => (
-          <TrackerStep TBC_PROP_NAME={state} key={key}>
+          <TrackerStep stage={state} key={key}>
             <StepLabel>{label}</StepLabel>
           </TrackerStep>
         ))}

--- a/site/src/examples/stepped-tracker/StepProgression.tsx
+++ b/site/src/examples/stepped-tracker/StepProgression.tsx
@@ -5,7 +5,7 @@ import { type ReactElement, useState } from "react";
 
 type Step = {
   label: string;
-  state: "pending" | "completed";
+  stage: "pending" | "completed";
 };
 
 type Steps = Step[];
@@ -13,19 +13,19 @@ type Steps = Step[];
 const sampleSteps: Steps = [
   {
     label: "Step One",
-    state: "pending",
+    stage: "pending",
   },
   {
     label: "Step Two",
-    state: "pending",
+    stage: "pending",
   },
   {
     label: "Step Three",
-    state: "pending",
+    stage: "pending",
   },
   {
     label: "Step Four",
-    state: "pending",
+    stage: "pending",
   },
 ];
 
@@ -44,7 +44,7 @@ export const StepProgression = (): ReactElement => {
         i === activeStep
           ? {
               ...step,
-              state: "completed",
+              stage: "completed",
             }
           : step,
       ),
@@ -63,8 +63,8 @@ export const StepProgression = (): ReactElement => {
       style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
     >
       <SteppedTracker activeStep={activeStep}>
-        {steps.map(({ label, state }, key) => (
-          <TrackerStep stage={state} key={key}>
+        {steps.map(({ label, stage }, key) => (
+          <TrackerStep stage={stage} key={key}>
             <StepLabel>{label}</StepLabel>
           </TrackerStep>
         ))}

--- a/site/src/examples/stepped-tracker/Vertical.tsx
+++ b/site/src/examples/stepped-tracker/Vertical.tsx
@@ -24,30 +24,30 @@ export const Vertical = (): ReactElement => {
         </TrackerStep>
       </SteppedTracker>
       <SteppedTracker activeStep={2} orientation="vertical">
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step Two</StepLabel>
         </TrackerStep>
-        <TrackerStep state="default">
+        <TrackerStep TBC_PROP_NAME="pending">
           <StepLabel>Step Three</StepLabel>
         </TrackerStep>
-        <TrackerStep state="default">
+        <TrackerStep TBC_PROP_NAME="pending">
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>
       <SteppedTracker activeStep={3} orientation="vertical">
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step Two</StepLabel>
         </TrackerStep>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step Three</StepLabel>
         </TrackerStep>
-        <TrackerStep state="completed">
+        <TrackerStep TBC_PROP_NAME="completed">
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>

--- a/site/src/examples/stepped-tracker/Vertical.tsx
+++ b/site/src/examples/stepped-tracker/Vertical.tsx
@@ -24,30 +24,30 @@ export const Vertical = (): ReactElement => {
         </TrackerStep>
       </SteppedTracker>
       <SteppedTracker activeStep={2} orientation="vertical">
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step Two</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="pending">
+        <TrackerStep stage="pending">
           <StepLabel>Step Three</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="pending">
+        <TrackerStep stage="pending">
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>
       <SteppedTracker activeStep={3} orientation="vertical">
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step Two</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step Three</StepLabel>
         </TrackerStep>
-        <TrackerStep TBC_PROP_NAME="completed">
+        <TrackerStep stage="completed">
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>

--- a/site/src/examples/stepped-tracker/index.ts
+++ b/site/src/examples/stepped-tracker/index.ts
@@ -1,4 +1,5 @@
 export * from "./Basic";
+export * from "./Status";
 export * from "./Vertical";
 export * from "./StepProgression";
 export * from "./NonSequentialProgress";

--- a/site/src/examples/stepped-tracker/index.ts
+++ b/site/src/examples/stepped-tracker/index.ts
@@ -1,5 +1,5 @@
 export * from "./Basic";
-export * from "./Status";
+export * from "./StageAndStatus";
 export * from "./Vertical";
 export * from "./StepProgression";
 export * from "./NonSequentialProgress";


### PR DESCRIPTION
Adds `status` prop that takes `warning` and `error` values.

Renames `state` prop to `stage` (and renames "default" to "pending")

Sets precedence of stage and status: "completed" > "active" > "error|warning" > "pending"

<img width="641" alt="Screenshot 2024-06-17 at 12 39 43" src="https://github.com/jpmorganchase/salt-ds/assets/5412181/270f89cd-9292-4c4a-bf07-ca5008a5e1b2">
