### PR TITLE
Various ag grid theme fixes

### DIFF
--- a/.changeset/large-carrots-end.md
+++ b/.changeset/large-carrots-end.md
@@ -7,6 +7,7 @@
 - Fixed Country Symbol taller than expected in HD compact. This alters `--salt-size-base` token so Salt Button, form controls (Input, Dropdown, Combo Box) will be impacted as well. Closes #3775.
 - Fixed group value not center aligned vertically.
 - Updated ag grid menu styling to match closer to Salt Menu component.
+- Updated floating filter column chooser item styles. Closes #3671.
 
 Note: We previously made a mistake on `rowHeight` recommendation when configurating AG Grid, which should be 1px more to account for border between row.
 `useAgGridHelpers` example hook is updated to reflect this.

--- a/.changeset/large-carrots-end.md
+++ b/.changeset/large-carrots-end.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/ag-grid-theme": patch
+---
+
+Fixed a few bugs (details to follow)

--- a/.changeset/large-carrots-end.md
+++ b/.changeset/large-carrots-end.md
@@ -2,4 +2,19 @@
 "@salt-ds/ag-grid-theme": patch
 ---
 
-Fixed a few bugs (details to follow)
+- Fixed background color for custom editor component.
+- Fixed header text being cropped in HD compact. Closes #3675.
+- Fixed Country Symbol taller than expected in HD compact. This alters `--salt-size-base` token so Salt Button, form controls (Input, Dropdown, Combo Box) will be impacted as well. Closes #3775.
+- Fixed group value not center aligned vertically.
+- Updated ag grid menu styling to match closer to Salt Menu component.
+
+Note: We previously made a mistake on `rowHeight` recommendation when configurating AG Grid, which should be 1px more to account for border between row.
+`useAgGridHelpers` example hook is updated to reflect this.
+
+| Density      | Row height ([`rowHeight`](https://www.ag-grid.com/javascript-data-grid/row-height/)) | Header height ([`headerHeight`](https://www.ag-grid.com/javascript-data-grid/column-headers/#header-height)) |
+| ------------ | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| HD (Compact) | 21                                                                                   | 20                                                                                                           |
+| HD           | 25                                                                                   | 24                                                                                                           |
+| MD           | 37                                                                                   | 36                                                                                                           |
+| LD           | 49                                                                                   | 48                                                                                                           |
+| TD           | 61                                                                                   | 60                                                                                                           |

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "prettier:ci": "prettier --check .",
     "lint": "biome check",
     "lint:fix": "biome check --fix",
+    "lint:check:error": "biome check --diagnostic-level=error",
     "lint:style": "yarn lint:style:core && yarn lint:style:icon && yarn lint:style:lab && yarn lint:style:ag-theme",
     "lint:style:core": "yarn stylelint -f verbose \"packages/core/src/**/*.css\"",
     "lint:style:icon": "yarn stylelint -f verbose \"packages/icons/src/**/*.css\"",

--- a/packages/ag-grid-theme/css/salt-ag-grid-theme.css
+++ b/packages/ag-grid-theme/css/salt-ag-grid-theme.css
@@ -61,11 +61,11 @@ div[class*="ag-theme-salt"] {
 }
 
 div[class*="ag-theme-salt-compact"] {
-  /* Ensures icon / country symbol renders correct height  */
+  /* 
+    Ensures icon / country symbol renders correct height.
+    This also means we don't need to touch `--ag-row-height`, which would impact some internal ag grid height calculation like `--ag-internal-padded-row-height` vs `--ag-internal-calculated-line-height`
+   */
   --salt-size-base: 16px;
-
-  /* --ag-row-height: var(--salt-size-base); */
-  /* --ag-header-height: var(--salt-size-base); */
 }
 
 div[class*="ag-theme-salt"] .ag-root-wrapper {
@@ -166,8 +166,12 @@ div[class*="ag-theme-salt"] .ag-cell-label-container {
 /* MENU */
 
 div[class*="ag-theme-salt"] .ag-menu {
-  padding: var(--salt-spacing-100);
+  padding: 0;
   border: var(--salt-size-border) var(--salt-container-borderStyle) var(--salt-selectable-borderColor-selected);
+}
+
+div[class*="ag-theme-salt"] .ag-tabs {
+  padding: var(--salt-spacing-100);
 }
 
 div[class*="ag-theme-salt"] .ag-popup-child:not(.ag-tooltip-custom) {
@@ -195,8 +199,9 @@ div[class*="ag-theme-salt"] .ag-menu-option {
   height: calc(var(--salt-size-base) + var(--salt-spacing-100));
 }
 
-div[class*="ag-theme-salt"] .ag-menu-option-icon {
-  padding: 0 var(--salt-spacing-100);
+div[class*="ag-theme-salt"] .ag-menu-option-icon,
+div[class*="ag-theme-salt"] .ag-compact-menu-option-icon {
+  padding-inline-start: var(--salt-spacing-100);
 }
 
 div[class*="ag-theme-salt"] .ag-tab {
@@ -242,6 +247,11 @@ div[class*="ag-theme-salt"] .ag-cell {
   line-height: calc(var(--ag-line-height) - 1px);
   padding-left: var(--salt-spacing-100);
   padding-right: var(--salt-spacing-100);
+}
+
+/* This is not restricted to `.editable-cell`, so any custom editor would get the same background treatment */
+div[class*="ag-theme-salt"] .ag-cell-inline-editing:focus-within {
+  background: var(--salt-container-primary-background);
 }
 
 div[class*="ag-theme-salt"] .editable-cell,
@@ -296,10 +306,6 @@ div[class*="ag-theme-salt"] .editable-cell.ag-cell-inline-editing:before {
 
 div[class*="ag-theme-salt"] .editable-cell.ag-cell-inline-editing {
   padding: 0;
-}
-
-div[class*="ag-theme-salt"] .editable-cell.ag-cell-inline-editing:focus-within {
-  background: var(--salt-container-primary-background);
 }
 
 div[class*="ag-theme-salt"] .editable-numeric-cell input,

--- a/packages/ag-grid-theme/css/salt-ag-grid-theme.css
+++ b/packages/ag-grid-theme/css/salt-ag-grid-theme.css
@@ -254,6 +254,10 @@ div[class*="ag-theme-salt"] .ag-cell-inline-editing:focus-within {
   background: var(--salt-container-primary-background);
 }
 
+div[class*="ag-theme-salt"] .ag-cell-inline-editing {
+  padding: 0;
+}
+
 div[class*="ag-theme-salt"] .editable-cell,
 div[class*="ag-theme-salt"] .editable-numeric-cell {
   outline: var(--salt-size-border) var(--salt-container-borderStyle) var(--salt-editable-borderColor);
@@ -302,10 +306,6 @@ div[class*="ag-theme-salt"] .editable-cell.ag-cell-inline-editing:before {
   position: absolute;
   top: 0px;
   z-index: 2;
-}
-
-div[class*="ag-theme-salt"] .editable-cell.ag-cell-inline-editing {
-  padding: 0;
 }
 
 div[class*="ag-theme-salt"] .editable-numeric-cell input,

--- a/packages/ag-grid-theme/css/salt-ag-grid-theme.css
+++ b/packages/ag-grid-theme/css/salt-ag-grid-theme.css
@@ -254,6 +254,7 @@ div[class*="ag-theme-salt"] .ag-cell-inline-editing:focus-within {
   background: var(--salt-container-primary-background);
 }
 
+/* This makes sure custom cell editor would start from no padding. Built-in ag grid editor's padding is added below. */
 div[class*="ag-theme-salt"] .ag-cell-inline-editing {
   padding: 0;
 }

--- a/packages/ag-grid-theme/css/salt-ag-grid-theme.css
+++ b/packages/ag-grid-theme/css/salt-ag-grid-theme.css
@@ -61,8 +61,11 @@ div[class*="ag-theme-salt"] {
 }
 
 div[class*="ag-theme-salt-compact"] {
-  --ag-row-height: var(--salt-size-base);
-  --ag-header-height: var(--salt-size-base);
+  /* Ensures icon / country symbol renders correct height  */
+  --salt-size-base: 16px;
+
+  /* --ag-row-height: var(--salt-size-base); */
+  /* --ag-header-height: var(--salt-size-base); */
 }
 
 div[class*="ag-theme-salt"] .ag-root-wrapper {
@@ -153,6 +156,11 @@ div[class*="ag-theme-salt"] .ag-header-cell.ag-column-menu-visible {
 
 div[class*="ag-theme-salt"] .ag-header-cell.ag-column-menu-visible .ag-icon {
   color: var(--salt-actionable-secondary-foreground-active);
+}
+
+div[class*="ag-theme-salt"] .ag-cell-label-container {
+  /* row height is base size + 50 spacing on top/bottom */
+  padding: var(--salt-spacing-50) 0;
 }
 
 /* MENU */

--- a/packages/ag-grid-theme/css/salt-ag-grid-theme.css
+++ b/packages/ag-grid-theme/css/salt-ag-grid-theme.css
@@ -165,6 +165,17 @@ div[class*="ag-theme-salt"] .ag-cell-label-container {
   padding: var(--salt-spacing-50) 0;
 }
 
+div[class*="ag-theme-salt"] .ag-list-item:hover,
+div[class*="ag-theme-salt"] .ag-virtual-list-item:hover {
+  background-color: var(--salt-selectable-background-hover);
+  cursor: pointer;
+}
+
+div[class*="ag-theme-salt"] .ag-label-align-right .ag-label {
+  margin-inline-start: var(--salt-spacing-100);
+  margin-inline-end: 0;
+}
+
 /* MENU */
 
 div[class*="ag-theme-salt"] .ag-menu {

--- a/packages/ag-grid-theme/css/salt-ag-grid-theme.css
+++ b/packages/ag-grid-theme/css/salt-ag-grid-theme.css
@@ -66,6 +66,8 @@ div[class*="ag-theme-salt-compact"] {
     This also means we don't need to touch `--ag-row-height`, which would impact some internal ag grid height calculation like `--ag-internal-padded-row-height` vs `--ag-internal-calculated-line-height`
    */
   --salt-size-base: 16px;
+  /* This is a deprecated token, until Salt Checkbox uses a new token, temparily pin it to HD size. */
+  --salt-size-selectable: 12px;
 }
 
 div[class*="ag-theme-salt"] .ag-root-wrapper {

--- a/packages/ag-grid-theme/src/dependencies/cell-editors/DropdownEditor.tsx
+++ b/packages/ag-grid-theme/src/dependencies/cell-editors/DropdownEditor.tsx
@@ -1,3 +1,5 @@
+import { Dropdown, type DropdownProps, Option } from "@salt-ds/core";
+import type { ICellEditorParams } from "ag-grid-community";
 import React, {
   forwardRef,
   useImperativeHandle,
@@ -7,8 +9,6 @@ import React, {
   type SyntheticEvent,
   type KeyboardEvent,
 } from "react";
-import type { ICellEditorParams } from "ag-grid-community";
-import { Dropdown, type DropdownProps, Option } from "@salt-ds/core";
 
 export type GridCellValue = string | boolean | number;
 
@@ -52,8 +52,6 @@ export const DropdownEditor = forwardRef((props: DropdownEditorParams, ref) => {
 
   useImperativeHandle(ref, () => ({ getValue: (): typeof value => value }));
 
-  console.log("--- DropdownEditor", { value });
-
   return (
     <Dropdown
       onSelectionChange={onSelect}
@@ -61,7 +59,15 @@ export const DropdownEditor = forwardRef((props: DropdownEditorParams, ref) => {
       selected={[value || ""]}
       ref={button}
       onKeyDown={onEscapeKeyPressed}
+      className="DropdownEditor"
       {...dropdownProps}
+      style={{
+        // Outline will be shown on the cell
+        outline: "none",
+        // Leave room for cell focus ring
+        marginInline: "2px",
+        width: "calc(100% - 4px)",
+      }}
     >
       <div
         ref={(elem): void => {

--- a/packages/ag-grid-theme/src/dependencies/cell-editors/DropdownEditor.tsx
+++ b/packages/ag-grid-theme/src/dependencies/cell-editors/DropdownEditor.tsx
@@ -1,0 +1,81 @@
+import React, {
+  forwardRef,
+  useImperativeHandle,
+  useState,
+  useEffect,
+  useCallback,
+  type SyntheticEvent,
+  type KeyboardEvent,
+} from "react";
+import type { ICellEditorParams } from "ag-grid-community";
+import { Dropdown, type DropdownProps, Option } from "@salt-ds/core";
+
+export type GridCellValue = string | boolean | number;
+
+export interface DropdownEditorParams extends ICellEditorParams {
+  source?: Array<GridCellValue>;
+  dropdownProps?: Partial<DropdownProps<string>>;
+}
+
+export const DropdownEditor = forwardRef((props: DropdownEditorParams, ref) => {
+  const { value: initialValue, source = [], dropdownProps } = props;
+  const [value, setValue] = useState(initialValue);
+
+  const button = React.useRef<HTMLButtonElement>(null);
+
+  const onSelect = useCallback(
+    (_event: SyntheticEvent, selectedValue: Array<GridCellValue>) => {
+      setValue(selectedValue[0]);
+
+      // hack to make selection actually record the edit.
+      // timeout is necessary because otherwise the grid stops editing
+      // before the useImperativeHandle getValue returns the new value state
+      setTimeout(() => {
+        props.api!.stopEditing();
+      }, 100);
+    },
+    [props.api],
+  );
+
+  const onEscapeKeyPressed = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        props.api!.stopEditing();
+      }
+    },
+    [props.api],
+  );
+
+  useEffect(() => {
+    button.current!.focus();
+  }, []);
+
+  useImperativeHandle(ref, () => ({ getValue: (): typeof value => value }));
+
+  console.log("--- DropdownEditor", { value });
+
+  return (
+    <Dropdown
+      onSelectionChange={onSelect}
+      defaultOpen={props.cellStartedEdit}
+      selected={[value || ""]}
+      ref={button}
+      onKeyDown={onEscapeKeyPressed}
+      {...dropdownProps}
+    >
+      <div
+        ref={(elem): void => {
+          if (!elem) return;
+          // current element -> list container -> list box that matters
+          (
+            (elem.parentElement as HTMLElement).parentElement as HTMLElement
+          ).className += " ag-custom-component-popup";
+        }}
+      >
+        {source.map((item) => (
+          <Option value={item} key={String(item)} />
+        ))}
+      </div>
+    </Dropdown>
+  );
+});

--- a/packages/ag-grid-theme/src/dependencies/cell-editors/DropdownEditor.tsx
+++ b/packages/ag-grid-theme/src/dependencies/cell-editors/DropdownEditor.tsx
@@ -1,13 +1,14 @@
 import { Dropdown, type DropdownProps, Option } from "@salt-ds/core";
 import type { ICellEditorParams } from "ag-grid-community";
-import React, {
-  forwardRef,
-  useImperativeHandle,
-  useState,
-  useEffect,
-  useCallback,
-  type SyntheticEvent,
+import {
   type KeyboardEvent,
+  type SyntheticEvent,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
 } from "react";
 
 export type GridCellValue = string | boolean | number;
@@ -21,7 +22,7 @@ export const DropdownEditor = forwardRef((props: DropdownEditorParams, ref) => {
   const { value: initialValue, source = [], dropdownProps } = props;
   const [value, setValue] = useState(initialValue);
 
-  const button = React.useRef<HTMLButtonElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   const onSelect = useCallback(
     (_event: SyntheticEvent, selectedValue: Array<GridCellValue>) => {
@@ -31,7 +32,7 @@ export const DropdownEditor = forwardRef((props: DropdownEditorParams, ref) => {
       // timeout is necessary because otherwise the grid stops editing
       // before the useImperativeHandle getValue returns the new value state
       setTimeout(() => {
-        props.api!.stopEditing();
+        props.api?.stopEditing();
       }, 100);
     },
     [props.api],
@@ -40,14 +41,14 @@ export const DropdownEditor = forwardRef((props: DropdownEditorParams, ref) => {
   const onEscapeKeyPressed = useCallback(
     (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        props.api!.stopEditing();
+        props.api?.stopEditing();
       }
     },
     [props.api],
   );
 
   useEffect(() => {
-    button.current!.focus();
+    buttonRef.current?.focus();
   }, []);
 
   useImperativeHandle(ref, () => ({ getValue: (): typeof value => value }));
@@ -57,7 +58,7 @@ export const DropdownEditor = forwardRef((props: DropdownEditorParams, ref) => {
       onSelectionChange={onSelect}
       defaultOpen={props.cellStartedEdit}
       selected={[value || ""]}
-      ref={button}
+      ref={buttonRef}
       onKeyDown={onEscapeKeyPressed}
       className="DropdownEditor"
       {...dropdownProps}
@@ -75,7 +76,7 @@ export const DropdownEditor = forwardRef((props: DropdownEditorParams, ref) => {
           // current element -> list container -> list box that matters
           (
             (elem.parentElement as HTMLElement).parentElement as HTMLElement
-          ).className += " ag-custom-component-popup";
+          ).className += " ag-custom-component-popup"; // https://www.ag-grid.com/react-data-grid/component-filter/#custom-filters-containing-a-popup-element
         }}
       >
         {source.map((item) => (

--- a/packages/ag-grid-theme/src/dependencies/cell-renderers/FlagRenderer.tsx
+++ b/packages/ag-grid-theme/src/dependencies/cell-renderers/FlagRenderer.tsx
@@ -1,0 +1,23 @@
+import type { CustomCellRendererProps } from "ag-grid-react";
+import { countryMetaMap } from "@salt-ds/countries";
+
+export const FlagRenderer = (props: CustomCellRendererProps) => {
+  const isoCode = props.value as keyof typeof countryMetaMap;
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexFlow: "row",
+        justifyContent: "center",
+        width: "100%",
+        height: "100%",
+        alignItems: "center",
+      }}
+    >
+      <span
+        className={`saltCountrySharp-${isoCode}`}
+        aria-label={countryMetaMap[isoCode]?.countryName}
+      />
+    </div>
+  );
+};

--- a/packages/ag-grid-theme/src/dependencies/cell-renderers/FlagRenderer.tsx
+++ b/packages/ag-grid-theme/src/dependencies/cell-renderers/FlagRenderer.tsx
@@ -1,5 +1,5 @@
-import type { CustomCellRendererProps } from "ag-grid-react";
 import { countryMetaMap } from "@salt-ds/countries";
+import type { CustomCellRendererProps } from "ag-grid-react";
 
 export const FlagRenderer = (props: CustomCellRendererProps) => {
   const isoCode = props.value as keyof typeof countryMetaMap;

--- a/packages/ag-grid-theme/src/dependencies/dataGridExampleColumnsHdCompact.ts
+++ b/packages/ag-grid-theme/src/dependencies/dataGridExampleColumnsHdCompact.ts
@@ -1,0 +1,65 @@
+import type { ColDef } from "ag-grid-community";
+import { FlagRenderer } from "./cell-renderers/FlagRenderer";
+import { DropdownEditor } from "./cell-editors/DropdownEditor";
+
+const dataGridExampleColumnsHdCompact: ColDef[] = [
+  {
+    headerName: "",
+    field: "on",
+    width: 70,
+    flex: 1,
+    checkboxSelection: true,
+    headerCheckboxSelection: true,
+    pinned: "left",
+    suppressHeaderMenuButton: true,
+    resizable: false,
+    suppressColumnsToolPanel: true,
+  },
+  {
+    headerName: "Name",
+    field: "name",
+    filterParams: {
+      buttons: ["reset", "apply"],
+    },
+    editable: false,
+  },
+  {
+    headerName: "Code",
+    field: "code",
+  },
+  {
+    headerName: "Capital",
+    field: "capital",
+    filter: "agSetColumnFilter",
+  },
+  {
+    headerName: "Population",
+    type: "numericColumn",
+    field: "population",
+    filter: "agNumberColumnFilter",
+    editable: true,
+    cellClass: ["editable-cell"],
+  },
+  {
+    headerName: "Date",
+    field: "date",
+    filter: "agDateColumnFilter",
+  },
+  {
+    headerName: "Rating",
+    field: "rating",
+    editable: true,
+    cellEditor: DropdownEditor,
+    cellEditorParams: {
+      source: [10, 20, 30, 40, 50, 60],
+    },
+    cellClass: ["editable-cell"],
+  },
+  {
+    headerName: "Flag",
+    field: "country",
+    cellRenderer: FlagRenderer,
+    initialWidth: 80,
+  },
+];
+export default dataGridExampleColumnsHdCompact;

--- a/packages/ag-grid-theme/src/dependencies/dataGridExampleColumnsHdCompact.ts
+++ b/packages/ag-grid-theme/src/dependencies/dataGridExampleColumnsHdCompact.ts
@@ -1,6 +1,6 @@
 import type { ColDef } from "ag-grid-community";
-import { FlagRenderer } from "./cell-renderers/FlagRenderer";
 import { DropdownEditor } from "./cell-editors/DropdownEditor";
+import { FlagRenderer } from "./cell-renderers/FlagRenderer";
 
 const dataGridExampleColumnsHdCompact: ColDef[] = [
   {
@@ -50,7 +50,7 @@ const dataGridExampleColumnsHdCompact: ColDef[] = [
     field: "rating",
     // Not using `editable-cell` as it doesn't work with Dropdown focus style
     editable: true,
-    cellEditor: DropdownEditor,
+    cellEditor: "DropdownEditor",
     cellEditorParams: {
       source: [10, 20, 30, 40, 50, 60],
     },

--- a/packages/ag-grid-theme/src/dependencies/dataGridExampleColumnsHdCompact.ts
+++ b/packages/ag-grid-theme/src/dependencies/dataGridExampleColumnsHdCompact.ts
@@ -48,12 +48,12 @@ const dataGridExampleColumnsHdCompact: ColDef[] = [
   {
     headerName: "Rating",
     field: "rating",
+    // Not using `editable-cell` as it doesn't work with Dropdown focus style
     editable: true,
     cellEditor: DropdownEditor,
     cellEditorParams: {
       source: [10, 20, 30, 40, 50, 60],
     },
-    cellClass: ["editable-cell"],
   },
   {
     headerName: "Flag",

--- a/packages/ag-grid-theme/src/dependencies/dataGridExampleData.ts
+++ b/packages/ag-grid-theme/src/dependencies/dataGridExampleData.ts
@@ -6,6 +6,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 8446790,
     date: "29/07/2004",
+    country: 'US'
   },
   {
     name: "Alaska",
@@ -14,6 +15,7 @@ const dataGridExampleData = [
     rating: 20,
     population: 5492139,
     date: "20/05/2009",
+    country: 'US'
   },
   {
     name: "Arizona",
@@ -22,6 +24,7 @@ const dataGridExampleData = [
     rating: 30,
     population: 806007,
     date: "23/02/2020",
+    country: 'US'
   },
   {
     name: "Arkansas",
@@ -30,6 +33,7 @@ const dataGridExampleData = [
     rating: 40,
     population: 59453,
     date: "19/02/1999",
+    country: 'US'
   },
   {
     name: "California",
@@ -38,6 +42,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 8319396,
     date: "29/04/1967",
+    country: 'US'
   },
   {
     name: "Colorado",
@@ -46,6 +51,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 8822592,
     date: "19/02/1944",
+    country: 'US'
   },
   {
     name: "Connecticut",
@@ -54,6 +60,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 2465263,
     date: "30/03/2015",
+    country: 'US'
   },
   {
     name: "Delaware",
@@ -62,6 +69,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 3075357,
     date: "04/03/1949",
+    country: 'US'
   },
   {
     name: "Florida",
@@ -70,6 +78,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 7597316,
     date: "03/10/2005",
+    country: 'US'
   },
   {
     name: "Georgia",
@@ -78,6 +87,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 7271180,
     date: "16/02/1998",
+    country: 'US'
   },
   {
     name: "Hawaii",
@@ -86,6 +96,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 8534120,
     date: "17/02/2005",
+    country: 'US'
   },
   {
     name: "Idaho",
@@ -94,6 +105,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 5806269,
     date: "19/02/2007",
+    country: 'US'
   },
   {
     name: "Illinois",
@@ -102,6 +114,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 525951,
     date: "08/11/2022",
+    country: 'US'
   },
   {
     name: "Indiana",
@@ -110,6 +123,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 5220228,
     date: "19/02/1920",
+    country: 'US'
   },
   {
     name: "Iowa",
@@ -118,6 +132,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 333600,
     date: "31/05/2020",
+    country: 'US'
   },
   {
     name: "Kansas",
@@ -126,6 +141,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 170082,
     date: "28/02/1999",
+    country: 'US'
   },
   {
     name: "Kentucky",
@@ -134,6 +150,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 1359657,
     date: "19/02/1920",
+    country: 'US'
   },
   {
     name: "Louisiana",
@@ -142,6 +159,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 9267793,
     date: "17/02/1970",
+    country: 'US'
   },
   {
     name: "Maine",
@@ -150,6 +168,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 7366792,
     date: "13/02/2000",
+    country: 'US'
   },
   {
     name: "Maryland",
@@ -158,6 +177,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 2474500,
     date: "18/11/1902",
+    country: 'US'
   },
   {
     name: "Massachusetts",
@@ -166,6 +186,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 7858200,
     date: "19/02/1902",
+    country: 'US'
   },
   {
     name: "Michigan",
@@ -174,6 +195,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 4036589,
     date: "19/02/2002",
+    country: 'US'
   },
   {
     name: "Minnesota",
@@ -182,6 +204,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 490080,
     date: "19/02/1920",
+    country: 'US'
   },
   {
     name: "Mississippi",
@@ -190,6 +213,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 2021576,
     date: "19/02/1920",
+    country: 'US'
   },
   {
     name: "Missouri",
@@ -198,6 +222,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 3511147,
     date: "19/02/1920",
+    country: 'US'
   },
   {
     name: "Montana",
@@ -206,6 +231,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 2856628,
     date: "19/05/0520",
+    country: 'US'
   },
   {
     name: "Nebraska",
@@ -214,6 +240,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 9584904,
     date: "05/02/0520",
+    country: 'US'
   },
   {
     name: "Nevada",
@@ -222,6 +249,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 489695,
     date: "05/02/2002",
+    country: 'US'
   },
   {
     name: "New Hampshire",
@@ -230,6 +258,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 8819049,
     date: "19/02/2002",
+    country: 'US'
   },
   {
     name: "New Jersey",
@@ -238,6 +267,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 2500770,
     date: "19/02/2002",
+    country: 'US'
   },
   {
     name: "New Mexico",
@@ -246,6 +276,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 536205,
     date: "19/02/2002",
+    country: 'US'
   },
   {
     name: "New York",
@@ -254,6 +285,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 5248173,
     date: "19/02/1920",
+    country: 'US'
   },
   {
     name: "North Carolina",
@@ -262,6 +294,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 1452619,
     date: "10/02/1020",
+    country: 'US'
   },
   {
     name: "North Dakota",
@@ -270,6 +303,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 8890392,
     date: "19/02/1920",
+    country: 'US'
   },
   {
     name: "Ohio",
@@ -278,6 +312,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 5968829,
     date: "19/02/1920",
+    country: 'US'
   },
   {
     name: "Oklahoma",
@@ -286,6 +321,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 9044655,
     date: "21/02/1950",
+    country: 'US'
   },
   {
     name: "Oregon",
@@ -294,6 +330,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 8054969,
     date: "12/10/1920",
+    country: 'US'
   },
   {
     name: "Pennsylvania",
@@ -302,6 +339,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 1359410,
     date: "19/02/1920",
+    country: 'US'
   },
   {
     name: "Rhode Island",
@@ -310,6 +348,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 4473590,
     date: "19/02/1920",
+    country: 'US'
   },
   {
     name: "South Carolina",
@@ -318,6 +357,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 6527907,
     date: "19/02/1920",
+    country: 'US'
   },
   {
     name: "South Dakota",
@@ -326,6 +366,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 3152416,
     date: "19/02/1920",
+    country: 'US'
   },
   {
     name: "Tennessee",
@@ -334,6 +375,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 9717114,
     date: "19/02/1920",
+    country: 'US'
   },
   {
     name: "Texas",
@@ -342,6 +384,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 6552290,
     date: "19/02/1920",
+    country: 'US'
   },
   {
     name: "Utah",
@@ -350,6 +393,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 2815416,
     date: "19/02/1920",
+    country: 'US'
   },
   {
     name: "Vermont",
@@ -358,6 +402,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 2845360,
     date: "19/02/1920",
+    country: 'US'
   },
   {
     name: "Virginia",
@@ -366,6 +411,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 4919143,
     date: "20/02/1920",
+    country: 'US'
   },
   {
     name: "Washington",
@@ -374,6 +420,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 4614717,
     date: "22/02/2009",
+    country: 'US'
   },
   {
     name: "West Virginia",
@@ -382,6 +429,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 6413104,
     date: "19/11/2002",
+    country: 'US'
   },
   {
     name: "Wisconsin",
@@ -390,6 +438,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 3934168,
     date: "01/08/2005",
+    country: 'US'
   },
   {
     name: "Wyoming",
@@ -398,6 +447,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 901078,
     date: "01/01/2000",
+    country: 'US'
   },
 ];
 

--- a/packages/ag-grid-theme/src/dependencies/dataGridExampleData.ts
+++ b/packages/ag-grid-theme/src/dependencies/dataGridExampleData.ts
@@ -6,7 +6,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 8446790,
     date: "29/07/2004",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Alaska",
@@ -15,7 +15,7 @@ const dataGridExampleData = [
     rating: 20,
     population: 5492139,
     date: "20/05/2009",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Arizona",
@@ -24,7 +24,7 @@ const dataGridExampleData = [
     rating: 30,
     population: 806007,
     date: "23/02/2020",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Arkansas",
@@ -33,7 +33,7 @@ const dataGridExampleData = [
     rating: 40,
     population: 59453,
     date: "19/02/1999",
-    country: 'US'
+    country: "US",
   },
   {
     name: "California",
@@ -42,7 +42,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 8319396,
     date: "29/04/1967",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Colorado",
@@ -51,7 +51,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 8822592,
     date: "19/02/1944",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Connecticut",
@@ -60,7 +60,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 2465263,
     date: "30/03/2015",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Delaware",
@@ -69,7 +69,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 3075357,
     date: "04/03/1949",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Florida",
@@ -78,7 +78,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 7597316,
     date: "03/10/2005",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Georgia",
@@ -87,7 +87,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 7271180,
     date: "16/02/1998",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Hawaii",
@@ -96,7 +96,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 8534120,
     date: "17/02/2005",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Idaho",
@@ -105,7 +105,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 5806269,
     date: "19/02/2007",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Illinois",
@@ -114,7 +114,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 525951,
     date: "08/11/2022",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Indiana",
@@ -123,7 +123,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 5220228,
     date: "19/02/1920",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Iowa",
@@ -132,7 +132,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 333600,
     date: "31/05/2020",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Kansas",
@@ -141,7 +141,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 170082,
     date: "28/02/1999",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Kentucky",
@@ -150,7 +150,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 1359657,
     date: "19/02/1920",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Louisiana",
@@ -159,7 +159,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 9267793,
     date: "17/02/1970",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Maine",
@@ -168,7 +168,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 7366792,
     date: "13/02/2000",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Maryland",
@@ -177,7 +177,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 2474500,
     date: "18/11/1902",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Massachusetts",
@@ -186,7 +186,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 7858200,
     date: "19/02/1902",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Michigan",
@@ -195,7 +195,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 4036589,
     date: "19/02/2002",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Minnesota",
@@ -204,7 +204,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 490080,
     date: "19/02/1920",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Mississippi",
@@ -213,7 +213,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 2021576,
     date: "19/02/1920",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Missouri",
@@ -222,7 +222,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 3511147,
     date: "19/02/1920",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Montana",
@@ -231,7 +231,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 2856628,
     date: "19/05/0520",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Nebraska",
@@ -240,7 +240,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 9584904,
     date: "05/02/0520",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Nevada",
@@ -249,7 +249,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 489695,
     date: "05/02/2002",
-    country: 'US'
+    country: "US",
   },
   {
     name: "New Hampshire",
@@ -258,7 +258,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 8819049,
     date: "19/02/2002",
-    country: 'US'
+    country: "US",
   },
   {
     name: "New Jersey",
@@ -267,7 +267,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 2500770,
     date: "19/02/2002",
-    country: 'US'
+    country: "US",
   },
   {
     name: "New Mexico",
@@ -276,7 +276,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 536205,
     date: "19/02/2002",
-    country: 'US'
+    country: "US",
   },
   {
     name: "New York",
@@ -285,7 +285,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 5248173,
     date: "19/02/1920",
-    country: 'US'
+    country: "US",
   },
   {
     name: "North Carolina",
@@ -294,7 +294,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 1452619,
     date: "10/02/1020",
-    country: 'US'
+    country: "US",
   },
   {
     name: "North Dakota",
@@ -303,7 +303,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 8890392,
     date: "19/02/1920",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Ohio",
@@ -312,7 +312,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 5968829,
     date: "19/02/1920",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Oklahoma",
@@ -321,7 +321,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 9044655,
     date: "21/02/1950",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Oregon",
@@ -330,7 +330,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 8054969,
     date: "12/10/1920",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Pennsylvania",
@@ -339,7 +339,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 1359410,
     date: "19/02/1920",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Rhode Island",
@@ -348,7 +348,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 4473590,
     date: "19/02/1920",
-    country: 'US'
+    country: "US",
   },
   {
     name: "South Carolina",
@@ -357,7 +357,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 6527907,
     date: "19/02/1920",
-    country: 'US'
+    country: "US",
   },
   {
     name: "South Dakota",
@@ -366,7 +366,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 3152416,
     date: "19/02/1920",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Tennessee",
@@ -375,7 +375,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 9717114,
     date: "19/02/1920",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Texas",
@@ -384,7 +384,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 6552290,
     date: "19/02/1920",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Utah",
@@ -393,7 +393,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 2815416,
     date: "19/02/1920",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Vermont",
@@ -402,7 +402,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 2845360,
     date: "19/02/1920",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Virginia",
@@ -411,7 +411,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 4919143,
     date: "20/02/1920",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Washington",
@@ -420,7 +420,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 4614717,
     date: "22/02/2009",
-    country: 'US'
+    country: "US",
   },
   {
     name: "West Virginia",
@@ -429,7 +429,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 6413104,
     date: "19/11/2002",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Wisconsin",
@@ -438,7 +438,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 3934168,
     date: "01/08/2005",
-    country: 'US'
+    country: "US",
   },
   {
     name: "Wyoming",
@@ -447,7 +447,7 @@ const dataGridExampleData = [
     rating: 10,
     population: 901078,
     date: "01/01/2000",
-    country: 'US'
+    country: "US",
   },
 ];
 

--- a/packages/ag-grid-theme/src/dependencies/useAgGridHelpers.ts
+++ b/packages/ag-grid-theme/src/dependencies/useAgGridHelpers.ts
@@ -45,20 +45,20 @@ export function useAgGridHelpers({
   const mode = modeProp ?? contextMode;
   const density = densityProp ?? contextDensity;
 
-  const [rowHeight, listItemHeight] = useMemo(() => {
+  const [rowHeight, headerRowHeight] = useMemo(() => {
     switch (density) {
       case compact && "high":
-        return [20, 20];
+        return [21, 20];
       case "high":
-        return [24, 24]; // 20 + 4
+        return [25, 24]; // 20 + 4 + [1 (border)]
       case "medium":
-        return [36, 36]; // 28 + 8
+        return [37, 36]; // 28 + 8 + [1 (border)]
       case "low":
-        return [48, 48]; // 36 + 12
+        return [49, 48]; // 36 + 12 + [1 (border)]
       case "touch":
-        return [60, 60]; // 44 + 16
+        return [61, 60]; // 44 + 16 + [1 (border)]
       default:
-        return [24, 24];
+        return [25, 24];
     }
   }, [density, compact]);
 
@@ -81,14 +81,14 @@ export function useAgGridHelpers({
     agGridProps: {
       onGridReady,
       rowHeight,
-      headerHeight: rowHeight,
+      headerHeight: headerRowHeight,
       suppressMenuHide: true,
       defaultColDef: {
         filter: true,
         resizable: true,
         sortable: true,
         filterParams: {
-          cellHeight: listItemHeight,
+          cellHeight: rowHeight,
         },
       },
     },

--- a/packages/ag-grid-theme/src/examples/HDCompact.tsx
+++ b/packages/ag-grid-theme/src/examples/HDCompact.tsx
@@ -1,5 +1,6 @@
 import { SaltProvider, SaltProviderNext, useTheme } from "@salt-ds/core";
 import { AgGridReact, type AgGridReactProps } from "ag-grid-react";
+import { DropdownEditor } from "../dependencies/cell-editors/DropdownEditor";
 import dataGridExampleColumnsHdCompact from "../dependencies/dataGridExampleColumnsHdCompact";
 import dataGridExampleData from "../dependencies/dataGridExampleData";
 import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
@@ -42,6 +43,9 @@ const HDCompact = (props: AgGridReactProps) => {
                 node.setSelected(true);
               }
             });
+          }}
+          components={{
+            DropdownEditor,
           }}
         />
       </div>

--- a/packages/ag-grid-theme/src/examples/HDCompact.tsx
+++ b/packages/ag-grid-theme/src/examples/HDCompact.tsx
@@ -1,6 +1,6 @@
 import { SaltProvider, SaltProviderNext, useTheme } from "@salt-ds/core";
 import { AgGridReact, type AgGridReactProps } from "ag-grid-react";
-import dataGridExampleColumns from "../dependencies/dataGridExampleColumns";
+import dataGridExampleColumnsHdCompact from "../dependencies/dataGridExampleColumnsHdCompact";
 import dataGridExampleData from "../dependencies/dataGridExampleData";
 import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 
@@ -29,7 +29,7 @@ const HDCompact = (props: AgGridReactProps) => {
     <Provider density="high">
       <div {...containerProps}>
         <AgGridReact
-          columnDefs={dataGridExampleColumns}
+          columnDefs={dataGridExampleColumnsHdCompact}
           rowData={dataGridExampleData}
           statusBar={statusBar}
           rowSelection="multiple"

--- a/packages/ag-grid-theme/stories/ag-grid-theme.stories.tsx
+++ b/packages/ag-grid-theme/stories/ag-grid-theme.stories.tsx
@@ -3,6 +3,8 @@ import { AgGridReact } from "ag-grid-react";
 import "ag-grid-community/styles/ag-grid.css";
 import "../salt-ag-theme.css";
 
+import "@salt-ds/countries/saltSharpCountries.css";
+
 export default {
   title: "Ag Grid/Ag Grid Theme",
   component: AgGridReact,

--- a/packages/core/src/list-control/ListControlState.ts
+++ b/packages/core/src/list-control/ListControlState.ts
@@ -54,7 +54,7 @@ export type ListControlProps<Item> = {
 };
 
 export function defaultValueToString<Item>(item: Item): string {
-  return typeof item === "string" ? item : "";
+  return String(item);
 }
 
 export function useListControl<Item>(props: ListControlProps<Item>) {

--- a/site/src/examples/ag-grid-theme/Default.tsx
+++ b/site/src/examples/ag-grid-theme/Default.tsx
@@ -35,15 +35,15 @@ export const Default = (): ReactElement => {
   const rowHeight = useMemo(() => {
     switch (density) {
       case "high":
-        return 24;
+        return 25;
       case "medium":
-        return 36;
+        return 37;
       case "low":
-        return 48;
+        return 49;
       case "touch":
-        return 60;
+        return 61;
       default:
-        return 20;
+        return 25;
     }
   }, [density]);
 

--- a/site/src/examples/ag-grid-theme/useAgGridHelpers.ts
+++ b/site/src/examples/ag-grid-theme/useAgGridHelpers.ts
@@ -23,20 +23,21 @@ export function useAgGridHelpers(compact = false): {
   const density = useDensity();
   const { mode } = useTheme();
 
-  const [rowHeight, listItemHeight] = useMemo(() => {
+  // Row height is 1px more than header row, to count for border between rows
+  const [rowHeight, headerRowHeight] = useMemo(() => {
     switch (density) {
       case compact && "high":
-        return [20, 20];
+        return [21, 20];
       case "high":
-        return [24, 24];
+        return [25, 24];
       case "medium":
-        return [36, 36];
+        return [37, 36];
       case "low":
-        return [48, 48];
+        return [49, 48];
       case "touch":
-        return [60, 60];
+        return [61, 60];
       default:
-        return [20, 24];
+        return [25, 24];
     }
   }, [density, compact]);
 
@@ -58,14 +59,14 @@ export function useAgGridHelpers(compact = false): {
     agGridProps: {
       onGridReady,
       rowHeight,
-      headerHeight: rowHeight,
+      headerHeight: headerRowHeight,
       suppressMenuHide: true,
       defaultColDef: {
         filter: true,
         resizable: true,
         sortable: true,
         filterParams: {
-          cellHeight: listItemHeight,
+          cellHeight: rowHeight,
         },
       },
     },


### PR DESCRIPTION
- [x] Adds custom dropdown editor example
- [x] Adds custom flag renderer example
- [x] Ag Menu padding to match Salt menu (0 padding) 
- [x] Group cell line height mismatch
- [x] Custom cell editor background color when focused (should be black in dark, instead of blue)
- [x] Double focus ring for a custom dropdown editor
- Changed base size implementation in HD Compact


#3775, #3675

Design related task to support HD compact in Figma Next: https://github.com/jpmorganchase/salt-ds/issues/3850