### PR TITLE
Add Badge to Pill's related components

### DIFF
--- a/site/docs/components/pill/index.mdx
+++ b/site/docs/components/pill/index.mdx
@@ -11,7 +11,7 @@ data:
     [
       { name: "Badge", relationship: "similarTo" },
       { name: "Button", relationship: "similarTo" },
-      { name: "Toggle button", relationship: "similarTo" }
+      { name: "Toggle button", relationship: "similarTo" },
     ]
 
 layout: DetailComponent

--- a/site/docs/components/pill/index.mdx
+++ b/site/docs/components/pill/index.mdx
@@ -9,8 +9,9 @@ data:
   alsoKnownAs: ["Tag", "Chip", "Badge"]
   relatedComponents:
     [
+      { name: "Badge", relationship: "similarTo" },
       { name: "Button", relationship: "similarTo" },
-      { name: "Toggle button", relationship: "similarTo" },
+      { name: "Toggle button", relationship: "similarTo" }
     ]
 
 layout: DetailComponent


### PR DESCRIPTION
This change is related to #25, adding a link in the right-hand column of the pill component back to badge