### PR TITLE
Add scrim secondary variant

### DIFF
--- a/packages/ag-grid-theme/css/salt-ag-grid-theme.css
+++ b/packages/ag-grid-theme/css/salt-ag-grid-theme.css
@@ -32,7 +32,7 @@ div[class*="ag-theme-salt"] {
   --ag-invalid-color: var(--salt-status-error-foreground-informative);
   --ag-list-item-height: calc(var(--salt-size-base) + var(--salt-spacing-100));
   --ag-material-primary-color: var(--salt-editable-borderColor);
-  --ag-modal-overlay-background-color: var(--salt-overlayable-background);
+  --ag-modal-overlay-background-color: var(--salt-overlayable-primary-background);
   --ag-popup-shadow: var(--salt-overlayable-shadow-modal);
   --ag-range-selection-background-color: var(--salt-overlayable-rangeSelection);
   --ag-range-selection-border-style: none;

--- a/packages/core/src/__tests__/__e2e__/scrim/Scrim.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/scrim/Scrim.cy.tsx
@@ -22,4 +22,24 @@ describe("Given a Scrim", () => {
       cy.get("@clickSpy").should("have.callCount", 1);
     });
   });
+
+  describe("Test Scrim variants", () => {
+    it("should render primary scrim by default", () => {
+      cy.mount(<Scrim open>Click to close Scrim</Scrim>);
+      cy.get(".saltScrim").should("have.class", "saltScrim-primary");
+      cy.get(".saltScrim").should("not.have.class", "saltScrim-secondary");
+    });
+
+    it("should render primary scrim with variant prop", () => {
+      cy.mount(<Scrim open variant={"primary"}>Click to close Scrim</Scrim>);
+      cy.get(".saltScrim").should("have.class", "saltScrim-primary");
+      cy.get(".saltScrim").should("not.have.class", "saltScrim-secondary");
+    });
+
+    it("should render secondary scrim with variant prop", () => {
+      cy.mount(<Scrim open variant={"secondary"}>Click to close Scrim</Scrim>);
+      cy.get(".saltScrim").should("have.class", "saltScrim-secondary");
+      cy.get(".saltScrim").should("not.have.class", "saltScrim-primary");
+    });
+  });
 });

--- a/packages/core/src/scrim/Scrim.css
+++ b/packages/core/src/scrim/Scrim.css
@@ -11,7 +11,6 @@
   position: absolute;
   align-items: center;
   justify-content: center;
-  background: var(--saltScrim-background, var(--salt-overlayable-background));
   -webkit-tap-highlight-color: transparent;
 }
 
@@ -22,4 +21,12 @@
 /* Style applied to the root element when fixed={true} */
 .saltScrim-fixed {
   position: fixed;
+}
+
+.saltScrim-primary {
+  background: var(--saltScrim-background, var(--salt-overlayable-primary-background));
+}
+
+.saltScrim-secondary {
+  background: var(--saltScrim-background, var(--salt-overlayable-secondary-background));
 }

