### PR TITLE
Support status color for FormFieldHelperText

### DIFF
--- a/.changeset/dull-turtles-teach.md
+++ b/.changeset/dull-turtles-teach.md
@@ -1,5 +1,5 @@
 ---
-"@salt-ds/core": patch
+"@salt-ds/core": minor
 ---
 
 Support status color for FormFieldHelperText

--- a/.changeset/dull-turtles-teach.md
+++ b/.changeset/dull-turtles-teach.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Support status color for FormFieldHelperText

--- a/.changeset/dull-turtles-teach.md
+++ b/.changeset/dull-turtles-teach.md
@@ -2,4 +2,4 @@
 "@salt-ds/core": minor
 ---
 
-Support status color for FormFieldHelperText
+Update FormFieldHelperText to have status colors applied when `validationStatus` is applied to FormField.

--- a/packages/core/src/__tests__/__e2e__/form-field/FormField.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/form-field/FormField.cy.tsx
@@ -41,6 +41,7 @@ describe("GIVEN a FormField", () => {
       );
 
       cy.findByText("Helper text").should("exist");
+      cy.findByText("Helper text").should("have.class", "saltText-secondary");
     });
   });
 
@@ -85,6 +86,7 @@ describe("GIVEN a FormField", () => {
         "have.class",
         "saltStatusIndicator-error",
       );
+      cy.findByText("Helper text").should("have.class", "saltText-error");
     });
 
     describe("AND is disabled", () => {
@@ -127,6 +129,7 @@ describe("GIVEN a FormField", () => {
           "have.class",
           "saltStatusIndicator-success",
         );
+        cy.findByText("Helper text").should("have.class", "saltText-success");
       });
     });
 
@@ -142,6 +145,7 @@ describe("GIVEN a FormField", () => {
           "have.class",
           "saltStatusIndicator-warning",
         );
+        cy.findByText("Helper text").should("have.class", "saltText-warning");
       });
     });
   });

--- a/packages/core/src/form-field/FormFieldHelperText.tsx
+++ b/packages/core/src/form-field/FormFieldHelperText.tsx
@@ -40,8 +40,8 @@ export const FormFieldHelperText = ({
       <Text
         disabled={disabled}
         id={a11yProps?.["aria-describedby"]}
-        variant="secondary"
         styleAs="label"
+        color={validationStatus ?? "secondary"}
         {...restProps}
       >
         {children}


### PR DESCRIPTION
Using the `color` prop instead of the deprecated `variant`. It should now apply the success/warning/error colour to the helper text based on the form field status.

Should address #3540 