### PR TITLE
Add meta description

### DIFF
--- a/site/src/pages/_document.tsx
+++ b/site/src/pages/_document.tsx
@@ -1,12 +1,16 @@
 import { Head, Html, Main, NextScript } from "next/document";
 
+const description = 'Salt is the J.P. Morgan design system, an open-source solution for building exceptional products and digital experiences in financial services and other industries.'
+
 /*
  * This is the same as the default Next.js _document.js, but with lang="en".
  */
 export default function Document() {
   return (
     <Html lang="en">
-      <Head />
+      <Head>
+        <meta name={"description"} content={description} />
+      </Head>
       <body>
         <Main />
         <NextScript />


### PR DESCRIPTION
Closes #951

- Added a meta description.
   - Copied the description text from the Salt home page, let me know if this should be changed to something else.
   - Set the description in `_document.tsx`, however it can be set in `_app.tsx` instead if preferred. 
- Tested SEO using Lighthouse, 100% passing.