--- a/packages/core/src/scrim/Scrim.tsx
+++ b/packages/core/src/scrim/Scrim.tsx
@@ -19,10 +19,21 @@ export interface ScrimProps extends ComponentPropsWithoutRef<"div"> {
    * If `true` the scrim is shown.
    */
   open?: boolean;
+  /**
+   * Styling variant. Defaults to "primary".
+   */
+  variant?: "primary" | "secondary";
 }
 
 export const Scrim = forwardRef<HTMLDivElement, ScrimProps>(function Scrim(
-  { className, children, fixed = false, open = true, ...rest },
+  {
+    className,
+    children,
+    fixed = false,
+    open = true,
+    variant = "primary",
+    ...rest
+  },
   ref
 ) {
   const targetWindow = useWindow();
@@ -40,6 +51,7 @@ export const Scrim = forwardRef<HTMLDivElement, ScrimProps>(function Scrim(
     <div
       className={clsx(
         withBaseName(),
+        withBaseName(variant),
         {
           [withBaseName("fixed")]: fixed,
         },

--- a/packages/core/stories/scrim/scrim.stories.tsx
+++ b/packages/core/stories/scrim/scrim.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Button, Scrim, Spinner, Text, Card, StackLayout } from "@salt-ds/core";
+import { Button, Scrim, Spinner, Text, Card, StackLayout, Label } from "@salt-ds/core";
 import { StoryFn, Meta } from "@storybook/react";
 
 export default {
@@ -151,5 +151,37 @@ export const CoveredBorder: StoryFn<typeof Scrim> = () => {
         <Button onClick={handleClose}>Click to close scrim</Button>
       </Scrim>
     </div>
+  );
+};
+
+export const Variants: StoryFn<typeof Scrim> = () => {
+  const variants = ["primary", "secondary"] as const;
+  return (
+    <StackLayout style={{ width: 600 }}>
+      {variants.map((variant) => {
+        return (
+          <StackLayout align="end" key={variant}>
+            <StackLayout direction="row">
+              <Card style={{ position: "relative", width: "512px" }}>
+                <StackLayout>
+                  <Text>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+                    ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                    Duis aute irure dolor in reprehenderit in voluptate velit
+                    esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+                    occaecat cupidatat non proident, sunt in culpa qui officia
+                    deserunt mollit anim id est laborum.
+                  </Text>
+                  <Scrim open={true} variant={variant} />
+                </StackLayout>
+              </Card>
+            </StackLayout>
+            <Label>Variant: {variant}</Label>
+          </StackLayout>
+        );
+      })}
+    </StackLayout>
   );
 };

--- a/packages/data-grid/stories/grid-sortColumns.stories.tsx
+++ b/packages/data-grid/stories/grid-sortColumns.stories.tsx
@@ -105,7 +105,7 @@ export function ServerSideSort() {
       style={{
         position: "relative",
         // @ts-ignore
-        "--salt-overlayable-background":
+        "--salt-overlayable-primary-background":
           mode === "light"
             ? "var(--salt-color-gray-60-fade-background)"
             : "var(--salt-color-gray-300-fade-background)",

--- a/packages/theme/css/characteristics/overlayable.css
+++ b/packages/theme/css/characteristics/overlayable.css
@@ -7,6 +7,8 @@
   --salt-overlayable-shadow-drag: var(--salt-shadow-400);
   --salt-overlayable-shadow-modal: var(--salt-shadow-500);
 
-  --salt-overlayable-background: var(--salt-palette-neutral-backdrop);
+  --salt-overlayable-primary-background: var(--salt-palette-neutral-primary-backdrop);
+  --salt-overlayable-secondary-background: var(--salt-palette-neutral-secondary-backdrop);
+
   --salt-overlayable-rangeSelection: var(--salt-palette-neutral-selection);
 }

--- a/packages/theme/css/foundations/fade.css
+++ b/packages/theme/css/foundations/fade.css
@@ -50,8 +50,10 @@
   --salt-color-gray-600-fade-background-readonly: rgba(47, 49, 54, var(--salt-palette-opacity-background-readonly));
   --salt-color-gray-800-fade-background-readonly: rgba(36, 37, 38, var(--salt-palette-opacity-background-readonly));
 
-  --salt-color-white-fade-backdrop: rgba(255, 255, 255, var(--salt-palette-opacity-backdrop));
-  --salt-color-black-fade-backdrop: rgba(0, 0, 0, var(--salt-palette-opacity-backdrop));
+  --salt-color-white-fade-backdrop-primary: rgba(255, 255, 255, var(--salt-palette-opacity-primary-backdrop));
+  --salt-color-white-fade-backdrop-secondary: rgba(255, 255, 255, var(--salt-palette-opacity-secondary-backdrop));
+  --salt-color-black-fade-backdrop-primary: rgba(0, 0, 0, var(--salt-palette-opacity-primary-backdrop));
+  --salt-color-black-fade-backdrop-secondary: rgba(0, 0, 0, var(--salt-palette-opacity-secondary-backdrop));
 
   --salt-color-blue-100-fade-fill: rgba(100, 177, 228, var(--salt-palette-opacity-disabled));
   --salt-color-blue-600-fade-fill: rgba(21, 92, 147, var(--salt-palette-opacity-disabled));

--- a/packages/theme/css/palette/neutral.css
+++ b/packages/theme/css/palette/neutral.css
@@ -14,7 +14,8 @@
   --salt-palette-neutral-secondary-border-disabled: var(--salt-color-gray-50-fade-border);
   --salt-palette-neutral-secondary-foreground: var(--salt-color-gray-200);
   --salt-palette-neutral-secondary-foreground-disabled: var(--salt-color-gray-200-fade-foreground);
-  --salt-palette-neutral-backdrop: var(--salt-color-white-fade-backdrop);
+  --salt-palette-neutral-primary-backdrop: var(--salt-color-white-fade-backdrop-primary);
+  --salt-palette-neutral-secondary-backdrop: var(--salt-color-white-fade-backdrop-secondary);
   --salt-palette-neutral-secondary-separator: var(--salt-color-black-fade-separatorOpacity-secondary);
   --salt-palette-neutral-tertiary-separator: var(--salt-color-black-fade-separatorOpacity-tertiary);
   --salt-palette-neutral-selection: var(--salt-color-black-fade-background-selection);
@@ -36,7 +37,8 @@
   --salt-palette-neutral-secondary-border-disabled: var(--salt-color-gray-300-fade-border);
   --salt-palette-neutral-secondary-foreground: var(--salt-color-gray-70);
   --salt-palette-neutral-secondary-foreground-disabled: var(--salt-color-gray-70-fade-foreground);
-  --salt-palette-neutral-backdrop: var(--salt-color-black-fade-backdrop);
+  --salt-palette-neutral-primary-backdrop: var(--salt-color-black-fade-backdrop-primary);
+  --salt-palette-neutral-secondary-backdrop: var(--salt-color-black-fade-backdrop-secondary);
   --salt-palette-neutral-secondary-separator: var(--salt-color-white-fade-separatorOpacity-secondary);
   --salt-palette-neutral-tertiary-separator: var(--salt-color-white-fade-separatorOpacity-tertiary);
   --salt-palette-neutral-selection: var(--salt-color-white-fade-background-selection);

--- a/packages/theme/css/palette/opacity.css
+++ b/packages/theme/css/palette/opacity.css
@@ -1,5 +1,6 @@
 .salt-theme {
-  --salt-palette-opacity-backdrop: var(--salt-opacity-70);
+  --salt-palette-opacity-primary-backdrop: var(--salt-opacity-70);
+  --salt-palette-opacity-secondary-backdrop: var(--salt-opacity-40);
   --salt-palette-opacity-disabled: var(--salt-opacity-40);
   --salt-palette-opacity-background-readonly: var(--salt-opacity-0);
   --salt-palette-opacity-border-readonly: var(--salt-opacity-15);

--- a/packages/theme/stories/introduction.mdx
+++ b/packages/theme/stories/introduction.mdx
@@ -97,7 +97,8 @@ Foundational tokens are divided into the following groups:
 | `--salt-palette-opacity-background-readonly` | `--salt-opacity-0`  |
 | `--salt-palette-opacity-border-readonly`     | `--salt-opacity-8`  |
 | `--salt-palette-opacity-disabled`            | `--salt-opacity-40` |
-| `--salt-palette-opacity-backdrop`            | `--salt-opacity-70` |
+| `--salt-palette-opacity-primary-backdrop`    | `--salt-opacity-70` |
+| `--salt-palette-opacity-secondary-backdrop`  | `--salt-opacity-40` |
 | `--salt-palette-opacity-primary-border`      | `--salt-opacity-40` |
 | `--salt-palette-opacity-secondary-border`    | `--salt-opacity-25` |
 | `--salt-palette-opacity-tertiary-border`     | `--salt-opacity-15` |

--- a/packages/theme/stories/palettes/neutral.mdx
+++ b/packages/theme/stories/palettes/neutral.mdx
@@ -13,10 +13,10 @@ Colors used to define regions or blocks of content without inferring meaning.
   <ColorPalette className="docs">
     <ColorItem
       title="Backdrop"
-      subtitle="--salt-palette-neutral-backdrop"
+      subtitle="--salt-palette-neutral-primary-backdrop"
       colors={{
-        "--salt-palette-neutral-backdrop":
-          "var(--salt-palette-neutral-backdrop)",
+        "--salt-palette-neutral-primary-backdrop":
+          "var(--salt-palette-neutral-primary-backdrop)",
       }}
     />
   </ColorPalette>

--- a/packages/theme/stories/palettes/opacity.mdx
+++ b/packages/theme/stories/palettes/opacity.mdx
@@ -34,7 +34,7 @@ import { OpacityBlock } from "docs/components/OpacityBlock";
     cssVariable="--salt-palette-opacity-disabled"
   />
 
-  <OpacityBlock opacity="--salt-opacity-70" cssVariable="--salt-palette-opacity-backdrop" />
+  <OpacityBlock opacity="--salt-opacity-70" cssVariable="--salt-palette-opacity-primary-backdrop" />
 </DocGrid>
 
 ## Deprecated

--- a/site/docs/components/scrim/examples.mdx
+++ b/site/docs/components/scrim/examples.mdx
@@ -38,4 +38,12 @@ You can pass children to a scrim, such as a [`Spinner`](../spinner) to indicate 
 
 </LivePreview>
 
+<LivePreview componentName="scrim" exampleName="Variants">
+
+## Variants
+
+All scrim components provide both primary and secondary variants, offering flexibility and enabling differentiation based on visual hierarchy within your UI.
+
+</LivePreview>
+
 </LivePreviewControls>

--- a/site/src/examples/scrim/Variants.tsx
+++ b/site/src/examples/scrim/Variants.tsx
@@ -1,0 +1,54 @@
+import { ReactElement, useState } from "react";
+import { Button, Scrim, Text, StackLayout } from "@salt-ds/core";
+
+export const Variants = (): ReactElement => {
+  const [openPrimary, setOpenPrimary] = useState(false);
+  const [openSecondary, setOpenSecondary] = useState(false);
+
+  const handleOpenPrimary = () => {
+    setOpenPrimary(true);
+  };
+
+  const handleClosePrimary = () => {
+    setOpenPrimary(false);
+  };
+
+  const handleOpenSecondary = () => {
+    setOpenSecondary(true);
+  };
+
+  const handleCloseSecondary = () => {
+    setOpenSecondary(false);
+  };
+
+  return (
+    <StackLayout direction="row">
+      <Scrim
+        fixed
+        open={openPrimary}
+        variant={"primary"}
+        onClick={handleClosePrimary}
+      >
+        <Text>
+          <strong>Click scrim to close</strong>
+        </Text>
+      </Scrim>
+      <Button onClick={handleOpenPrimary} variant="primary">
+        Show primary scrim
+      </Button>
+      <Scrim
+        fixed
+        open={openSecondary}
+        variant={"secondary"}
+        onClick={handleCloseSecondary}
+      >
+        <Text>
+          <strong>Click scrim to close</strong>
+        </Text>
+      </Scrim>
+      <Button onClick={handleOpenSecondary} variant="secondary">
+        Show secondary scrim
+      </Button>
+    </StackLayout>
+  );
+};

--- a/site/src/examples/scrim/index.ts
+++ b/site/src/examples/scrim/index.ts
@@ -1,3 +1,4 @@
 export * from "./FillContainer";
 export * from "./FillViewport";
 export * from "./WithChild";
+export * from "./Variants";


### PR DESCRIPTION
Closes #1418

- Added `variant` prop to Scrim.
   - `"primary"` sets the background to 70% opacity.
   - `"secondary"` sets the background to 40% opacity.
   - Defaults to `"primary"`.
- Updated the site docs with Scrim variants example.
- Updated storybook with Scrim variants example.
- Updated the Scrim tests.

CSS Changes:

| Before                           | After                                       | 
| ----------------                 | -----------                                 |
| `--salt-overlayable-background`    | `--salt-overlayable-primary-background`       |
|                                  | `--salt-overlayable-secondary-background`     |
| `--salt-palette-neutral-backdrop`  | `--salt-palette-neutral-primary-backdrop`     | 
|                                  | `--salt-palette-neutral-secondary-backdrop`   |
| `--salt-color-white-fade-backdrop` | `--salt-color-white-fade-backdrop-primary`    |
|                                  | `--salt-color-white-fade-backdrop-secondary`  |
| `--salt-color-black-fade-backdrop` | `--salt-color-black-fade-backdrop-primary`    |
|                                  | `--salt-color-black-fade-backdrop-secondary`  |
| `--salt-palette-opacity-backdrop`  | `--salt-palette-opacity-primary-backdrop`     | 
|                                  | `--salt-palette-opacity-secondary-backdrop`   |  