### PR TITLE
Add ag grid theme v1 release branch to CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - release-hotfix-*
+      - release-ag-grid-theme-v1
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release-hotfix-*
 
 permissions:
   contents: write


### PR DESCRIPTION
Need to release a hotfix, ag-grid-theme@1.4.3 from #3585.

Enable the release PR from a branch, hopefully this is enough?