### PR TITLE
Nested stepped tracker

### DIFF
--- a/.changeset/neat-pianos-judge.md
+++ b/.changeset/neat-pianos-judge.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/lab": minor
+---
+
+Adds support for nesting steps in a vertical SteppedTracker using the new `depth` prop on TrackerStep components.

--- a/packages/lab/src/__tests__/__e2e__/stepped-tracker/SteppedTracker.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/stepped-tracker/SteppedTracker.cy.tsx
@@ -231,4 +231,37 @@ describe("GIVEN a SteppedTracker", () => {
       .findByTestId("ErrorSolidIcon")
       .should("exist");
   });
+
+  it("should show in-progress icon for parent steps with only some completed steps", () => {
+    const TestComponent = (
+      <SteppedTracker
+        orientation="vertical"
+        activeStep={2}
+        style={{ width: "100%", minWidth: 300, maxWidth: 400 }}
+      >
+        <TrackerStep stage="inprogress">
+          <StepLabel>Step 1</StepLabel>
+        </TrackerStep>
+        <TrackerStep depth={1} stage="completed">
+          <StepLabel>Step 1.1</StepLabel>
+        </TrackerStep>
+        <TrackerStep depth={1}>
+          <StepLabel>Step 1.2</StepLabel>
+        </TrackerStep>
+        <TrackerStep depth={1}>
+          <StepLabel>Step 1.3</StepLabel>
+        </TrackerStep>
+        <TrackerStep>
+          <StepLabel>Step 2</StepLabel>
+        </TrackerStep>
+      </SteppedTracker>
+    );
+
+    cy.mount(TestComponent);
+
+    cy.findAllByRole("listitem")
+      .filter(`:nth-child(${1})`)
+      .findByTestId("ProgressInprogressIcon")
+      .should("exist");
+  });
 });

