### PR TITLE
Dialog close button focus ring visibility and overlap with content

### DIFF
--- a/packages/core/src/dialog/Dialog.css
+++ b/packages/core/src/dialog/Dialog.css
@@ -8,7 +8,7 @@
   margin: auto;
   display: flex;
   flex-direction: column;
-  padding-top: var(--salt-spacing-300);
+  padding-top: calc(var(--saltButton-height, var(--salt-size-base)) + (var(--salt-focused-outlineWidth) * 2));
   padding-bottom: var(--salt-spacing-300);
   background: var(--salt-container-primary-background);
   box-shadow: var(--salt-overlayable-shadow-modal);

--- a/packages/core/src/dialog/DialogCloseButton.css
+++ b/packages/core/src/dialog/DialogCloseButton.css
@@ -1,5 +1,5 @@
 .saltButton.saltDialogCloseButton {
   position: absolute;
-  top: 0;
-  right: 0;
+  top: var(--salt-focused-outlineWidth);
+  right: var(--salt-focused-outlineWidth);
 }

--- a/packages/core/stories/dialog/dialog.stories.tsx
+++ b/packages/core/stories/dialog/dialog.stories.tsx
@@ -332,6 +332,21 @@ export const DesktopDialog = () => {
   );
 };
 
+export const FullBleedContent = () => {
+  return (
+    <Dialog size="small" open={true}>
+      <div
+        style={{
+          maxWidth: "100%",
+          height: "200px",
+          background: "grey",
+        }}
+      />
+      <DialogCloseButton />
+    </Dialog>
+  );
+};
+
 export const StickyFooter: StoryFn<typeof Dialog> = ({
   open: openProp = false,
 }) => {


### PR DESCRIPTION
Issue: https://github.com/jpmorganchase/salt-ds/issues/2970

Fixes two issues:
1. Close-button focus ring hidden by Dialog `overflow: hidden` restriction.
2. Close-button overlaps Dialog content

<img width="128" alt="Screenshot 2024-07-08 at 11 02 21" src="https://github.com/jpmorganchase/salt-ds/assets/5412181/bb66b06d-04a2-44ec-8f9d-94c1f156b983">

---

Two notable changes:

Close-button now has visible padding (when hovered) between itself and the container and content:

<img width="169" alt="Screenshot 2024-07-08 at 11 00 37" src="https://github.com/jpmorganchase/salt-ds/assets/5412181/02f43dda-f578-4822-8c72-5fd1a1ff1c04">

<img width="210" alt="Screenshot 2024-07-08 at 11 00 42" src="https://github.com/jpmorganchase/salt-ds/assets/5412181/879f6e99-4da7-476e-9a95-ecdddc5e0781">


---

The Dialog header now gets it's height from the close-button (was previously hard-coded as `spacing-300`

<img width="621" alt="Screenshot 2024-07-08 at 11 00 51" src="https://github.com/jpmorganchase/salt-ds/assets/5412181/5458c98d-d0f6-40e0-a69c-7941cef165e6">