### PR TITLE
Fix invalid HTML structure in AccordionHeader

### DIFF
--- a/.changeset/kind-bottles-flow.md
+++ b/.changeset/kind-bottles-flow.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Fixed invalid HTML structure in AccordionHeader.

--- a/packages/core/src/accordion/AccordionHeader.tsx
+++ b/packages/core/src/accordion/AccordionHeader.tsx
@@ -25,15 +25,14 @@ export interface AccordionHeaderProps
 
 const withBaseName = makePrefixer("saltAccordionHeader");
 
-const ExpansionIcon = ({ expanded }: { expanded: boolean }) =>
-  expanded ? (
-    <ChevronUpIcon aria-hidden="true" className={clsx(withBaseName("icon"))} />
-  ) : (
-    <ChevronDownIcon
-      aria-hidden="true"
-      className={clsx(withBaseName("icon"))}
-    />
-  );
+function ExpansionIcon({ expanded }: { expanded: boolean }) {
+  if (expanded) {
+    return <ChevronUpIcon aria-hidden className={withBaseName("icon")} />;
+  }
+
+  return <ChevronDownIcon aria-hidden className={withBaseName("icon")} />;
+}
+
 export const AccordionHeader = forwardRef<
   HTMLButtonElement,
   AccordionHeaderProps
@@ -72,7 +71,7 @@ export const AccordionHeader = forwardRef<
       {...rest}
     >
       {indicatorSide === "left" && <ExpansionIcon expanded={expanded} />}
-      <div className={withBaseName("content")}>{children}</div>
+      <span className={withBaseName("content")}>{children}</span>
       {status && (
         <StatusIndicator
           className={withBaseName("statusIndicator")}

--- a/packages/core/src/accordion/AccordionPanel.css
+++ b/packages/core/src/accordion/AccordionPanel.css
@@ -26,7 +26,7 @@
   padding-bottom: var(--salt-spacing-300);
 }
 
-.saltAccordionPanel-content.saltAccordionPanel-indentedContent {
+.saltAccordionPanel-indentedContent {
   padding-left: calc(var(--salt-spacing-200) + var(--salt-size-icon));
 }
 


### PR DESCRIPTION
Fixes the invalid HTML button > div vs button > span.
Updates a CSS selector to make it easier to override.
Adds a display name to a component to make it easier to debug.