--- a/packages/lab/src/__tests__/stepped-tracker/utils.spec.tsx
+++ b/packages/lab/src/__tests__/stepped-tracker/utils.spec.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  convertDepthsToDepthMap,
+  normalizeDepthValues,
+} from "../../stepped-tracker/utils";
+
+const exampleDepths = [0, 1, 1, 0, 0, 1, 2, 2, 1, 2, 0];
+const exampleOffsetDepths = [1, 2, 2, 1, 1, 2, 3, 3, 2, 3, 1];
+
+const exampleDepthMap = [
+  {
+    i: 0,
+    children: [
+      { i: 1, children: [] },
+      { i: 2, children: [] },
+    ],
+  },
+  {
+    i: 3,
+    children: [],
+  },
+  {
+    i: 4,
+    children: [
+      {
+        i: 5,
+        children: [
+          {
+            i: 6,
+            children: [],
+          },
+          {
+            i: 7,
+            children: [],
+          },
+        ],
+      },
+      {
+        i: 8,
+        children: [
+          {
+            i: 9,
+            children: [],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    i: 10,
+    children: [],
+  },
+];
+
+describe("convertDepthsToDepthMap", () => {
+  test("should create a depth-map from an array of depths", () => {
+    const depthMap = convertDepthsToDepthMap(exampleDepths);
+    expect(depthMap.length).toBe(exampleDepthMap.length);
+    expect(depthMap[0].children.length).toBe(
+      exampleDepthMap[0].children.length,
+    );
+    expect(depthMap[1].children.length).toBe(
+      exampleDepthMap[1].children.length,
+    );
+    expect(depthMap[2].children.length).toBe(
+      exampleDepthMap[2].children.length,
+    );
+    expect(depthMap[2].children[0].children.length).toBe(
+      exampleDepthMap[2].children[0].children.length,
+    );
+  });
+});
+
+describe("normalizeDepthValues", () => {
+  test("should normalize depth values when not zero-indexed", () => {
+    const normalizedDepths = normalizeDepthValues(exampleOffsetDepths);
+    expect(normalizedDepths).toEqual(exampleDepths);
+  });
+  test("should leave correct depth values unchanged", () => {
+    const depths = normalizeDepthValues(exampleDepths);
+    expect(depths).toEqual(exampleDepths);
+  });
+});

--- a/packages/lab/src/stepped-tracker/StepLabel/StepLabel.css
+++ b/packages/lab/src/stepped-tracker/StepLabel/StepLabel.css
@@ -8,4 +8,6 @@
 
 .saltSteppedTracker.saltSteppedTracker-vertical .saltStepLabel {
   text-align: left;
+  height: var(--salt-size-base);
+  line-height: var(--salt-size-base);
 }

--- a/packages/lab/src/stepped-tracker/StepLabel/StepLabel.css
+++ b/packages/lab/src/stepped-tracker/StepLabel/StepLabel.css
@@ -1,20 +1,22 @@
-.saltStepLabel {
+label.saltText.saltStepLabel {
   width: 100%;
+  font-size: var(--salt-text-fontSize);
+  line-height: var(--salt-text-lineHeight);
 }
 
 .saltSteppedTracker.saltSteppedTracker-horizontal .saltStepLabel {
   text-align: center;
-  font-weight: var(--salt-text-label-fontWeight-strong);
+  font-weight: var(--salt-text-fontWeight-strong);
 }
 
 .saltSteppedTracker.saltSteppedTracker-vertical .saltStepLabel {
-  --stepLabel-top-offset: calc((var(--salt-size-base) - var(--salt-text-label-lineHeight)) / 2);
+  --stepLabel-top-offset: calc((var(--salt-size-base) - var(--salt-text-lineHeight)) / 2);
   text-align: left;
   display: block;
   padding-top: var(--stepLabel-top-offset);
   padding-bottom: var(--stepLabel-top-offset);
-  font-weight: var(--salt-text-label-fontWeight);
+  font-weight: var(--salt-text-fontWeight);
 }
 .saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerStep-depth-0 .saltStepLabel {
-  font-weight: var(--salt-text-label-fontWeight-strong);
+  font-weight: var(--salt-text-fontWeight-strong);
 }

--- a/packages/lab/src/stepped-tracker/StepLabel/StepLabel.css
+++ b/packages/lab/src/stepped-tracker/StepLabel/StepLabel.css
@@ -4,10 +4,17 @@
 
 .saltSteppedTracker.saltSteppedTracker-horizontal .saltStepLabel {
   text-align: center;
+  font-weight: var(--salt-text-label-fontWeight-strong);
 }
 
 .saltSteppedTracker.saltSteppedTracker-vertical .saltStepLabel {
+  --stepLabel-top-offset: calc((var(--salt-size-base) - var(--salt-text-label-lineHeight)) / 2);
   text-align: left;
-  height: var(--salt-size-base);
-  line-height: var(--salt-size-base);
+  display: block;
+  padding-top: var(--stepLabel-top-offset);
+  padding-bottom: var(--stepLabel-top-offset);
+  font-weight: var(--salt-text-label-fontWeight);
+}
+.saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerStep-depth-0 .saltStepLabel {
+  font-weight: var(--salt-text-label-fontWeight-strong);
 }

--- a/packages/lab/src/stepped-tracker/StepLabel/StepLabel.tsx
+++ b/packages/lab/src/stepped-tracker/StepLabel/StepLabel.tsx
@@ -26,7 +26,7 @@ export const StepLabel = forwardRef<HTMLLabelElement, StepLabelProps>(
 
     return (
       <Label className={clsx(withBaseName(), className)} ref={ref} {...rest}>
-        <strong>{children}</strong>
+        {children}
       </Label>
     );
   },

--- a/packages/lab/src/stepped-tracker/SteppedTracker.css
+++ b/packages/lab/src/stepped-tracker/SteppedTracker.css
@@ -1,4 +1,5 @@
-.saltSteppedTracker {
+.saltSteppedTracker,
+.saltSteppedTracker-nested-group {
   margin: 0;
   padding: 0;
   text-indent: 0;
@@ -8,10 +9,15 @@
   position: relative;
 }
 
-.saltSteppedTracker.saltSteppedTracker-horizontal {
+.saltSteppedTracker.saltSteppedTracker-horizontal,
+.saltSteppedTracker.saltSteppedTracker-horizontal .saltSteppedTracker-nested-group {
   flex-direction: row;
 }
 
-.saltSteppedTracker.saltSteppedTracker-vertical {
+.saltSteppedTracker.saltSteppedTracker-vertical,
+.saltSteppedTracker.saltSteppedTracker-vertical .saltSteppedTracker-nested-group {
   flex-direction: column;
+}
+
+.saltSteppedTracker-nested-group {
 }

--- a/packages/lab/src/stepped-tracker/SteppedTracker.css
+++ b/packages/lab/src/stepped-tracker/SteppedTracker.css
@@ -1,5 +1,4 @@
-.saltSteppedTracker,
-.saltSteppedTracker-nested-group {
+.saltSteppedTracker {
   margin: 0;
   padding: 0;
   text-indent: 0;
@@ -9,15 +8,10 @@
   position: relative;
 }
 
-.saltSteppedTracker.saltSteppedTracker-horizontal,
-.saltSteppedTracker.saltSteppedTracker-horizontal .saltSteppedTracker-nested-group {
+.saltSteppedTracker.saltSteppedTracker-horizontal {
   flex-direction: row;
 }
 
-.saltSteppedTracker.saltSteppedTracker-vertical,
-.saltSteppedTracker.saltSteppedTracker-vertical .saltSteppedTracker-nested-group {
+.saltSteppedTracker.saltSteppedTracker-vertical {
   flex-direction: column;
-}
-
-.saltSteppedTracker-nested-group {
 }

--- a/packages/lab/src/stepped-tracker/SteppedTracker.tsx
+++ b/packages/lab/src/stepped-tracker/SteppedTracker.tsx
@@ -14,8 +14,9 @@ import {
 
 import {
   SteppedTrackerProvider,
-  TrackerStepProvider,
+  // TrackerStepProvider,
 } from "./SteppedTrackerContext";
+import { getDepthMap, renderNestedSteps } from "./utils";
 
 import steppedTrackerCss from "./SteppedTracker.css";
 
@@ -76,6 +77,12 @@ export const SteppedTracker = forwardRef<HTMLUListElement, SteppedTrackerProps>(
 
     const totalSteps = Children.count(children);
 
+    const depthMap = getDepthMap(children);
+
+    const childrenArray = Children.toArray(children);
+
+    const nestedSteps = renderNestedSteps(childrenArray, depthMap);
+
     return (
       <SteppedTrackerProvider totalSteps={totalSteps} activeStep={activeStep}>
         <ul
@@ -83,9 +90,7 @@ export const SteppedTracker = forwardRef<HTMLUListElement, SteppedTrackerProps>(
           ref={ref}
           {...restProps}
         >
-          {Children.map(children, (child, i) => (
-            <TrackerStepProvider stepNumber={i}>{child}</TrackerStepProvider>
-          ))}
+          {nestedSteps}
         </ul>
       </SteppedTrackerProvider>
     );

--- a/packages/lab/src/stepped-tracker/SteppedTracker.tsx
+++ b/packages/lab/src/stepped-tracker/SteppedTracker.tsx
@@ -16,7 +16,7 @@ import {
   SteppedTrackerProvider,
   // TrackerStepProvider,
 } from "./SteppedTrackerContext";
-import { getDepthMap, renderNestedSteps } from "./utils";
+import { checkNesting, getDepthMap, renderNestedSteps } from "./utils";
 
 import steppedTrackerCss from "./SteppedTracker.css";
 
@@ -79,6 +79,8 @@ export const SteppedTracker = forwardRef<HTMLUListElement, SteppedTrackerProps>(
 
     const depthMap = getDepthMap(children);
 
+    const isNested = checkNesting(depthMap);
+
     const childrenArray = Children.toArray(children);
 
     const nestedSteps = renderNestedSteps(childrenArray, depthMap);
@@ -86,7 +88,12 @@ export const SteppedTracker = forwardRef<HTMLUListElement, SteppedTrackerProps>(
     return (
       <SteppedTrackerProvider totalSteps={totalSteps} activeStep={activeStep}>
         <ul
-          className={clsx(withBaseName(), className, withBaseName(orientation))}
+          className={clsx(
+            withBaseName(),
+            withBaseName(orientation),
+            { [withBaseName("nested")]: isNested },
+            className,
+          )}
           ref={ref}
           {...restProps}
         >

--- a/packages/lab/src/stepped-tracker/SteppedTracker.tsx
+++ b/packages/lab/src/stepped-tracker/SteppedTracker.tsx
@@ -22,7 +22,7 @@ import steppedTrackerCss from "./SteppedTracker.css";
 
 const withBaseName = makePrefixer("saltSteppedTracker");
 
-export interface SteppedTrackerProps extends ComponentPropsWithoutRef<"ul"> {
+export interface SteppedTrackerProps extends ComponentPropsWithoutRef<"ol"> {
   /**
    * The index of the current activeStep
    */
@@ -56,7 +56,7 @@ const useCheckInvalidChildren = (children: ReactNode) => {
   }, [children]);
 };
 
-export const SteppedTracker = forwardRef<HTMLUListElement, SteppedTrackerProps>(
+export const SteppedTracker = forwardRef<HTMLOListElement, SteppedTrackerProps>(
   function SteppedTracker(
     {
       children,
@@ -87,7 +87,7 @@ export const SteppedTracker = forwardRef<HTMLUListElement, SteppedTrackerProps>(
 
     return (
       <SteppedTrackerProvider totalSteps={totalSteps} activeStep={activeStep}>
-        <ul
+        <ol
           className={clsx(
             withBaseName(),
             withBaseName(orientation),
@@ -98,7 +98,7 @@ export const SteppedTracker = forwardRef<HTMLUListElement, SteppedTrackerProps>(
           {...restProps}
         >
           {nestedSteps}
-        </ul>
+        </ol>
       </SteppedTrackerProvider>
     );
   },

--- a/packages/lab/src/stepped-tracker/SteppedTrackerContext.tsx
+++ b/packages/lab/src/stepped-tracker/SteppedTrackerContext.tsx
@@ -48,10 +48,12 @@ export const useSteppedTrackerContext = () => useContext(SteppedTrackerContext);
 
 type TrackerStepNumberContextType = {
   stepNumber: number;
+  parent: boolean;
 };
 
 const TrackerStepContext = createContext<TrackerStepNumberContextType>({
   stepNumber: 0,
+  parent: false,
 });
 
 export const useTrackerStepContext = () => useContext(TrackerStepContext);
@@ -59,14 +61,16 @@ export const useTrackerStepContext = () => useContext(TrackerStepContext);
 interface TrackerStepProviderProps {
   stepNumber: number;
   children: ReactNode;
+  parent: boolean;
 }
 
 export const TrackerStepProvider = ({
   children,
   stepNumber,
+  parent,
 }: TrackerStepProviderProps) => {
   return (
-    <TrackerStepContext.Provider value={{ stepNumber }}>
+    <TrackerStepContext.Provider value={{ stepNumber, parent }}>
       {children}
     </TrackerStepContext.Provider>
   );

--- a/packages/lab/src/stepped-tracker/SteppedTrackerContext.tsx
+++ b/packages/lab/src/stepped-tracker/SteppedTrackerContext.tsx
@@ -46,9 +46,13 @@ export const SteppedTrackerProvider = ({
 
 export const useSteppedTrackerContext = () => useContext(SteppedTrackerContext);
 
-type TrackerStepNumberContextType = number;
+type TrackerStepNumberContextType = {
+  stepNumber: number;
+};
 
-const TrackerStepContext = createContext<TrackerStepNumberContextType>(0);
+const TrackerStepContext = createContext<TrackerStepNumberContextType>({
+  stepNumber: 0,
+});
 
 export const useTrackerStepContext = () => useContext(TrackerStepContext);
 
@@ -62,7 +66,7 @@ export const TrackerStepProvider = ({
   stepNumber,
 }: TrackerStepProviderProps) => {
   return (
-    <TrackerStepContext.Provider value={stepNumber}>
+    <TrackerStepContext.Provider value={{ stepNumber }}>
       {children}
     </TrackerStepContext.Provider>
   );

--- a/packages/lab/src/stepped-tracker/TrackerConnector/TrackerConnector.css
+++ b/packages/lab/src/stepped-tracker/TrackerConnector/TrackerConnector.css
@@ -15,15 +15,16 @@
   border-top-width: var(--trackerConnector-thickness);
   border-top-style: var(--trackerConnector-style-border);
   border-top-color: var(--trackerConnector-color);
-  width: calc(100% - (var(--saltIcon-size)) - (var(--trackerConnector-margin) * 2));
-  left: calc(50% + (var(--saltIcon-size) / 2) + var(--trackerConnector-margin));
-  top: calc(var(--saltIcon-size) / 2 - (var(--trackerConnector-thickness) / 2));
+  width: calc(100% - var(--salt-size-base));
+  left: calc(50% + (var(--salt-size-base) / 2));
+  top: calc(var(--salt-size-base) / 2 - (var(--trackerConnector-thickness) / 2));
+  transform: translateY(-50%);
   height: 0;
 }
 
 .saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerConnector {
   top: var(--salt-size-base);
-  left: calc((var(--saltIcon-size) / 2) - (var(--trackerConnector-thickness) / 2));
+  left: calc((var(--salt-size-base) / 2) - (var(--trackerConnector-thickness) / 2));
   bottom: 0;
   border-left-width: var(--trackerConnector-thickness);
   border-left-style: var(--trackerConnector-style-border);

--- a/packages/lab/src/stepped-tracker/TrackerConnector/TrackerConnector.css
+++ b/packages/lab/src/stepped-tracker/TrackerConnector/TrackerConnector.css
@@ -22,9 +22,9 @@
 }
 
 .saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerConnector {
-  top: calc(50% + (var(--saltIcon-size) / 2) + var(--trackerConnector-margin));
+  top: var(--salt-size-base);
   left: calc((var(--saltIcon-size) / 2) - (var(--trackerConnector-thickness) / 2));
-  height: calc(100% - (var(--saltIcon-size)) - (var(--trackerConnector-margin) * 2));
+  bottom: 0;
   border-left-width: var(--trackerConnector-thickness);
   border-left-style: var(--trackerConnector-style-border);
   border-left-color: var(--trackerConnector-color);

--- a/packages/lab/src/stepped-tracker/TrackerConnector/TrackerConnector.css
+++ b/packages/lab/src/stepped-tracker/TrackerConnector/TrackerConnector.css
@@ -21,6 +21,7 @@
   top: calc(var(--trackerStep-icon-size) / 2);
   transform: translateY(-50%);
   height: 0;
+  opacity: 1;
 }
 
 .saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerConnector {
@@ -34,4 +35,9 @@
 
 .saltTrackerConnector.saltTrackerConnector-active {
   --trackerConnector-style-border: var(--trackerConnector-style-active);
+}
+
+.saltSteppedTracker-nested .saltTrackerStepWrapper:last-child.saltTrackerStepWrapper-collapsed .saltTrackerStep .saltTrackerConnector {
+  opacity: 0;
+  transition: opacity var(--salt-duration-perceptible) ease-in-out;
 }

--- a/packages/lab/src/stepped-tracker/TrackerConnector/TrackerConnector.css
+++ b/packages/lab/src/stepped-tracker/TrackerConnector/TrackerConnector.css
@@ -12,12 +12,13 @@
 }
 
 .saltSteppedTracker.saltSteppedTracker-horizontal .saltTrackerConnector {
+  --trackerConnector-indicator-width: calc(var(--trackerStep-icon-size) + (2 * var(--salt-spacing-100)));
   border-top-width: var(--trackerConnector-thickness);
   border-top-style: var(--trackerConnector-style-border);
   border-top-color: var(--trackerConnector-color);
-  width: calc(100% - var(--salt-size-base));
-  left: calc(50% + (var(--salt-size-base) / 2));
-  top: calc(var(--salt-size-base) / 2 - (var(--trackerConnector-thickness) / 2));
+  width: calc(100% - var(--trackerConnector-indicator-width));
+  left: calc(50% + (var(--trackerConnector-indicator-width) / 2));
+  top: calc(var(--trackerStep-icon-size) / 2);
   transform: translateY(-50%);
   height: 0;
 }

--- a/packages/lab/src/stepped-tracker/TrackerConnector/TrackerConnector.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerConnector/TrackerConnector.tsx
@@ -25,5 +25,10 @@ export const TrackerConnector = ({ state }: TrackerConnectorProps) => {
     window: targetWindow,
   });
 
-  return <span className={clsx(withBaseName(), withBaseName(state))} />;
+  return (
+    <span
+      className={clsx(withBaseName(), withBaseName(state))}
+      aria-hidden="true"
+    />
+  );
 };

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
@@ -1,7 +1,14 @@
+.saltTrackerStep {
+  --trackerStep-icon-size: calc(var(--salt-size-icon) * 1.5);
+}
+
 .saltTrackerStep .saltTrackerStep-indicator {
   --trackerStep-icon-color-active: var(--saltTrackerStep-icon-color-active, var(--salt-status-info-foreground-decorative));
+
   --trackerStep-icon-color-completed: var(--saltTrackerStep-icon-color-completed, var(--salt-status-success-foreground-decorative));
+
   --trackerStep-icon-color-warning: var(--saltTrackerStep-icon-color-warning, var(--salt-status-warning-foreground-decorative));
+
   --trackerStep-icon-color-error: var(--saltTrackerStep-icon-color-error, var(--salt-status-error-foreground-decorative));
 
   --trackerStep-icon-color: var(--saltTrackerStep-icon-color, var(--salt-status-static-foreground));
@@ -38,14 +45,19 @@
   padding-bottom: var(--salt-spacing-300);
 }
 
-.saltTrackerStep-indicator {
+.saltSteppedTracker .saltTrackerStep-indicator {
   flex-shrink: 0;
   flex-grow: 0;
-  width: var(--salt-size-base);
-  height: var(--salt-size-base);
   display: flex;
   justify-content: center;
   align-items: center;
+}
+.saltSteppedTracker.saltSteppedTracker-horizontal .saltTrackerStep-indicator {
+  margin: 0 var(--salt-spacing-100);
+}
+.saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerStep-indicator {
+  width: var(--salt-size-base);
+  height: var(--salt-size-base);
 }
 
 /* Pseudo-class applied to the root element on focus */

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
@@ -7,8 +7,6 @@
   --trackerStep-icon-color: var(--saltTrackerStep-icon-color, var(--salt-status-static-foreground));
 
   --saltIcon-color: var(--trackerStep-icon-color);
-  /* We redefine Icon Size so we can use it in calc functions in the trackerConnector */
-  --saltIcon-size: var(--saltTrackerStep-icon-size, max(var(--salt-size-icon), 12px));
 }
 
 .saltTrackerStep {
@@ -40,8 +38,10 @@
   padding-bottom: var(--salt-spacing-300);
 }
 
-.saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerStep-indicator {
-  width: var(--salt-size-icon);
+.saltTrackerStep-indicator {
+  flex-shrink: 0;
+  flex-grow: 0;
+  width: var(--salt-size-base);
   height: var(--salt-size-base);
   display: flex;
   justify-content: center;
@@ -95,8 +95,8 @@
   --trackerStep-icon-color: var(--trackerStep-icon-color-active);
 }
 
-.saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerStep-depth-1 .saltIcon,
+/* .saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerStep-depth-1 .saltIcon,
 .saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerStep-depth-2 .saltIcon {
   width: var(--salt-size-adornment);
   min-width: var(--salt-size-adornment);
-}
+} */

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
@@ -91,12 +91,6 @@
   gap: var(--salt-spacing-300);
 }
 
-.saltTrackerStep.saltTrackerStep-inprogress {
+.saltTrackerStep.saltTrackerStep-stage-inprogress {
   --trackerStep-icon-color: var(--trackerStep-icon-color-active);
 }
-
-/* .saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerStep-depth-1 .saltIcon,
-.saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerStep-depth-2 .saltIcon {
-  width: var(--salt-size-adornment);
-  min-width: var(--salt-size-adornment);
-} */

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
@@ -107,3 +107,13 @@
 .saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerStep-depth-2 {
   gap: var(--salt-spacing-300);
 }
+
+.saltSteppedTracker-nested.saltSteppedTracker-vertical .saltTrackerStep:not(.saltTrackerStep-parent) > .saltTrackerStep-body {
+  --trackerStep-toggle-width: calc(
+    2 *
+    var(--saltButton-padding, calc(var(--salt-spacing-100) - var(--saltButton-borderWidth, var(--salt-size-border, 0)))) +
+    var(--saltButton-iconSize, var(--salt-size-icon))
+  );
+  padding-right: var(--salt-spacing-300);
+  margin-right: var(--trackerStep-toggle-width);
+}

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
@@ -33,8 +33,19 @@
 
 .saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerStep {
   flex-direction: row;
-  min-height: calc(var(--salt-size-base) * 2);
+  min-height: var(--salt-size-base);
   width: 100%;
+  align-items: flex-start;
+  gap: var(--salt-spacing-100);
+  padding-bottom: var(--salt-spacing-300);
+}
+
+.saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerStep-indicator {
+  width: var(--salt-size-icon);
+  height: var(--salt-size-base);
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 /* Pseudo-class applied to the root element on focus */
@@ -51,6 +62,10 @@
   align-items: center;
   flex-direction: column;
 }
+.saltSteppedTracker-vertical .saltTrackerStep-body {
+  width: 100%;
+  display: block;
+}
 
 .saltTrackerStep.saltTrackerStep-status-warning {
   --trackerStep-icon-color: var(--trackerStep-icon-color-warning);
@@ -66,4 +81,22 @@
 
 .saltTrackerStep.saltTrackerStep-stage-completed {
   --trackerStep-icon-color: var(--trackerStep-icon-color-completed);
+}
+
+/* Nested styles (vertical only) */
+.saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerStep-depth-1 {
+  gap: var(--salt-spacing-200);
+}
+.saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerStep-depth-2 {
+  gap: var(--salt-spacing-300);
+}
+
+.saltTrackerStep.saltTrackerStep-inprogress {
+  --trackerStep-icon-color: var(--trackerStep-icon-color-active);
+}
+
+.saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerStep-depth-1 .saltIcon,
+.saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerStep-depth-2 .saltIcon {
+  width: var(--salt-size-adornment);
+  min-width: var(--salt-size-adornment);
 }

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
@@ -78,6 +78,9 @@
   width: 100%;
   display: block;
 }
+.saltSteppedTracker-horizontal .saltTrackerStep-body {
+  text-align: center;
+}
 
 .saltTrackerStep-status-warning .saltTrackerStep-indicator {
   --trackerStep-icon-color: var(--trackerStep-icon-color-warning);

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.css
@@ -1,4 +1,4 @@
-.saltTrackerStep {
+.saltTrackerStep .saltTrackerStep-indicator {
   --trackerStep-icon-color-active: var(--saltTrackerStep-icon-color-active, var(--salt-status-info-foreground-decorative));
   --trackerStep-icon-color-completed: var(--saltTrackerStep-icon-color-completed, var(--salt-status-success-foreground-decorative));
   --trackerStep-icon-color-warning: var(--saltTrackerStep-icon-color-warning, var(--salt-status-warning-foreground-decorative));
@@ -67,30 +67,31 @@
   display: block;
 }
 
-.saltTrackerStep.saltTrackerStep-status-warning {
+.saltTrackerStep-status-warning .saltTrackerStep-indicator {
   --trackerStep-icon-color: var(--trackerStep-icon-color-warning);
 }
 
-.saltTrackerStep.saltTrackerStep-status-error {
+.saltTrackerStep-status-error .saltTrackerStep-indicator {
   --trackerStep-icon-color: var(--trackerStep-icon-color-error);
 }
 
-.saltTrackerStep.saltTrackerStep-active {
+.saltTrackerStep-active .saltTrackerStep-indicator {
   --trackerStep-icon-color: var(--trackerStep-icon-color-active);
 }
 
-.saltTrackerStep.saltTrackerStep-stage-completed {
+.saltTrackerStep-stage-completed .saltTrackerStep-indicator {
   --trackerStep-icon-color: var(--trackerStep-icon-color-completed);
+}
+
+.saltTrackerStep-stage-inprogress .saltTrackerStep-indicator {
+  --trackerStep-icon-color: var(--trackerStep-icon-color-active);
 }
 
 /* Nested styles (vertical only) */
 .saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerStep-depth-1 {
   gap: var(--salt-spacing-200);
 }
+
 .saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerStep-depth-2 {
   gap: var(--salt-spacing-300);
-}
-
-.saltTrackerStep.saltTrackerStep-stage-inprogress {
-  --trackerStep-icon-color: var(--trackerStep-icon-color-active);
 }

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
@@ -10,7 +10,7 @@ import {
 import { useComponentCssInjection } from "@salt-ds/styles";
 import { useWindow } from "@salt-ds/window";
 import { clsx } from "clsx";
-import { type ComponentPropsWithoutRef, forwardRef, useEffect } from "react";
+import { type ComponentPropsWithoutRef, useEffect } from "react";
 import { TrackerConnector } from "../TrackerConnector";
 
 import {
@@ -26,7 +26,7 @@ type StageOptions = "pending" | "completed" | "inprogress";
 type StatusOptions = Extract<ValidationStatus, "warning" | "error">;
 type Depth = 0 | 1 | 2;
 
-export interface TrackerStepProps extends ComponentPropsWithoutRef<"li"> {
+export interface TrackerStepProps {
   /**
    * The stage of the step: "pending" or "completed" (note, "active" is derived from "activeStep" in parent SteppedTracker component)
    */
@@ -41,7 +41,18 @@ export interface TrackerStepProps extends ComponentPropsWithoutRef<"li"> {
    * The nesting depth of the TrackerStep
    */
   depth?: Depth;
+  style?: React.CSSProperties;
+  className?: string;
+  children?: React.ReactNode;
 }
+
+interface TrackerStepLiProps
+  extends TrackerStepProps,
+    ComponentPropsWithoutRef<"li"> {}
+
+interface TrackerStepDivProps
+  extends TrackerStepProps,
+    ComponentPropsWithoutRef<"div"> {}
 
 const iconMap = {
   pending: StepDefaultIcon,
@@ -79,70 +90,75 @@ const parseIconName = ({
   return stage;
 };
 
-export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
-  function TrackerStep(props, ref) {
-    const {
-      stage = "pending",
-      status,
-      style,
-      className,
-      children,
-      depth = 0,
-      ...restProps
-    } = props;
+export const TrackerStep = (props: TrackerStepProps) => {
+  const {
+    stage = "pending",
+    status,
+    style,
+    className,
+    children,
+    depth = 0,
+    ...restProps
+  } = props;
 
-    const targetWindow = useWindow();
-    useComponentCssInjection({
-      testId: "salt-tracker-step",
-      css: trackerStepCss,
-      window: targetWindow,
-    });
+  const targetWindow = useWindow();
+  useComponentCssInjection({
+    testId: "salt-tracker-step",
+    css: trackerStepCss,
+    window: targetWindow,
+  });
 
-    const { activeStep, totalSteps, isWithinSteppedTracker } =
-      useSteppedTrackerContext();
-    const { stepNumber, parent } = useTrackerStepContext();
+  const { activeStep, totalSteps, isWithinSteppedTracker } =
+    useSteppedTrackerContext();
+  const { stepNumber, parent } = useTrackerStepContext();
 
-    useCheckWithinSteppedTracker(isWithinSteppedTracker);
+  useCheckWithinSteppedTracker(isWithinSteppedTracker);
 
-    const isActive = activeStep === stepNumber;
-    const iconName = parseIconName({ stage, status, active: isActive });
+  const isActive = activeStep === stepNumber;
+  const iconName = parseIconName({ stage, status, active: isActive });
 
-    const Icon = iconMap[iconName];
-    const connectorState = activeStep > stepNumber ? "active" : "default";
-    const hasConnector = stepNumber < totalSteps - 1;
-    const depthClass = withBaseName(`depth-${depth}`);
-    const hierarchy = parent ? "parent" : "child";
-    const iconSize = depth > 0 ? 1 : 1.5;
+  const Icon = iconMap[iconName];
+  const connectorState = activeStep > stepNumber ? "active" : "default";
+  const hasConnector = stepNumber < totalSteps - 1;
+  const depthClass = withBaseName(`depth-${depth}`);
+  const hierarchy = parent ? "parent" : "child";
+  const iconSize = depth > 0 ? 1 : 1.5;
 
-    const innerStyle = {
-      ...style,
-      "--saltTrackerStep-width": `${100 / totalSteps}%`,
-    };
+  const innerStyle = {
+    ...style,
+    "--saltTrackerStep-width": `${100 / totalSteps}%`,
+  };
 
-    return (
-      <li
-        className={clsx(
-          withBaseName(),
-          withBaseName(`stage-${stage}`),
-          withBaseName(`status-${status}`),
-          withBaseName(hierarchy),
-          {
-            [withBaseName("active")]: isActive,
-          },
-          depthClass,
-          className,
-        )}
-        style={innerStyle}
-        aria-current={isActive ? "step" : undefined}
-        ref={ref}
-        {...restProps}
-      >
+  const renderContainer = parent
+    ? (props: TrackerStepDivProps) => <div {...props} />
+    : (props: TrackerStepLiProps) => <li {...props} />;
+
+  const containerClass = clsx(
+    withBaseName(),
+    withBaseName(`stage-${stage}`),
+    withBaseName(`status-${status}`),
+    withBaseName(hierarchy),
+    {
+      [withBaseName("active")]: isActive,
+    },
+    depthClass,
+    className,
+  );
+  const ariaCurrent = isActive ? "step" : undefined;
+
+  return renderContainer({
+    className: containerClass,
+    style: innerStyle,
+    "aria-current": ariaCurrent,
+    ...restProps,
+    children: (
+      <>
         <div className={withBaseName("indicator")}>
           <Icon size={iconSize} />
         </div>
         {hasConnector && <TrackerConnector state={connectorState} />}
         <div className={withBaseName("body")}>{children}</div>
-      </li>
-    );
-  },
-);
+      </>
+    ),
+  });
+};

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
@@ -6,7 +6,6 @@ import {
   StepDefaultIcon,
   StepSuccessIcon,
   WarningSolidIcon,
-  SuccessIcon,
 } from "@salt-ds/icons";
 import { useComponentCssInjection } from "@salt-ds/styles";
 import { useWindow } from "@salt-ds/window";
@@ -23,7 +22,7 @@ import trackerStepCss from "./TrackerStep.css";
 
 const withBaseName = makePrefixer("saltTrackerStep");
 
-type StageOptions = "pending" | "completed";
+type StageOptions = "pending" | "completed" | "inprogress";
 type StatusOptions = Extract<ValidationStatus, "warning" | "error">;
 type Depth = 0 | 1 | 2;
 
@@ -50,7 +49,6 @@ const iconMap = {
   completed: StepSuccessIcon,
   warning: WarningSolidIcon,
   error: ErrorSolidIcon,
-  "completed-sub": SuccessIcon,
   inprogress: ProgressInprogressIcon,
 };
 

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
@@ -113,6 +113,7 @@ export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
     const connectorState = activeStep > stepNumber ? "active" : "default";
     const hasConnector = stepNumber < totalSteps - 1;
     const depthClass = withBaseName(`depth-${depth}`);
+    const iconSize = depth > 0 ? 1 : 1.5;
 
     const innerStyle = {
       ...style,
@@ -135,7 +136,7 @@ export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
         {...restProps}
       >
         <div className={withBaseName("indicator")}>
-          <Icon />
+          <Icon size={iconSize} />
         </div>
         {hasConnector && <TrackerConnector state={connectorState} />}
         <div className={withBaseName("body")}>{children}</div>

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
@@ -5,6 +5,8 @@ import {
   StepDefaultIcon,
   StepSuccessIcon,
   WarningSolidIcon,
+  SuccessIcon,
+  ProgressInprogressIcon,
 } from "@salt-ds/icons";
 import { useComponentCssInjection } from "@salt-ds/styles";
 import { useWindow } from "@salt-ds/window";
@@ -23,6 +25,7 @@ const withBaseName = makePrefixer("saltTrackerStep");
 
 type StageOptions = "pending" | "completed";
 type StatusOptions = Extract<ValidationStatus, "warning" | "error">;
+type Depth = 0 | 1 | 2;
 
 export interface TrackerStepProps extends ComponentPropsWithoutRef<"li"> {
   /**
@@ -35,6 +38,10 @@ export interface TrackerStepProps extends ComponentPropsWithoutRef<"li"> {
    * If the stage is completed or active, the status prop will be ignored
    */
   status?: StatusOptions;
+  /**
+   * The nesting depth of the TrackerStep
+   */
+  depth?: Depth;
 }
 
 const iconMap = {
@@ -43,6 +50,8 @@ const iconMap = {
   completed: StepSuccessIcon,
   warning: WarningSolidIcon,
   error: ErrorSolidIcon,
+  "completed-sub": SuccessIcon,
+  inprogress: ProgressInprogressIcon,
 };
 
 const useCheckWithinSteppedTracker = (isWithinSteppedTracker: boolean) => {
@@ -80,6 +89,7 @@ export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
       style,
       className,
       children,
+      depth = 0,
       ...restProps
     } = props;
 
@@ -102,6 +112,7 @@ export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
     const Icon = iconMap[iconName];
     const connectorState = activeStep > stepNumber ? "active" : "default";
     const hasConnector = stepNumber < totalSteps - 1;
+    const depthClass = withBaseName(`depth-${depth}`);
 
     const innerStyle = {
       ...style,
@@ -115,6 +126,7 @@ export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
           withBaseName(`stage-${stage}`),
           withBaseName(`status-${status}`),
           { [withBaseName("active")]: isActive },
+          depthClass,
           className,
         )}
         style={innerStyle}
@@ -122,7 +134,9 @@ export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
         ref={ref}
         {...restProps}
       >
-        <Icon />
+        <div className={withBaseName("indicator")}>
+          <Icon />
+        </div>
         {hasConnector && <TrackerConnector state={connectorState} />}
         <div className={withBaseName("body")}>{children}</div>
       </li>

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
@@ -100,7 +100,7 @@ export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
 
     const { activeStep, totalSteps, isWithinSteppedTracker } =
       useSteppedTrackerContext();
-    const { stepNumber } = useTrackerStepContext();
+    const { stepNumber, parent } = useTrackerStepContext();
 
     useCheckWithinSteppedTracker(isWithinSteppedTracker);
 
@@ -111,6 +111,7 @@ export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
     const connectorState = activeStep > stepNumber ? "active" : "default";
     const hasConnector = stepNumber < totalSteps - 1;
     const depthClass = withBaseName(`depth-${depth}`);
+    const hierarchy = parent ? "parent" : "child";
     const iconSize = depth > 0 ? 1 : 1.5;
 
     const innerStyle = {
@@ -124,7 +125,10 @@ export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
           withBaseName(),
           withBaseName(`stage-${stage}`),
           withBaseName(`status-${status}`),
-          { [withBaseName("active")]: isActive },
+          withBaseName(hierarchy),
+          {
+            [withBaseName("active")]: isActive,
+          },
           depthClass,
           className,
         )}

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
@@ -1,12 +1,12 @@
 import { type ValidationStatus, makePrefixer } from "@salt-ds/core";
 import {
   ErrorSolidIcon,
+  ProgressInprogressIcon,
   StepActiveIcon,
   StepDefaultIcon,
   StepSuccessIcon,
   WarningSolidIcon,
   SuccessIcon,
-  ProgressInprogressIcon,
 } from "@salt-ds/icons";
 import { useComponentCssInjection } from "@salt-ds/styles";
 import { useWindow } from "@salt-ds/window";

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
@@ -102,7 +102,7 @@ export const TrackerStep = forwardRef<HTMLLIElement, TrackerStepProps>(
 
     const { activeStep, totalSteps, isWithinSteppedTracker } =
       useSteppedTrackerContext();
-    const stepNumber = useTrackerStepContext();
+    const { stepNumber } = useTrackerStepContext();
 
     useCheckWithinSteppedTracker(isWithinSteppedTracker);
 

--- a/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStep/TrackerStep.tsx
@@ -150,10 +150,11 @@ export const TrackerStep = (props: TrackerStepProps) => {
     className: containerClass,
     style: innerStyle,
     "aria-current": ariaCurrent,
+    "aria-label": `Step ${stepNumber + 1} (${stage}${status ? `, ${status}` : ""})`,
     ...restProps,
     children: (
       <>
-        <div className={withBaseName("indicator")}>
+        <div className={withBaseName("indicator")} aria-hidden="true">
           <Icon size={iconSize} />
         </div>
         {hasConnector && <TrackerConnector state={connectorState} />}

--- a/packages/lab/src/stepped-tracker/TrackerStepWrapper/TrackerStepWrapper.css
+++ b/packages/lab/src/stepped-tracker/TrackerStepWrapper/TrackerStepWrapper.css
@@ -1,18 +1,15 @@
-.saltTrackerStepWrapper {
+.saltTrackerStepWrapper-parent {
   display: flex;
   align-items: start;
   width: var(--saltTrackerStep-width, 100%);
   gap: var(--salt-spacing-50);
 }
 
-.saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerStepWrapper-nested-group {
-  flex-direction: column;
-}
-
 .saltTrackerStepWrapper-nested-group {
-  width: 100%;
   display: grid;
   transition: grid-template-rows var(--salt-duration-perceptible) ease-in-out, opacity var(--salt-duration-perceptible) ease-in-out, visibility var(--salt-duration-perceptible) ease-in-out;
+  margin: 0;
+  padding: 0;
 }
 
 .saltTrackerStepWrapper-nested-group-inner {

--- a/packages/lab/src/stepped-tracker/TrackerStepWrapper/TrackerStepWrapper.css
+++ b/packages/lab/src/stepped-tracker/TrackerStepWrapper/TrackerStepWrapper.css
@@ -1,0 +1,36 @@
+.saltTrackerStepWrapper {
+  display: flex;
+  align-items: start;
+  width: var(--saltTrackerStep-width, 100%);
+  gap: var(--salt-spacing-50);
+}
+
+.saltSteppedTracker.saltSteppedTracker-vertical .saltTrackerStepWrapper-nested-group {
+  flex-direction: column;
+}
+
+.saltTrackerStepWrapper-nested-group {
+  width: 100%;
+  display: grid;
+  transition: grid-template-rows var(--salt-duration-perceptible) ease-in-out, opacity var(--salt-duration-perceptible) ease-in-out, visibility var(--salt-duration-perceptible) ease-in-out;
+}
+
+.saltTrackerStepWrapper-nested-group-inner {
+  margin: 0;
+  padding: 0;
+  text-indent: 0;
+  list-style-type: none;
+  overflow: hidden;
+}
+
+.saltTrackerStepWrapper-nested-group[aria-hidden="true"] {
+  grid-template-rows: 0fr;
+  opacity: 0;
+  visibility: hidden;
+}
+
+.saltTrackerStepWrapper-nested-group {
+  grid-template-rows: 1fr;
+  opacity: 1;
+  visibility: visible;
+}

--- a/packages/lab/src/stepped-tracker/TrackerStepWrapper/TrackerStepWrapper.css
+++ b/packages/lab/src/stepped-tracker/TrackerStepWrapper/TrackerStepWrapper.css
@@ -18,6 +18,10 @@
   text-indent: 0;
   list-style-type: none;
   overflow: hidden;
+  padding-right: var(--salt-focused-outlineWidth);
+  margin-right: calc(0px - var(--salt-focused-outlineWidth));
+  padding-top: var(--salt-focused-outlineWidth);
+  margin-top: calc(0px - var(--salt-focused-outlineWidth));
 }
 
 .saltTrackerStepWrapper-nested-group[aria-hidden="true"] {

--- a/packages/lab/src/stepped-tracker/TrackerStepWrapper/TrackerStepWrapper.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStepWrapper/TrackerStepWrapper.tsx
@@ -1,0 +1,73 @@
+import { Button, makePrefixer } from "@salt-ds/core";
+import { clsx } from "clsx";
+import { type ComponentPropsWithoutRef, type ReactNode, useState } from "react";
+
+import { ChevronDownIcon, ChevronUpIcon } from "@salt-ds/icons";
+import { useComponentCssInjection } from "@salt-ds/styles";
+import { useWindow } from "@salt-ds/window";
+import { TrackerStepProvider } from "../SteppedTrackerContext";
+
+import trackerStepWrapperCss from "./TrackerStepWrapper.css";
+
+const withBaseName = makePrefixer("saltTrackerStepWrapper");
+
+export interface TrackerStepWrapperProps
+  extends ComponentPropsWithoutRef<"ul"> {
+  child: ReactNode;
+  stepNumber: number;
+}
+
+export const TrackerStepWrapper = (props: TrackerStepWrapperProps) => {
+  const { children, child, stepNumber } = props;
+
+  const targetWindow = useWindow();
+  useComponentCssInjection({
+    testId: "salt-tracker-step",
+    css: trackerStepWrapperCss,
+    window: targetWindow,
+  });
+
+  const [expanded, setExpanded] = useState(true);
+
+  const handleCollapseToggle = () => {
+    setExpanded(!expanded);
+  };
+
+  return (
+    <>
+      <TrackerStepProvider stepNumber={stepNumber}>
+        <div className={withBaseName()}>
+          {child}
+          <Button
+            className={withBaseName("collapse-toggle")}
+            onClick={handleCollapseToggle}
+            variant="secondary"
+          >
+            {expanded ? (
+              <ChevronUpIcon
+                aria-label="clear input"
+                className={withBaseName("expand-icon")}
+              />
+            ) : (
+              <ChevronDownIcon
+                aria-label="clear input"
+                className={withBaseName("expand-icon")}
+              />
+            )}
+          </Button>
+        </div>
+      </TrackerStepProvider>
+      <div
+        className={clsx(withBaseName("nested-group"), {
+          [withBaseName("nested-group-expanded")]: expanded,
+          [withBaseName("nested-group-collapsed")]: !expanded,
+        })}
+        data-parent-step={stepNumber}
+        aria-hidden={!expanded ? "true" : undefined}
+        hidden={!expanded}
+      >
+        <ul className={withBaseName("nested-group-inner")}>{children}</ul>
+      </div>
+    </>
+  );
+};

--- a/packages/lab/src/stepped-tracker/TrackerStepWrapper/TrackerStepWrapper.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStepWrapper/TrackerStepWrapper.tsx
@@ -34,7 +34,12 @@ export const TrackerStepWrapper = (props: TrackerStepWrapperProps) => {
   };
 
   return (
-    <li className={withBaseName()}>
+    <li
+      className={clsx(withBaseName(), {
+        [withBaseName("expanded")]: expanded,
+        [withBaseName("collapsed")]: !expanded,
+      })}
+    >
       <TrackerStepProvider stepNumber={stepNumber} parent={true}>
         <div className={withBaseName("parent")}>
           {child}

--- a/packages/lab/src/stepped-tracker/TrackerStepWrapper/TrackerStepWrapper.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStepWrapper/TrackerStepWrapper.tsx
@@ -34,9 +34,9 @@ export const TrackerStepWrapper = (props: TrackerStepWrapperProps) => {
   };
 
   return (
-    <>
+    <li className={withBaseName()}>
       <TrackerStepProvider stepNumber={stepNumber} parent={true}>
-        <div className={withBaseName()}>
+        <div className={withBaseName("parent")}>
           {child}
           <Button
             className={withBaseName("collapse-toggle")}
@@ -68,6 +68,6 @@ export const TrackerStepWrapper = (props: TrackerStepWrapperProps) => {
       >
         <ul className={withBaseName("nested-group-inner")}>{children}</ul>
       </div>
-    </>
+    </li>
   );
 };

--- a/packages/lab/src/stepped-tracker/TrackerStepWrapper/TrackerStepWrapper.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStepWrapper/TrackerStepWrapper.tsx
@@ -35,7 +35,7 @@ export const TrackerStepWrapper = (props: TrackerStepWrapperProps) => {
 
   return (
     <>
-      <TrackerStepProvider stepNumber={stepNumber}>
+      <TrackerStepProvider stepNumber={stepNumber} parent={true}>
         <div className={withBaseName()}>
           {child}
           <Button

--- a/packages/lab/src/stepped-tracker/TrackerStepWrapper/TrackerStepWrapper.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStepWrapper/TrackerStepWrapper.tsx
@@ -71,7 +71,7 @@ export const TrackerStepWrapper = (props: TrackerStepWrapperProps) => {
         aria-hidden={!expanded ? "true" : undefined}
         hidden={!expanded}
       >
-        <ul className={withBaseName("nested-group-inner")}>{children}</ul>
+        <ol className={withBaseName("nested-group-inner")}>{children}</ol>
       </div>
     </li>
   );

--- a/packages/lab/src/stepped-tracker/TrackerStepWrapper/TrackerStepWrapper.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStepWrapper/TrackerStepWrapper.tsx
@@ -47,7 +47,9 @@ export const TrackerStepWrapper = (props: TrackerStepWrapperProps) => {
             className={withBaseName("collapse-toggle")}
             onClick={handleCollapseToggle}
             aria-expanded={expanded}
-            variant="secondary"
+            aria-label={`Step ${stepNumber} show sub steps`}
+            sentiment="neutral"
+            appearance="transparent"
           >
             {expanded ? (
               <ChevronUpIcon

--- a/packages/lab/src/stepped-tracker/TrackerStepWrapper/TrackerStepWrapper.tsx
+++ b/packages/lab/src/stepped-tracker/TrackerStepWrapper/TrackerStepWrapper.tsx
@@ -46,6 +46,7 @@ export const TrackerStepWrapper = (props: TrackerStepWrapperProps) => {
           <Button
             className={withBaseName("collapse-toggle")}
             onClick={handleCollapseToggle}
+            aria-expanded={expanded}
             variant="secondary"
           >
             {expanded ? (

--- a/packages/lab/src/stepped-tracker/TrackerStepWrapper/index.ts
+++ b/packages/lab/src/stepped-tracker/TrackerStepWrapper/index.ts
@@ -1,0 +1,1 @@
+export { TrackerStepWrapper } from "./TrackerStepWrapper";

--- a/packages/lab/src/stepped-tracker/utils.tsx
+++ b/packages/lab/src/stepped-tracker/utils.tsx
@@ -1,6 +1,9 @@
 import { Children, isValidElement, Fragment, type ReactNode } from "react";
+import { makePrefixer } from "@salt-ds/core";
 
 import { TrackerStepProvider } from "./SteppedTrackerContext";
+
+const withBaseName = makePrefixer("saltSteppedTracker");
 
 type DepthMap = {
   i: number;
@@ -75,7 +78,12 @@ export const renderNestedSteps = (
           <TrackerStepProvider stepNumber={depthItem.i}>
             {child}
           </TrackerStepProvider>
-          <div className={} >{renderNestedSteps(childrenArray, depthItem.children)}</div>
+          <ul
+            className={withBaseName("nested-group")}
+            data-parent-step={depthItem.i}
+          >
+            {renderNestedSteps(childrenArray, depthItem.children)}
+          </ul>
         </Fragment>
       );
     }

--- a/packages/lab/src/stepped-tracker/utils.tsx
+++ b/packages/lab/src/stepped-tracker/utils.tsx
@@ -1,9 +1,7 @@
-import { Children, isValidElement, Fragment, type ReactNode } from "react";
-import { makePrefixer } from "@salt-ds/core";
+import { Children, type ReactNode, isValidElement } from "react";
 
 import { TrackerStepProvider } from "./SteppedTrackerContext";
-
-const withBaseName = makePrefixer("saltSteppedTracker");
+import { TrackerStepWrapper } from "./TrackerStepWrapper";
 
 type DepthMap = {
   i: number;
@@ -74,17 +72,13 @@ export const renderNestedSteps = (
 
     if (depthItem.children.length > 0) {
       return (
-        <Fragment key={`step-${depthItem.i}`}>
-          <TrackerStepProvider stepNumber={depthItem.i}>
-            {child}
-          </TrackerStepProvider>
-          <ul
-            className={withBaseName("nested-group")}
-            data-parent-step={depthItem.i}
-          >
-            {renderNestedSteps(childrenArray, depthItem.children)}
-          </ul>
-        </Fragment>
+        <TrackerStepWrapper
+          key={`step-${depthItem.i}`}
+          child={child}
+          stepNumber={depthItem.i}
+        >
+          {renderNestedSteps(childrenArray, depthItem.children)}
+        </TrackerStepWrapper>
       );
     }
 

--- a/packages/lab/src/stepped-tracker/utils.tsx
+++ b/packages/lab/src/stepped-tracker/utils.tsx
@@ -1,0 +1,88 @@
+import { Children, isValidElement, Fragment, type ReactNode } from "react";
+
+import { TrackerStepProvider } from "./SteppedTrackerContext";
+
+type DepthMap = {
+  i: number;
+  children: DepthMap[];
+  depth?: number;
+};
+
+export const getDepthMap = (children: ReactNode): DepthMap[] => {
+  const depths = getDepthsFromChildren(children);
+
+  const validDepths =
+    depths && depths.length > 0
+      ? depths.filter((depth) => typeof depth === "number")
+      : [];
+
+  const noramlisedDepths = normalizeDepthValues(validDepths);
+
+  const depthMap = convertDepthsToDepthMap(noramlisedDepths);
+
+  return depthMap;
+};
+
+export const normalizeDepthValues = (depths: number[]) => {
+  const minDepth = Math.min(...depths);
+  return depths.map((depth) => depth - minDepth);
+};
+
+export const getDepthsFromChildren = (children: ReactNode) =>
+  Children.map(children, (child) => {
+    if (isValidElement(child)) {
+      const depthProp = child.props.depth;
+      return Number.parseInt(depthProp, 10) || 0;
+    }
+  });
+
+export const convertDepthsToDepthMap = (depths: number[]) => {
+  const depthsObjects = depths.map(
+    (depth: number, i: number): DepthMap => ({ i, depth, children: [] }),
+  );
+
+  const depthMap = depthsObjects.reduce((acc: DepthMap[], item: DepthMap) => {
+    if (item.depth === 0) {
+      acc.push(item);
+      return acc;
+    }
+    if (item.depth === 1) {
+      acc[acc.length - 1].children.push(item);
+      return acc;
+    }
+    if (item.depth === 2) {
+      const last0 = acc.length - 1;
+      const last1 = acc[last0].children.length - 1;
+      acc[last0].children[last1].children.push(item);
+      return acc;
+    }
+    return acc;
+  }, []);
+
+  return depthMap;
+};
+
+export const renderNestedSteps = (
+  childrenArray: ReactNode[],
+  depthMap: DepthMap[],
+) =>
+  depthMap.map((depthItem) => {
+    const child = childrenArray[depthItem.i];
+
+    if (depthItem.children.length > 0) {
+      return (
+        <Fragment key={`step-${depthItem.i}`}>
+          <TrackerStepProvider stepNumber={depthItem.i}>
+            {child}
+          </TrackerStepProvider>
+          <div className={} >{renderNestedSteps(childrenArray, depthItem.children)}</div>
+        </Fragment>
+      );
+    }
+
+    return (
+      <TrackerStepProvider key={`step-${depthItem.i}`} stepNumber={depthItem.i}>
+        {child}
+      </TrackerStepProvider>
+    );
+  });

--- a/packages/lab/src/stepped-tracker/utils.tsx
+++ b/packages/lab/src/stepped-tracker/utils.tsx
@@ -83,8 +83,15 @@ export const renderNestedSteps = (
     }
 
     return (
-      <TrackerStepProvider key={`step-${depthItem.i}`} stepNumber={depthItem.i}>
+      <TrackerStepProvider
+        key={`step-${depthItem.i}`}
+        stepNumber={depthItem.i}
+        parent={false}
+      >
         {child}
       </TrackerStepProvider>
     );
   });
+
+export const checkNesting = (depthMap: DepthMap[]) =>
+  depthMap.reduce((acc, item) => acc || item.children.length > 0, false);

--- a/packages/lab/stories/stepped-tracker/stepped-tracker.qa.stories.tsx
+++ b/packages/lab/stories/stepped-tracker/stepped-tracker.qa.stories.tsx
@@ -159,6 +159,63 @@ export const Vertical: StoryFn<QAContainerProps> = (props) => {
   );
 };
 
+export const NestedVertical: StoryFn<QAContainerProps> = (props) => {
+  return (
+    <QAContainer height={500} width={1000} {...props}>
+      <StackLayout
+        direction="row"
+        align="stretch"
+        gap={2}
+        style={{
+          minWidth: 450,
+          marginBottom: 50,
+        }}
+      >
+        <SteppedTracker orientation="vertical" activeStep={0}>
+          <TrackerStep>
+            <StepLabel>1</StepLabel>
+          </TrackerStep>
+          <TrackerStep depth={1}>
+            <StepLabel>1.1</StepLabel>
+          </TrackerStep>
+          <TrackerStep depth={1}>
+            <StepLabel>1.2</StepLabel>
+          </TrackerStep>
+          <TrackerStep depth={2}>
+            <StepLabel>1.2.1</StepLabel>
+          </TrackerStep>
+          <TrackerStep depth={2}>
+            <StepLabel>1.2.2</StepLabel>
+          </TrackerStep>
+          <TrackerStep depth={2}>
+            <StepLabel>1.2.3</StepLabel>
+          </TrackerStep>
+        </SteppedTracker>
+        <SteppedTracker orientation="vertical" activeStep={4}>
+          <TrackerStep stage="inprogress">
+            <StepLabel>1</StepLabel>
+          </TrackerStep>
+          <TrackerStep depth={1} stage="completed">
+            <StepLabel>1.1</StepLabel>
+          </TrackerStep>
+          <TrackerStep depth={1} stage="inprogress">
+            <StepLabel>1.2</StepLabel>
+          </TrackerStep>
+          <TrackerStep depth={2} stage="completed">
+            <StepLabel>1.2.1</StepLabel>
+          </TrackerStep>
+          <TrackerStep depth={2}>
+            <StepLabel>1.2.2</StepLabel>
+          </TrackerStep>
+          <TrackerStep depth={2}>
+            <StepLabel>1.2.3</StepLabel>
+          </TrackerStep>
+        </SteppedTracker>
+      </StackLayout>
+    </QAContainer>
+  );
+};
+
 Basic.parameters = {
   chromatic: { disableSnapshot: false },
 };

--- a/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
+++ b/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
@@ -152,33 +152,33 @@ export const NestedVertical: StoryFn<typeof SteppedTracker> = () => {
       activeStep={8}
       style={{ width: 400 }}
     >
-      <TrackerStep state="completed">
+      <TrackerStep stage="completed">
         <StepLabel>Step 1</StepLabel>
         <Text color="secondary">
           A label that is very long describing the sub-steps and why they are
           there and stuff like that. Lorem ipsum dolor sit amet, consectetur.
         </Text>
       </TrackerStep>
-      <TrackerStep depth={1} state="completed">
+      <TrackerStep depth={1} stage="completed">
         <StepLabel>Step 1.1</StepLabel>
       </TrackerStep>
-      <TrackerStep depth={2} state="completed">
+      <TrackerStep depth={2} stage="completed">
         <StepLabel>Step 1.1.1</StepLabel>
         <Text color="secondary">This one has an extra label</Text>
       </TrackerStep>
-      <TrackerStep depth={2} state="completed">
+      <TrackerStep depth={2} stage="completed">
         <StepLabel>Step 1.1.2</StepLabel>
       </TrackerStep>
-      <TrackerStep state="completed">
+      <TrackerStep stage="completed">
         <StepLabel>Step 2</StepLabel>
       </TrackerStep>
-      <TrackerStep state="inprogress">
+      <TrackerStep stage="inprogress">
         <StepLabel>Step 3</StepLabel>
       </TrackerStep>
-      <TrackerStep depth={1} state="inprogress">
+      <TrackerStep depth={1} stage="inprogress">
         <StepLabel>Step 3.1</StepLabel>
       </TrackerStep>
-      <TrackerStep depth={2} state="completed">
+      <TrackerStep depth={2} stage="completed">
         <StepLabel>Step 3.1.1</StepLabel>
       </TrackerStep>
       <TrackerStep depth={2}>
@@ -194,7 +194,7 @@ export const NestedVertical: StoryFn<typeof SteppedTracker> = () => {
       <TrackerStep depth={1}>
         <StepLabel>Step 3.3</StepLabel>
       </TrackerStep>
-      <TrackerStep state="default">
+      <TrackerStep>
         <StepLabel>Step 4</StepLabel>
       </TrackerStep>
     </SteppedTracker>

--- a/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
+++ b/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
@@ -154,6 +154,50 @@ export const NestedVertical: StoryFn<typeof SteppedTracker> = () => {
     >
       <TrackerStep stage="completed">
         <StepLabel>Step 1</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={1} stage="completed">
+        <StepLabel>Step 1.1</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={1} stage="completed">
+        <StepLabel>Step 1.2</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={1} stage="completed">
+        <StepLabel>Step 1.3</StepLabel>
+      </TrackerStep>
+      <TrackerStep stage="completed">
+        <StepLabel>Step 2</StepLabel>
+      </TrackerStep>
+      <TrackerStep stage="inprogress">
+        <StepLabel>Step 3</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={1} stage="completed">
+        <StepLabel>Step 3.1</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={1} stage="completed">
+        <StepLabel>Step 3.2</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={1} stage="inprogress">
+        <StepLabel>Step 3.3</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={1}>
+        <StepLabel>Step 3.4</StepLabel>
+      </TrackerStep>
+      <TrackerStep>
+        <StepLabel>Step 4</StepLabel>
+      </TrackerStep>
+    </SteppedTracker>
+  );
+};
+
+export const NestedVerticalComplex: StoryFn<typeof SteppedTracker> = () => {
+  return (
+    <SteppedTracker
+      orientation="vertical"
+      activeStep={8}
+      style={{ width: 400 }}
+    >
+      <TrackerStep stage="completed">
+        <StepLabel>Step 1</StepLabel>
         <Text color="secondary">
           A label that is very long describing the sub-steps and why they are
           there and stuff like that. Lorem ipsum dolor sit amet, consectetur.
@@ -168,34 +212,51 @@ export const NestedVertical: StoryFn<typeof SteppedTracker> = () => {
       </TrackerStep>
       <TrackerStep depth={2} stage="completed">
         <StepLabel>Step 1.1.2</StepLabel>
+        <Text color="secondary">
+          A label that is very long describing the sub-steps and why they are
+          there and stuff like that. Lorem ipsum dolor sit amet, consectetur. A
+          label that is very long describing the sub-steps and why they are
+          there and stuff like that. Lorem ipsum dolor sit amet, consectetur.
+        </Text>
       </TrackerStep>
       <TrackerStep stage="completed">
         <StepLabel>Step 2</StepLabel>
       </TrackerStep>
+      <TrackerStep stage="completed">
+        <StepLabel>
+          Step 3: a title that is very long and breaks over multiple lines.
+          Lorem ipsum dolor sit amet.
+        </StepLabel>
+      </TrackerStep>
       <TrackerStep stage="inprogress">
-        <StepLabel>Step 3</StepLabel>
+        <StepLabel>
+          Step 4: a title that is very long and breaks over multiple lines.
+          Lorem ipsum dolor sit amet, consectetur. Step 3: a title that is very
+          long and breaks over multiple lines. Lorem ipsum dolor sit amet,
+          consectetur.
+        </StepLabel>
       </TrackerStep>
       <TrackerStep depth={1} stage="inprogress">
-        <StepLabel>Step 3.1</StepLabel>
+        <StepLabel>Step 4.1</StepLabel>
       </TrackerStep>
       <TrackerStep depth={2} stage="completed">
-        <StepLabel>Step 3.1.1</StepLabel>
+        <StepLabel>Step 4.1.1</StepLabel>
       </TrackerStep>
       <TrackerStep depth={2}>
-        <StepLabel>Step 3.1.2</StepLabel>
+        <StepLabel>Step 4.1.2</StepLabel>
       </TrackerStep>
       <TrackerStep depth={2}>
-        <StepLabel>Step 3.1.3</StepLabel>
+        <StepLabel>Step 4.1.3</StepLabel>
       </TrackerStep>
       <TrackerStep depth={1}>
-        <StepLabel>Step 3.2</StepLabel>
+        <StepLabel>Step 4.2</StepLabel>
         <Text color="secondary">This one has an extra label</Text>
       </TrackerStep>
       <TrackerStep depth={1}>
-        <StepLabel>Step 3.3</StepLabel>
+        <StepLabel>Step 4.3</StepLabel>
       </TrackerStep>
       <TrackerStep>
-        <StepLabel>Step 4</StepLabel>
+        <StepLabel>Step 5</StepLabel>
       </TrackerStep>
     </SteppedTracker>
   );

--- a/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
+++ b/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { Button, FlexLayout, StackLayout, Text, Tooltip } from "@salt-ds/core";
+import { Button, FlexLayout, StackLayout, Label, Tooltip } from "@salt-ds/core";
 import { RefreshIcon } from "@salt-ds/icons";
 import { StepLabel, SteppedTracker, TrackerStep } from "@salt-ds/lab";
 import type { Meta, StoryFn } from "@storybook/react";
@@ -99,23 +99,23 @@ export const Status: StoryFn<typeof SteppedTracker> = () => {
       <SteppedTracker activeStep={1}>
         <TrackerStep stage="completed">
           <StepLabel>Completed</StepLabel>
-          <Text color="secondary">Descriptive text</Text>
+          <Label color="secondary">Descriptive text</Label>
         </TrackerStep>
         <TrackerStep>
           <StepLabel>Active</StepLabel>
-          <Text color="secondary">Descriptive text</Text>
+          <Label color="secondary">Descriptive text</Label>
         </TrackerStep>
         <TrackerStep status="warning">
           <StepLabel>Warning</StepLabel>
-          <Text color="warning">Descriptive text</Text>
+          <Label color="warning">Descriptive text</Label>
         </TrackerStep>
         <TrackerStep status="error">
           <StepLabel>Error</StepLabel>
-          <Text color="error">Descriptive text</Text>
+          <Label color="error">Descriptive text</Label>
         </TrackerStep>
         <TrackerStep>
           <StepLabel>Default</StepLabel>
-          <Text color="secondary">Descriptive text</Text>
+          <Label color="secondary">Descriptive text</Label>
         </TrackerStep>
       </SteppedTracker>
     </div>
@@ -131,17 +131,17 @@ export const SingleVertical: StoryFn<typeof SteppedTracker> = () => {
     >
       <TrackerStep stage="completed">
         <StepLabel>Step One</StepLabel>
-        <Text color="secondary">
+        <Label color="secondary">
           A label that is very long describing the sub-steps and why they are
           there and stuff like that. Lorem ipsum dolor sit amet, consectetur.
-        </Text>
+        </Label>
       </TrackerStep>
       <TrackerStep stage="completed">
         <StepLabel>Step Two</StepLabel>
       </TrackerStep>
       <TrackerStep>
         <StepLabel>Step Three</StepLabel>
-        <Text color="secondary">This one has an extra label</Text>
+        <Label color="secondary">This one has an extra label</Label>
       </TrackerStep>
       <TrackerStep>
         <StepLabel>Step Four</StepLabel>
@@ -203,26 +203,26 @@ export const NestedVerticalComplex: StoryFn<typeof SteppedTracker> = () => {
     >
       <TrackerStep stage="completed">
         <StepLabel>Step 1</StepLabel>
-        <Text color="secondary">
+        <Label color="secondary">
           A label that is very long describing the sub-steps and why they are
           there and stuff like that. Lorem ipsum dolor sit amet, consectetur.
-        </Text>
+        </Label>
       </TrackerStep>
       <TrackerStep depth={1} stage="completed">
         <StepLabel>Step 1.1</StepLabel>
       </TrackerStep>
       <TrackerStep depth={2} stage="completed">
         <StepLabel>Step 1.1.1</StepLabel>
-        <Text color="secondary">This one has an extra label</Text>
+        <Label color="secondary">This one has an extra label</Label>
       </TrackerStep>
       <TrackerStep depth={2} stage="completed">
         <StepLabel>Step 1.1.2</StepLabel>
-        <Text color="secondary">
+        <Label color="secondary">
           A label that is very long describing the sub-steps and why they are
           there and stuff like that. Lorem ipsum dolor sit amet, consectetur. A
           label that is very long describing the sub-steps and why they are
           there and stuff like that. Lorem ipsum dolor sit amet, consectetur.
-        </Text>
+        </Label>
       </TrackerStep>
       <TrackerStep stage="completed">
         <StepLabel>Step 2</StepLabel>
@@ -255,7 +255,7 @@ export const NestedVerticalComplex: StoryFn<typeof SteppedTracker> = () => {
       </TrackerStep>
       <TrackerStep depth={1}>
         <StepLabel>Step 4.2</StepLabel>
-        <Text color="secondary">This one has an extra label</Text>
+        <Label color="secondary">This one has an extra label</Label>
       </TrackerStep>
       <TrackerStep depth={1}>
         <StepLabel>Step 4.3</StepLabel>

--- a/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
+++ b/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { Button, FlexLayout, StackLayout, Label, Tooltip } from "@salt-ds/core";
+import { Button, FlexLayout, Label, StackLayout, Tooltip } from "@salt-ds/core";
 import { RefreshIcon } from "@salt-ds/icons";
 import { StepLabel, SteppedTracker, TrackerStep } from "@salt-ds/lab";
 import type { Meta, StoryFn } from "@storybook/react";
@@ -127,7 +127,7 @@ export const SingleVertical: StoryFn<typeof SteppedTracker> = () => {
     <SteppedTracker
       orientation="vertical"
       activeStep={2}
-      style={{ width: 400 }}
+      style={{ width: "100%", maxWidth: 400 }}
     >
       <TrackerStep stage="completed">
         <StepLabel>Step One</StepLabel>
@@ -155,7 +155,7 @@ export const NestedVertical: StoryFn<typeof SteppedTracker> = () => {
     <SteppedTracker
       orientation="vertical"
       activeStep={8}
-      style={{ width: 400 }}
+      style={{ width: "100%", minWidth: 300, maxWidth: 400 }}
     >
       <TrackerStep stage="completed">
         <StepLabel>Step 1</StepLabel>
@@ -199,7 +199,7 @@ export const NestedVerticalComplex: StoryFn<typeof SteppedTracker> = () => {
     <SteppedTracker
       orientation="vertical"
       activeStep={8}
-      style={{ width: 400 }}
+      style={{ width: "100%", maxWidth: 400 }}
     >
       <TrackerStep stage="completed">
         <StepLabel>Step 1</StepLabel>

--- a/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
+++ b/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
@@ -187,8 +187,17 @@ export const NestedVertical: StoryFn<typeof SteppedTracker> = () => {
       <TrackerStep depth={1}>
         <StepLabel>Step 3.4</StepLabel>
       </TrackerStep>
+      <TrackerStep depth={1}>
+        <StepLabel>Step 3.4</StepLabel>
+      </TrackerStep>
       <TrackerStep>
         <StepLabel>Step 4</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={1}>
+        <StepLabel>Step 4.1</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={2}>
+        <StepLabel>Step 4.1.1</StepLabel>
       </TrackerStep>
     </SteppedTracker>
   );

--- a/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
+++ b/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
@@ -99,18 +99,23 @@ export const Status: StoryFn<typeof SteppedTracker> = () => {
       <SteppedTracker activeStep={1}>
         <TrackerStep stage="completed">
           <StepLabel>Completed</StepLabel>
+          <Text color="secondary">Descriptive text</Text>
         </TrackerStep>
         <TrackerStep>
           <StepLabel>Active</StepLabel>
+          <Text color="secondary">Descriptive text</Text>
         </TrackerStep>
         <TrackerStep status="warning">
           <StepLabel>Warning</StepLabel>
+          <Text color="warning">Descriptive text</Text>
         </TrackerStep>
         <TrackerStep status="error">
           <StepLabel>Error</StepLabel>
+          <Text color="error">Descriptive text</Text>
         </TrackerStep>
         <TrackerStep>
           <StepLabel>Default</StepLabel>
+          <Text color="secondary">Descriptive text</Text>
         </TrackerStep>
       </SteppedTracker>
     </div>

--- a/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
+++ b/packages/lab/stories/stepped-tracker/stepped-tracker.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { Button, FlexLayout, StackLayout, Tooltip } from "@salt-ds/core";
+import { Button, FlexLayout, StackLayout, Text, Tooltip } from "@salt-ds/core";
 import { RefreshIcon } from "@salt-ds/icons";
 import { StepLabel, SteppedTracker, TrackerStep } from "@salt-ds/lab";
 import type { Meta, StoryFn } from "@storybook/react";
@@ -119,18 +119,83 @@ export const Status: StoryFn<typeof SteppedTracker> = () => {
 
 export const SingleVertical: StoryFn<typeof SteppedTracker> = () => {
   return (
-    <SteppedTracker orientation="vertical" activeStep={1}>
+    <SteppedTracker
+      orientation="vertical"
+      activeStep={2}
+      style={{ width: 400 }}
+    >
       <TrackerStep stage="completed">
         <StepLabel>Step One</StepLabel>
+        <Text color="secondary">
+          A label that is very long describing the sub-steps and why they are
+          there and stuff like that. Lorem ipsum dolor sit amet, consectetur.
+        </Text>
       </TrackerStep>
       <TrackerStep stage="completed">
         <StepLabel>Step Two</StepLabel>
       </TrackerStep>
       <TrackerStep>
         <StepLabel>Step Three</StepLabel>
+        <Text color="secondary">This one has an extra label</Text>
       </TrackerStep>
       <TrackerStep>
         <StepLabel>Step Four</StepLabel>
+      </TrackerStep>
+    </SteppedTracker>
+  );
+};
+
+export const NestedVertical: StoryFn<typeof SteppedTracker> = () => {
+  return (
+    <SteppedTracker
+      orientation="vertical"
+      activeStep={8}
+      style={{ width: 400 }}
+    >
+      <TrackerStep state="completed">
+        <StepLabel>Step 1</StepLabel>
+        <Text color="secondary">
+          A label that is very long describing the sub-steps and why they are
+          there and stuff like that. Lorem ipsum dolor sit amet, consectetur.
+        </Text>
+      </TrackerStep>
+      <TrackerStep depth={1} state="completed">
+        <StepLabel>Step 1.1</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={2} state="completed">
+        <StepLabel>Step 1.1.1</StepLabel>
+        <Text color="secondary">This one has an extra label</Text>
+      </TrackerStep>
+      <TrackerStep depth={2} state="completed">
+        <StepLabel>Step 1.1.2</StepLabel>
+      </TrackerStep>
+      <TrackerStep state="completed">
+        <StepLabel>Step 2</StepLabel>
+      </TrackerStep>
+      <TrackerStep state="inprogress">
+        <StepLabel>Step 3</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={1} state="inprogress">
+        <StepLabel>Step 3.1</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={2} state="completed">
+        <StepLabel>Step 3.1.1</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={2}>
+        <StepLabel>Step 3.1.2</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={2}>
+        <StepLabel>Step 3.1.3</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={1}>
+        <StepLabel>Step 3.2</StepLabel>
+        <Text color="secondary">This one has an extra label</Text>
+      </TrackerStep>
+      <TrackerStep depth={1}>
+        <StepLabel>Step 3.3</StepLabel>
+      </TrackerStep>
+      <TrackerStep state="default">
+        <StepLabel>Step 4</StepLabel>
       </TrackerStep>
     </SteppedTracker>
   );

--- a/site/docs/components/stepped-tracker/examples.mdx
+++ b/site/docs/components/stepped-tracker/examples.mdx
@@ -46,6 +46,22 @@ Use a vertical stepped tracker when horizontal space is limited in the context o
 
   </LivePreview>
   
+  <LivePreview componentName="stepped-tracker" exampleName="NestedVertical" >
+
+## Nested Vertical
+
+Vertically orientated stepped trackers can be nested. Nesting is achieved by use of the `depth` prop on the `TrackerStep` component. Up to 2 levels of nesting are supported.
+
+When a step has nested children, the step icon will show an "in progress" icon when some of the children are completed, and a "completed" icon when all children are completed.
+
+Nesting is only supported in vertical orientation.
+
+### Best practices
+
+While sub-steps support the use of descriptive text and long labels, it's recommended to keep the labels short and concise to preserve the visual calarity of nested steps.
+
+  </LivePreview>
+  
   <LivePreview componentName="stepped-tracker" exampleName="StepProgression" >
 
 ## Step progression

--- a/site/src/examples/stepped-tracker/Basic.tsx
+++ b/site/src/examples/stepped-tracker/Basic.tsx
@@ -52,7 +52,7 @@ export const Basic = (): ReactElement => {
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>
-      <SteppedTracker activeStep={2}>
+      <SteppedTracker activeStep={1}>
         <TrackerStep stage="completed">
           <StepLabel>Completed</StepLabel>
         </TrackerStep>

--- a/site/src/examples/stepped-tracker/Basic.tsx
+++ b/site/src/examples/stepped-tracker/Basic.tsx
@@ -10,7 +10,10 @@ export const Basic = (): ReactElement => {
       gap={10}
       style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
     >
-      <SteppedTracker activeStep={0}>
+      <SteppedTracker
+        activeStep={0}
+        aria-label="Stepped Tracker example: first step active"
+      >
         <TrackerStep>
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
@@ -24,7 +27,10 @@ export const Basic = (): ReactElement => {
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>
-      <SteppedTracker activeStep={2}>
+      <SteppedTracker
+        activeStep={2}
+        aria-label="Stepped Tracker example: third step active"
+      >
         <TrackerStep stage="completed">
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
@@ -38,7 +44,10 @@ export const Basic = (): ReactElement => {
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>
-      <SteppedTracker activeStep={3}>
+      <SteppedTracker
+        activeStep={3}
+        aria-label="Stepped Tracker example: all steps complete"
+      >
         <TrackerStep stage="completed">
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
@@ -52,7 +61,10 @@ export const Basic = (): ReactElement => {
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>
-      <SteppedTracker activeStep={1}>
+      <SteppedTracker
+        activeStep={1}
+        aria-label="Stepped Tracker example: status display options"
+      >
         <TrackerStep stage="completed">
           <StepLabel>Completed</StepLabel>
         </TrackerStep>

--- a/site/src/examples/stepped-tracker/NestedVertical.tsx
+++ b/site/src/examples/stepped-tracker/NestedVertical.tsx
@@ -1,0 +1,52 @@
+import { StepLabel, SteppedTracker, TrackerStep } from "@salt-ds/lab";
+import type { ReactElement } from "react";
+
+export const NestedVertical = (): ReactElement => {
+  return (
+    <SteppedTracker
+      orientation="vertical"
+      activeStep={10}
+      style={{ width: "100%", minWidth: 300, maxWidth: 400 }}
+    >
+      <TrackerStep stage="completed">
+        <StepLabel>Step 1</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={1} stage="completed">
+        <StepLabel>Step 1.1</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={1} stage="completed">
+        <StepLabel>Step 1.2</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={2} stage="completed">
+        <StepLabel>Step 1.2.1</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={2} stage="completed">
+        <StepLabel>Step 1.2.2</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={1} stage="completed">
+        <StepLabel>Step 1.3</StepLabel>
+      </TrackerStep>
+      <TrackerStep stage="completed">
+        <StepLabel>Step 2</StepLabel>
+      </TrackerStep>
+      <TrackerStep stage="inprogress">
+        <StepLabel>Step 3</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={1} stage="completed">
+        <StepLabel>Step 3.1</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={1} stage="completed">
+        <StepLabel>Step 3.2</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={1} stage="inprogress">
+        <StepLabel>Step 3.3</StepLabel>
+      </TrackerStep>
+      <TrackerStep depth={1}>
+        <StepLabel>Step 3.4</StepLabel>
+      </TrackerStep>
+      <TrackerStep>
+        <StepLabel>Step 4</StepLabel>
+      </TrackerStep>
+    </SteppedTracker>
+  );
+};

--- a/site/src/examples/stepped-tracker/NestedVertical.tsx
+++ b/site/src/examples/stepped-tracker/NestedVertical.tsx
@@ -7,6 +7,7 @@ export const NestedVertical = (): ReactElement => {
       orientation="vertical"
       activeStep={10}
       style={{ width: "100%", minWidth: 300, maxWidth: 400 }}
+      aria-label="Stepped Tracker example: vertical nesting"
     >
       <TrackerStep stage="completed">
         <StepLabel>Step 1</StepLabel>

--- a/site/src/examples/stepped-tracker/NonSequentialProgress.tsx
+++ b/site/src/examples/stepped-tracker/NonSequentialProgress.tsx
@@ -60,7 +60,10 @@ export const NonSequentialProgress = (): ReactElement => {
       align="stretch"
       style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
     >
-      <SteppedTracker activeStep={activeStep}>
+      <SteppedTracker
+        activeStep={activeStep}
+        aria-label="Stepped Tracker example: non sequential progress"
+      >
         {steps.map(({ label, stage }, key) => (
           <TrackerStep stage={stage} key={key}>
             <StepLabel>{label}</StepLabel>

--- a/site/src/examples/stepped-tracker/StageAndStatus.tsx
+++ b/site/src/examples/stepped-tracker/StageAndStatus.tsx
@@ -10,7 +10,10 @@ export const StageAndStatus = (): ReactElement => {
       gap={10}
       style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
     >
-      <SteppedTracker activeStep={1}>
+      <SteppedTracker
+        activeStep={1}
+        aria-label="Stepped Tracker example: stage and status in action"
+      >
         <TrackerStep stage="completed">
           <StepLabel>Completed</StepLabel>
         </TrackerStep>

--- a/site/src/examples/stepped-tracker/StepProgression.tsx
+++ b/site/src/examples/stepped-tracker/StepProgression.tsx
@@ -62,7 +62,10 @@ export const StepProgression = (): ReactElement => {
       align="stretch"
       style={{ width: "100%", minWidth: 600, maxWidth: 800, margin: "auto" }}
     >
-      <SteppedTracker activeStep={activeStep}>
+      <SteppedTracker
+        activeStep={activeStep}
+        aria-label="Stepped Tracker example: step progression"
+      >
         {steps.map(({ label, stage }, key) => (
           <TrackerStep stage={stage} key={key}>
             <StepLabel>{label}</StepLabel>

--- a/site/src/examples/stepped-tracker/Vertical.tsx
+++ b/site/src/examples/stepped-tracker/Vertical.tsx
@@ -9,7 +9,11 @@ export const Vertical = (): ReactElement => {
       gap={8}
       style={{ height: "100%", maxWidth: 800, margin: "auto" }}
     >
-      <SteppedTracker activeStep={0} orientation="vertical">
+      <SteppedTracker
+        activeStep={0}
+        orientation="vertical"
+        aria-label="Stepped Tracker example: vertical, first step active"
+      >
         <TrackerStep>
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
@@ -23,7 +27,11 @@ export const Vertical = (): ReactElement => {
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>
-      <SteppedTracker activeStep={2} orientation="vertical">
+      <SteppedTracker
+        activeStep={2}
+        orientation="vertical"
+        aria-label="Stepped Tracker example: vertical, third step active"
+      >
         <TrackerStep stage="completed">
           <StepLabel>Step One</StepLabel>
         </TrackerStep>
@@ -37,7 +45,11 @@ export const Vertical = (): ReactElement => {
           <StepLabel>Step Four</StepLabel>
         </TrackerStep>
       </SteppedTracker>
-      <SteppedTracker activeStep={3} orientation="vertical">
+      <SteppedTracker
+        activeStep={3}
+        orientation="vertical"
+        aria-label="Stepped Tracker example: vertical, all steps complete"
+      >
         <TrackerStep stage="completed">
           <StepLabel>Step One</StepLabel>
         </TrackerStep>

--- a/site/src/examples/stepped-tracker/index.ts
+++ b/site/src/examples/stepped-tracker/index.ts
@@ -1,5 +1,6 @@
 export * from "./Basic";
 export * from "./StageAndStatus";
 export * from "./Vertical";
+export * from "./NestedVertical";
 export * from "./StepProgression";
 export * from "./NonSequentialProgress";


### PR DESCRIPTION
Closes https://github.com/jpmorganchase/salt-ds/issues/1869
Adds support for nesting steps in a vertical SteppedTracker.

Nesting is achieved via the `depth` prop on the `TrackerStep` component. When a step has nested children, the step icon will show an "in progress" icon when some of the children are completed, and a "completed" icon when all children are completed.

<img width="389" alt="Screenshot 2024-08-16 at 11 36 34" src="https://github.com/user-attachments/assets/cfd18c00-96db-4b73-9c0e-d1762e060184">

<img width="457" alt="Screenshot 2024-08-16 at 11 36 22" src="https://github.com/user-attachments/assets/8b285775-cf66-4ecf-bd13-635d2d9c6d17">


