### PR TITLE
Add `--salt-overlayable-rangeSelection` to theme next

### DIFF
--- a/.changeset/rotten-jokes-fix.md
+++ b/.changeset/rotten-jokes-fix.md
@@ -1,0 +1,7 @@
+---
+"@salt-ds/theme": patch
+---
+
+Added `--salt-overlayable-rangeSelection` variable in theme next, pointing to the same underlying value as before.
+
+Closes #3517.

--- a/packages/theme/css/characteristics/overlayable-next.css
+++ b/packages/theme/css/characteristics/overlayable-next.css
@@ -1,3 +1,4 @@
 .salt-theme.salt-theme-next {
   --salt-overlayable-background: var(--salt-palette-alpha-backdrop);
+  --salt-overlayable-rangeSelection: var(--salt-palette-alpha-weak);
 }


### PR DESCRIPTION
The token is only used in ag grid theme, test with theme next enabled

#3517