### PR TITLE
Typescript clean up

### DIFF
--- a/.changeset/moody-rocks-smile.md
+++ b/.changeset/moody-rocks-smile.md
@@ -1,0 +1,7 @@
+---
+"@salt-ds/data-grid": patch
+"@salt-ds/core": patch
+"@salt-ds/lab": patch
+---
+
+Cleaned up TypeScript types in multiple components.

--- a/docs/components/QAContainer.tsx
+++ b/docs/components/QAContainer.tsx
@@ -56,7 +56,7 @@ const DensityValues = ["high", "medium", "low", "touch"] as const;
 const DensityBlock = ({
   mode,
   children,
-}: DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> & {
+}: DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> & {
   mode: Mode;
 }) => {
   const { themeNext } = useTheme();

--- a/packages/core/src/__tests__/__e2e__/text/Text.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/text/Text.cy.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import { VALIDATION_NAMED_STATUS } from "../../../status-indicator";
 import {
   Display1,
@@ -333,7 +334,7 @@ describe("GIVEN Text component with styleAs=display3", () => {
 describe("GIVEN Text component within font family CSS var override", () => {
   it("should have non-default font family applied", () => {
     cy.mount(
-      <div style={{ "--salt-text-fontFamily": "Lato" } as React.CSSProperties}>
+      <div style={{ "--salt-text-fontFamily": "Lato" } as CSSProperties}>
         <Text>{textExample}</Text>
       </div>,
     );

--- a/packages/core/src/dialog/DialogContent.tsx
+++ b/packages/core/src/dialog/DialogContent.tsx
@@ -4,6 +4,7 @@ import { clsx } from "clsx";
 import {
   type HTMLAttributes,
   type ReactNode,
+  type UIEvent,
   forwardRef,
   useState,
 } from "react";
@@ -25,7 +26,7 @@ export const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>(
     const { children, className, ...rest } = props;
     const [scrollTop, setScrollTop] = useState(0);
 
-    const handleScroll = (event: React.UIEvent<HTMLElement>) => {
+    const handleScroll = (event: UIEvent<HTMLElement>) => {
       setScrollTop(event.currentTarget.scrollTop);
     };
 

--- a/packages/core/src/overlay/OverlayContext.ts
+++ b/packages/core/src/overlay/OverlayContext.ts
@@ -4,7 +4,7 @@ import type {
   ReferenceType,
   Strategy,
 } from "@floating-ui/react";
-import { useContext } from "react";
+import { type HTMLProps, useContext } from "react";
 import { createContext, type useFloatingUI } from "../utils";
 
 type FloatingReturn = ReturnType<typeof useFloatingUI>;
@@ -24,10 +24,10 @@ export interface OverlayContextValue {
   reference?: (node: ReferenceType | null) => void;
   floating?: (node: HTMLElement | null) => void;
   getFloatingProps: (
-    userProps?: React.HTMLProps<HTMLElement> | undefined,
+    userProps?: HTMLProps<HTMLElement> | undefined,
   ) => Record<string, unknown>;
   getReferenceProps: (
-    userProps?: React.HTMLProps<Element> | undefined,
+    userProps?: HTMLProps<Element> | undefined,
   ) => Record<string, unknown>;
 }
 

--- a/packages/core/src/salt-provider/SaltProvider.tsx
+++ b/packages/core/src/salt-provider/SaltProvider.tsx
@@ -4,13 +4,15 @@ import {
 } from "@salt-ds/styles";
 import { type WindowContextType, useWindow } from "@salt-ds/window";
 import { clsx } from "clsx";
-import React, {
-  createContext,
-  useContext,
-  useMemo,
+import {
   type HTMLAttributes,
   type ReactElement,
   type ReactNode,
+  cloneElement,
+  createContext,
+  isValidElement,
+  useContext,
+  useMemo,
 } from "react";
 import { AriaAnnouncerProvider } from "../aria-announcer";
 import {
@@ -132,8 +134,8 @@ const createThemedChildren = ({
     return children;
   }
   if (applyClassesTo === "child") {
-    if (React.isValidElement<HTMLAttributes<HTMLElement>>(children)) {
-      return React.cloneElement(children, {
+    if (isValidElement<HTMLAttributes<HTMLElement>>(children)) {
+      return cloneElement(children, {
         className: clsx(
           children.props?.className,
           themeNamesString,

--- a/packages/core/src/utils/renderProps.tsx
+++ b/packages/core/src/utils/renderProps.tsx
@@ -1,4 +1,5 @@
 import {
+  type ComponentProps,
   type ElementType,
   type ReactElement,
   cloneElement,
@@ -12,16 +13,16 @@ export interface RenderPropsType {
 
 export function renderProps<Type extends ElementType>(
   Type: Type,
-  props: RenderPropsType & React.ComponentProps<Type>,
+  props: RenderPropsType & ComponentProps<Type>,
 ): ReactElement {
   const { render, ...rest } = props;
   // Case 1: If render is a valid React element, clone it with merged props
   if (isValidElement(render)) {
-    const renderProps = render.props as React.ComponentProps<Type>;
+    const renderProps = render.props as ComponentProps<Type>;
     return cloneElement(render, mergeProps(rest, renderProps));
   }
 
-  const restProps = rest as React.ComponentProps<Type>;
+  const restProps = rest as ComponentProps<Type>;
 
   // Case 2: If render is a function, call it with the rest of the props
   if (typeof render === "function") {

--- a/packages/core/stories/floating-platform/custom-floating-ui-platform.stories.tsx
+++ b/packages/core/stories/floating-platform/custom-floating-ui-platform.stories.tsx
@@ -1,8 +1,9 @@
 import { offset, platform } from "@floating-ui/dom";
 import type { Platform } from "@floating-ui/react";
 import type { Meta, StoryFn } from "@storybook/react";
-import type React from "react";
 import {
+  type CSSProperties,
+  type ChangeEvent,
   type ComponentPropsWithoutRef,
   type Ref,
   forwardRef,
@@ -48,7 +49,7 @@ type RootComponentProps = FloatingComponentProps &
 
 type NewWindowTestProps = Pick<TooltipProps, "placement" | "content">;
 
-const offscreenStyles: React.CSSProperties = {
+const offscreenStyles: CSSProperties = {
   top: -9999,
   left: -9999,
   position: "fixed",
@@ -158,7 +159,7 @@ const NewWindowTest = (props: NewWindowTestProps) => {
 
   const [value, setValue] = useState("");
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setValue(event.target.value);
   };
 

--- a/packages/core/stories/form-field/form-field.stories.tsx
+++ b/packages/core/stories/form-field/form-field.stories.tsx
@@ -914,7 +914,7 @@ export const MultiColumnLayoutEmptySlot: StoryFn<typeof FormField> = (
 ) => {
   return (
     <StackLayout
-      style={{ "--saltFormField-label-width": "100px" } as React.CSSProperties}
+      style={{ "--saltFormField-label-width": "100px" } as CSSProperties}
     >
       <FormField {...props}>
         <FormLabel>Form Field label left</FormLabel>

--- a/packages/core/stories/overlay/overlay.stories.tsx
+++ b/packages/core/stories/overlay/overlay.stories.tsx
@@ -14,7 +14,7 @@ import {
   useId,
 } from "@salt-ds/core";
 import type { Meta, StoryFn } from "@storybook/react";
-import React, { type ChangeEvent, useState } from "react";
+import { type ChangeEvent, useState } from "react";
 
 import "./overlay.stories.css";
 
@@ -156,11 +156,11 @@ const WithActionsContent = ({
   onClose: () => void;
   id: string | undefined;
 }) => {
-  const [controlledValues, setControlledValues] = React.useState([
+  const [controlledValues, setControlledValues] = useState([
     checkboxesData[0].value,
   ]);
 
-  const [checkboxState, setCheckboxState] = React.useState({
+  const [checkboxState, setCheckboxState] = useState({
     checked: false,
     indeterminate: true,
   });
@@ -231,7 +231,7 @@ const WithActionsContent = ({
 };
 
 export const WithActions = ({ onOpenChange }: OverlayProps) => {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
   const id = useId();
 
   const onChange = (newOpen: boolean) => {

--- a/packages/data-grid/src/ColumnSortContext.ts
+++ b/packages/data-grid/src/ColumnSortContext.ts
@@ -1,11 +1,11 @@
-import type React from "react";
+import type { SetStateAction } from "react";
 import { createContext, useContext } from "react";
 import type { SortOrder } from "./Grid";
 import type { GridColumnProps } from "./GridColumn";
 
 export interface ColumnSortContext {
   sortByColumnId?: GridColumnProps["id"];
-  setSortByColumnId: (c: React.SetStateAction<GridColumnProps["id"]>) => void;
+  setSortByColumnId: (c: SetStateAction<GridColumnProps["id"]>) => void;
   sortOrder: SortOrder;
   setSortOrder: (o: SortOrder) => void;
   onClickSortColumn: (colHeaderId: GridColumnProps["id"]) => void;

--- a/packages/data-grid/src/SizingContext.ts
+++ b/packages/data-grid/src/SizingContext.ts
@@ -1,10 +1,10 @@
-import type React from "react";
+import type { MouseEvent } from "react";
 import { createContext, useContext } from "react";
 
 export interface SizingContext {
   rowHeight: number;
   resizeColumn: (colIdx: number, width: number) => void;
-  onResizeHandleMouseDown: (event: React.MouseEvent<HTMLDivElement>) => void;
+  onResizeHandleMouseDown: (event: MouseEvent<HTMLDivElement>) => void;
 }
 
 export const SizingContext = createContext<SizingContext | undefined>(

--- a/packages/data-grid/src/internal/gridHooks.tsx
+++ b/packages/data-grid/src/internal/gridHooks.tsx
@@ -1,9 +1,9 @@
 import { useControlled } from "@salt-ds/core";
-import type React from "react";
 import {
   Children,
   type FocusEventHandler,
   type MouseEventHandler,
+  type MouseEvent as ReactMouseEvent,
   type ReactNode,
   type RefObject,
   isValidElement,
@@ -460,7 +460,7 @@ export function useColumnResize<T>(
   }, []);
 
   return useCallback(
-    (event: React.MouseEvent<HTMLDivElement>) => {
+    (event: ReactMouseEvent<HTMLDivElement>) => {
       const targetElement = event.target as HTMLElement;
       const [columnIndexAttribute, thElement] = getAttribute(
         targetElement,
@@ -849,7 +849,7 @@ export function useRowSelection<T>(
   }, [setSelRowIdxs]);
 
   const onMouseDown = useCallback(
-    (event: React.MouseEvent<HTMLDivElement>) => {
+    (event: ReactMouseEvent<HTMLDivElement>) => {
       if (rowSelectionMode === "none") {
         return;
       }
@@ -1188,7 +1188,7 @@ export function useRangeSelection(cellSelectionMode?: GridCellSelectionMode) {
   }, []);
 
   const onCellMouseDown = useCallback(
-    (event: React.MouseEvent) => {
+    (event: ReactMouseEvent) => {
       if (cellSelectionMode !== "range") {
         return;
       }

--- a/packages/lab/src/breadcrumbs/Breadcrumb.tsx
+++ b/packages/lab/src/breadcrumbs/Breadcrumb.tsx
@@ -3,6 +3,7 @@ import type { IconProps } from "@salt-ds/icons";
 import { clsx } from "clsx";
 import {
   Children,
+  type ComponentType,
   type HTMLAttributes,
   type ReactNode,
   forwardRef,
@@ -28,7 +29,7 @@ export interface BreadcrumbProps {
   minWidth?: number;
   onItemClick?: (item: any, event: any) => void; // TODO
   overflowLabel?: string;
-  Icon?: React.ComponentType<IconProps>;
+  Icon?: ComponentType<IconProps>;
 }
 
 export const Breadcrumb = forwardRef<HTMLLIElement, BreadcrumbProps>(

--- a/packages/lab/src/breadcrumbs/Breadcrumbs.tsx
+++ b/packages/lab/src/breadcrumbs/Breadcrumbs.tsx
@@ -1,10 +1,13 @@
 import { makePrefixer } from "@salt-ds/core";
 import type { IconProps } from "@salt-ds/icons";
 import { clsx } from "clsx";
-import React, {
+import {
+  Children,
   type HTMLAttributes,
-  isValidElement,
   type ReactNode,
+  cloneElement,
+  forwardRef,
+  isValidElement,
   useMemo,
 } from "react";
 import type { BreadcrumbProps } from "./Breadcrumb";
@@ -60,7 +63,7 @@ export interface BreadcrumbsProps extends HTMLAttributes<HTMLElement> {
   children?: ReactNode;
 }
 
-export const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
+export const Breadcrumbs = forwardRef<HTMLElement, BreadcrumbsProps>(
   function Breadcrumbs(props, ref) {
     const {
       children,
@@ -102,7 +105,7 @@ export const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
       <BreadcrumbsSeparator {...SeparatorProps} />
     );
 
-    const childrenArray = React.Children.toArray(children);
+    const childrenArray = Children.toArray(children);
     const shouldRenderAllItems =
       wrap || maxItems == null || childrenArray.length <= maxItems;
 
@@ -111,7 +114,7 @@ export const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
       .map((child, index) => {
         const isLastChild = index === childrenArray.length - 1;
 
-        return React.cloneElement(child, {
+        return cloneElement(child, {
           isCurrentLevel: isLastChild,
         } as BreadcrumbProps);
       });

--- a/packages/lab/src/color-chooser/AlphaInputField.tsx
+++ b/packages/lab/src/color-chooser/AlphaInputField.tsx
@@ -1,6 +1,12 @@
 import { makePrefixer } from "@salt-ds/core";
 import { clsx } from "clsx";
-import { type ChangeEvent, useEffect, useState } from "react";
+import {
+  type ChangeEvent,
+  type FocusEvent,
+  type KeyboardEvent,
+  useEffect,
+  useState,
+} from "react";
 import { InputLegacy as Input } from "../input-legacy";
 
 import { useComponentCssInjection } from "@salt-ds/styles";
@@ -58,9 +64,7 @@ export const AlphaInput = ({
     setAlphaInputValue(alpha);
   };
 
-  const handleKeyDownAlpha = (
-    e: React.KeyboardEvent<HTMLInputElement>,
-  ): void => {
+  const handleKeyDownAlpha = (e: KeyboardEvent<HTMLInputElement>): void => {
     if (e.key === "Enter") {
       const alpha =
         alphaInputValue.trim().replace("%", "") !== ""
@@ -72,7 +76,7 @@ export const AlphaInput = ({
     }
   };
 
-  const handleOnBlurAlpha = (e: React.FocusEvent<HTMLInputElement>): void => {
+  const handleOnBlurAlpha = (e: FocusEvent<HTMLInputElement>): void => {
     // Guard against parseFloat('') becoming NaN
     const alpha =
       alphaInputValue.trim() !== "" ? Number.parseFloat(alphaInputValue) : 0;

--- a/packages/lab/src/color-chooser/HexInput.tsx
+++ b/packages/lab/src/color-chooser/HexInput.tsx
@@ -1,5 +1,6 @@
 import { makePrefixer } from "@salt-ds/core";
 import { clsx } from "clsx";
+import type { ChangeEvent, FocusEvent, KeyboardEvent } from "react";
 import { useEffect, useState } from "react";
 import { InputLegacy as Input } from "../input-legacy";
 import { isValidHex } from "./ColorHelpers";
@@ -14,7 +15,7 @@ const withBaseName = makePrefixer("saltColorChooserHexInput");
 interface HexInputProps {
   hexValue: string | undefined;
   disableAlphaChooser: boolean;
-  onSubmit: (hex: string | undefined, e?: React.ChangeEvent) => void;
+  onSubmit: (hex: string | undefined, e?: ChangeEvent) => void;
 }
 
 export const HexInput = ({
@@ -38,7 +39,7 @@ export const HexInput = ({
   }, [hexValue]);
 
   const handleHexInputChange = (
-    event: React.ChangeEvent<HTMLInputElement>,
+    event: ChangeEvent<HTMLInputElement>,
     value: string,
   ): void => {
     if (disableAlphaChooser && value.length < 7) {
@@ -49,13 +50,13 @@ export const HexInput = ({
     }
   };
 
-  const handleKeyDownHex = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+  const handleKeyDownHex = (e: KeyboardEvent<HTMLInputElement>): void => {
     if (e.key === "Enter") {
       isValidHex(hexInputValue) && onSubmit(hexInputValue);
     }
   };
 
-  const handleOnBlurHex = (e: React.FocusEvent<HTMLInputElement>): void => {
+  const handleOnBlurHex = (e: FocusEvent<HTMLInputElement>): void => {
     isValidHex(hexInputValue) && onSubmit(hexInputValue, e);
   };
 

--- a/packages/lab/src/color-chooser/HexInputField.tsx
+++ b/packages/lab/src/color-chooser/HexInputField.tsx
@@ -1,6 +1,12 @@
 import { useComponentCssInjection } from "@salt-ds/styles";
 import { useWindow } from "@salt-ds/window";
-import { useEffect, useState } from "react";
+import {
+  type ChangeEvent,
+  type FocusEvent,
+  type KeyboardEvent,
+  useEffect,
+  useState,
+} from "react";
 import { InputLegacy as Input } from "../input-legacy";
 import { isValidHex } from "./ColorHelpers";
 
@@ -9,7 +15,7 @@ import colorPickerCss from "./ColorPicker.css";
 interface HexInputProps {
   hexValue: string | undefined;
   disableAlphaChooser: boolean;
-  onSubmit: (hex: string | undefined, e?: React.ChangeEvent) => void;
+  onSubmit: (hex: string | undefined, e?: ChangeEvent) => void;
 }
 
 export const HexInput = ({
@@ -33,7 +39,7 @@ export const HexInput = ({
   }, [hexValue]);
 
   const handleHexInputChange = (
-    event: React.ChangeEvent<HTMLInputElement>,
+    event: ChangeEvent<HTMLInputElement>,
     value: string,
   ): void => {
     if (disableAlphaChooser && value.length < 7) {
@@ -44,13 +50,13 @@ export const HexInput = ({
     }
   };
 
-  const handleKeyDownHex = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+  const handleKeyDownHex = (e: KeyboardEvent<HTMLInputElement>): void => {
     if (e.key === "Enter") {
       isValidHex(hexInputValue) && onSubmit(hexInputValue);
     }
   };
 
-  const handleOnBlurHex = (e: React.FocusEvent<HTMLInputElement>): void => {
+  const handleOnBlurHex = (e: FocusEvent<HTMLInputElement>): void => {
     isValidHex(hexInputValue) && onSubmit(hexInputValue, e);
   };
 

--- a/packages/lab/src/color-chooser/RGBAInputField.tsx
+++ b/packages/lab/src/color-chooser/RGBAInputField.tsx
@@ -1,5 +1,11 @@
 import { makePrefixer } from "@salt-ds/core";
-import { useEffect, useState } from "react";
+import {
+  type ChangeEvent,
+  type FocusEvent,
+  type KeyboardEvent,
+  useEffect,
+  useState,
+} from "react";
 import { InputLegacy as Input } from "../input-legacy";
 import type { RGBAValue } from "./Color";
 
@@ -11,7 +17,7 @@ const withBaseName = makePrefixer("saltColorChooser");
 interface RGBInputProps {
   rgbaValue: RGBAValue;
   value: "r" | "g" | "b";
-  onSubmit: (rgb: RGBAValue, e?: React.ChangeEvent) => void;
+  onSubmit: (rgb: RGBAValue, e?: ChangeEvent) => void;
 }
 
 export const RGBInput = ({
@@ -35,7 +41,7 @@ export const RGBInput = ({
   }, [rgbaValue, value]);
 
   const handleRGBInputChange = (
-    e: React.ChangeEvent<HTMLInputElement>,
+    e: ChangeEvent<HTMLInputElement>,
     value: string,
   ): void => {
     let rgb: string | number;
@@ -49,7 +55,7 @@ export const RGBInput = ({
     setRgbaInputValue(rgb);
   };
 
-  const handleKeyDownRGB = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+  const handleKeyDownRGB = (e: KeyboardEvent<HTMLInputElement>): void => {
     if (e.key === "Enter") {
       const newRgb = { ...rgbaValue, [value]: e.currentTarget.value };
       const validatedRgb = {
@@ -63,7 +69,7 @@ export const RGBInput = ({
     }
   };
 
-  const handleOnBlurRGB = (e: React.FocusEvent<HTMLInputElement>): void => {
+  const handleOnBlurRGB = (e: FocusEvent<HTMLInputElement>): void => {
     const newRgb = { ...rgbaValue, [value]: e.target.value };
     const validatedRgb = {
       r: Math.max(0, Math.min(newRgb.r, 255)),

--- a/packages/lab/src/color-chooser/Swatches.tsx
+++ b/packages/lab/src/color-chooser/Swatches.tsx
@@ -1,5 +1,6 @@
 import { makePrefixer } from "@salt-ds/core";
 import { clsx } from "clsx";
+import type { ChangeEvent } from "react";
 import { AlphaInput } from "./AlphaInputField";
 import type { Color } from "./Color";
 import { SwatchesPicker } from "./SwatchesPicker";
@@ -18,7 +19,7 @@ export interface SwatchesTabProps {
   handleColorChange: (
     color: Color | undefined,
     finalSelection: boolean,
-    e?: React.ChangeEvent,
+    e?: ChangeEvent,
   ) => void;
   displayColorName: string | undefined;
   placeholder: string | undefined;
@@ -61,7 +62,7 @@ export const Swatches = ({
           <AlphaInput
             alphaValue={color?.rgba.a === 0 ? 0 : alpha}
             showAsOpacity={true}
-            onSubmit={(alpha: number, e?: React.ChangeEvent): void => {
+            onSubmit={(alpha: number, e?: ChangeEvent): void => {
               const newColor = color?.setAlpha(alpha);
               handleColorChange(newColor, false, e);
             }}

--- a/packages/lab/src/color-chooser/SwatchesPicker.tsx
+++ b/packages/lab/src/color-chooser/SwatchesPicker.tsx
@@ -1,3 +1,4 @@
+import type { ChangeEvent } from "react";
 import type { Color } from "./Color";
 import { convertColorMapValueToHex } from "./ColorHelpers";
 import { Swatch } from "./Swatch";
@@ -15,7 +16,7 @@ interface SwatchesPickerProps {
   onChange: (
     color: Color | undefined,
     finalSelection: boolean,
-    e?: React.ChangeEvent,
+    e?: ChangeEvent,
   ) => void;
   onDialogClosed: () => void;
 }
@@ -27,7 +28,7 @@ interface SwatchesGroupProps {
   onClick: (
     color: Color | undefined,
     finalSelection: boolean,
-    e?: React.ChangeEvent,
+    e?: ChangeEvent,
   ) => void;
   onDialogClosed: () => void;
 }

--- a/packages/lab/src/common-hooks/keyUtils.ts
+++ b/packages/lab/src/common-hooks/keyUtils.ts
@@ -1,4 +1,4 @@
-import type React from "react";
+import type { KeyboardEvent } from "react";
 
 function union<T>(set1: Set<T>, ...sets: Set<T>[]) {
   const result = new Set(set1);
@@ -55,13 +55,13 @@ const specialKeys = union(
   functionKeys,
   focusKeys,
 );
-export const isCharacterKey = (evt: React.KeyboardEvent): boolean => {
+export const isCharacterKey = (evt: KeyboardEvent): boolean => {
   if (specialKeys.has(evt.key)) {
     return false;
   }
   return evt.key.length === 1 && !evt.ctrlKey && !evt.metaKey && !evt.altKey;
 };
 
-export const isNavigationKey = ({ key }: React.KeyboardEvent): boolean => {
+export const isNavigationKey = ({ key }: KeyboardEvent): boolean => {
   return navigationKeys.has(key);
 };

--- a/packages/lab/src/common-hooks/selectionTypes.ts
+++ b/packages/lab/src/common-hooks/selectionTypes.ts
@@ -1,4 +1,4 @@
-import type { SyntheticEvent } from "react";
+import type { KeyboardEvent, MouseEvent, SyntheticEvent } from "react";
 import type { CollectionItem } from "./collectionTypes";
 
 export const SINGLE = "default";
@@ -62,13 +62,10 @@ export interface SelectionProps<
 }
 
 export interface ListHandlers {
-  onClick?: (event: React.MouseEvent) => void;
-  onKeyDown?: (event: React.KeyboardEvent) => void;
-  onKeyboardNavigation?: (
-    event: React.KeyboardEvent,
-    currentIndex: number,
-  ) => void;
-  onMouseMove?: (event: React.MouseEvent) => void;
+  onClick?: (event: MouseEvent) => void;
+  onKeyDown?: (event: KeyboardEvent) => void;
+  onKeyboardNavigation?: (event: KeyboardEvent, currentIndex: number) => void;
+  onMouseMove?: (event: MouseEvent) => void;
 }
 export interface SelectionHookProps<
   Item,

--- a/packages/lab/src/common-hooks/useTypeahead.ts
+++ b/packages/lab/src/common-hooks/useTypeahead.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { type KeyboardEvent, useCallback, useRef } from "react";
 import type { CollectionItem } from "./collectionTypes";
 import { Space, isCharacterKey } from "./keyUtils";
 
@@ -12,7 +12,7 @@ interface TypeaheadHookProps<Item> {
 }
 
 interface TypeaheadHookResult {
-  onKeyDown?: (e: React.KeyboardEvent) => void;
+  onKeyDown?: (e: KeyboardEvent) => void;
 }
 
 export const useTypeahead = <Item>({
@@ -52,7 +52,7 @@ export const useTypeahead = <Item>({
   );
 
   const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
+    (e: KeyboardEvent) => {
       const searchInProgress = startIdx.current !== -1;
       if (isCharacterKey(e) || (searchInProgress && e.key === Space)) {
         if (typeToNavigate) {

--- a/packages/lab/src/contact-details/internal/FavoriteToggle.tsx
+++ b/packages/lab/src/contact-details/internal/FavoriteToggle.tsx
@@ -1,8 +1,8 @@
 import { useControlled, useForkRef, useIsFocusVisible } from "@salt-ds/core";
-import type React from "react";
 import {
   type FocusEventHandler,
   type KeyboardEventHandler,
+  type MouseEvent,
   type MouseEventHandler,
   forwardRef,
   useState,
@@ -16,7 +16,7 @@ export interface FavoriteToggleProps
   extends Omit<StarIconContainerProps, "onChange"> {
   onBlur?: FocusEventHandler;
   onChange?: (isSelected: boolean) => void;
-  onClick?: (event: React.MouseEvent<HTMLSpanElement>) => void;
+  onClick?: (event: MouseEvent<HTMLSpanElement>) => void;
   onFocus?: FocusEventHandler;
   onKeyDown?: KeyboardEventHandler<HTMLSpanElement>;
   onMouseEnter?: MouseEventHandler<HTMLSpanElement>;
@@ -80,7 +80,7 @@ export const FavoriteToggle = forwardRef<HTMLSpanElement, FavoriteToggleProps>(
       setIsFocusVisible(false);
     };
 
-    const handleClick: React.MouseEventHandler<HTMLSpanElement> = (event) => {
+    const handleClick: MouseEventHandler<HTMLSpanElement> = (event) => {
       if (onClickProp) {
         onClickProp(event);
       }
@@ -88,18 +88,14 @@ export const FavoriteToggle = forwardRef<HTMLSpanElement, FavoriteToggleProps>(
       toggleSelected();
     };
 
-    const handleMouseEnter: React.MouseEventHandler<HTMLSpanElement> = (
-      event,
-    ) => {
+    const handleMouseEnter: MouseEventHandler<HTMLSpanElement> = (event) => {
       if (onMouseEnterProp) {
         onMouseEnterProp(event);
       }
       setIsHighlighted(true);
     };
 
-    const handleMouseLeave: React.MouseEventHandler<HTMLSpanElement> = (
-      event,
-    ) => {
+    const handleMouseLeave: MouseEventHandler<HTMLSpanElement> = (event) => {
       if (onMouseLeaveProp) {
         onMouseLeaveProp(event);
       }

--- a/packages/lab/src/form-field-legacy/FormHelperText.tsx
+++ b/packages/lab/src/form-field-legacy/FormHelperText.tsx
@@ -6,17 +6,16 @@ import { useWindow } from "@salt-ds/window";
 
 import formHelperTextCss from "./FormHelperText.css";
 
-export type FormHelperTextProps<E extends React.ElementType = "p"> =
-  ComponentPropsWithoutRef<E> & {
-    helperText: FormFieldProps["helperText"];
-    helperTextPlacement: FormFieldProps["helperTextPlacement"];
-  };
+export interface FormHelperTextProps extends ComponentPropsWithoutRef<"p"> {
+  helperText: FormFieldProps["helperText"];
+  helperTextPlacement: FormFieldProps["helperTextPlacement"];
+}
 
-export const FormHelperText = <E extends React.ElementType = "p">({
+export const FormHelperText = ({
   helperText,
   helperTextPlacement,
   ...restProps
-}: FormHelperTextProps<E>) => {
+}: FormHelperTextProps) => {
   const targetWindow = useWindow();
   useComponentCssInjection({
     testId: "salt-form-helper-text",

--- a/packages/lab/src/list/listTypes.ts
+++ b/packages/lab/src/list/listTypes.ts
@@ -1,4 +1,3 @@
-import type React from "react";
 import type {
   FocusEventHandler,
   ForwardedRef,
@@ -7,6 +6,7 @@ import type {
   KeyboardEventHandler,
   MouseEventHandler,
   PropsWithChildren,
+  ReactNode,
   Ref,
   RefObject,
 } from "react";
@@ -35,7 +35,7 @@ export type ListItemType<T = unknown> = ComponentType<
 
 export interface ListItemProps<T = unknown>
   extends HTMLAttributes<HTMLDivElement> {
-  children?: React.ReactNode;
+  children?: ReactNode;
   disabled?: boolean;
   item?: T;
   itemHeight?: number | string;
@@ -221,10 +221,7 @@ export interface ListHookProps<Item, Selection extends SelectionStrategy>
   label?: string;
   listHandlers?: ListHandlers;
   onHighlight?: (index: number) => void;
-  onKeyboardNavigation?: (
-    event: React.KeyboardEvent,
-    currentIndex: number,
-  ) => void;
+  onKeyboardNavigation?: (event: KeyboardEvent, currentIndex: number) => void;
   onKeyDown?: (evt: KeyboardEvent) => void;
   onSelect?: SelectHandler<Item>;
   onSelectionChange?: SelectionChangeHandler<Item, Selection>;

--- a/packages/lab/src/responsive/OverflowReducer.ts
+++ b/packages/lab/src/responsive/OverflowReducer.ts
@@ -4,11 +4,12 @@
  * the source prop or as child elements. We also support 'injected' items. These allow for additional UI
  * controls to be inserted into the container, eg an 'Add Item' button.
  */
-import React, {
-  isValidElement,
+import {
+  Children,
   type ReactElement,
   type ReactNode,
   type Reducer,
+  isValidElement,
 } from "react";
 
 import type {
@@ -89,7 +90,7 @@ const mapReactElementChildren = (
   fn: (el: ReactElement, index: number) => OverflowItem,
 ): OverflowItem[] => {
   const childElements: OverflowItem[] = [];
-  React.Children.forEach(children, (child, i) => {
+  Children.forEach(children, (child, i) => {
     if (isValidElement(child)) {
       childElements.push(fn(child, i));
     }
@@ -185,7 +186,7 @@ const childItem = (
 };
 
 const createChildItems = (
-  children: React.ReactNode,
+  children: ReactNode,
   idRoot: string,
   options?: OverflowCollectionOptions,
 ): OverflowItem<"child">[] | undefined => {

--- a/packages/lab/src/slider/internal/useSliderKeyDown.ts
+++ b/packages/lab/src/slider/internal/useSliderKeyDown.ts
@@ -1,3 +1,4 @@
+import type { KeyboardEvent } from "react";
 import type { SliderChangeHandler, SliderValue } from "../types";
 import {
   type UpdateValueItem,
@@ -16,7 +17,7 @@ export function useSliderKeyDown(
   setValue: SliderChangeHandler,
   onChange?: SliderChangeHandler,
 ) {
-  return (event: React.KeyboardEvent) => {
+  return (event: KeyboardEvent) => {
     const handleElement = event.target as HTMLDivElement;
     const handleIndex = getHandleIndex(handleElement);
     let valueItem: number = Array.isArray(value) ? value[handleIndex] : value;

--- a/packages/lab/src/tabs/Tabstrip.tsx
+++ b/packages/lab/src/tabs/Tabstrip.tsx
@@ -7,12 +7,16 @@ import {
 } from "@salt-ds/core";
 import { AddIcon, OverflowMenuIcon } from "@salt-ds/icons";
 import { clsx } from "clsx";
-import React, {
+import {
+  Children,
   type ForwardedRef,
-  forwardRef,
   type KeyboardEvent,
   type MouseEvent,
   type RefObject,
+  cloneElement,
+  createElement,
+  forwardRef,
+  isValidElement,
   useCallback,
   useImperativeHandle,
   useRef,
@@ -144,13 +148,13 @@ export const Tabstrip = forwardRef(function Tabstrip(
     },
   });
 
-  const childCount = useRef(React.Children.count(children));
+  const childCount = useRef(Children.count(children));
 
   const getChildren = (): TabElement[] | undefined => {
-    if (React.Children.count(children) === 0) {
+    if (Children.count(children) === 0) {
       return undefined;
     }
-    return React.Children.toArray(children) as TabElement[];
+    return Children.toArray(children) as TabElement[];
   };
 
   const [innerContainerRef, switchOverflowPriorities] = useOverflowLayout({
@@ -298,8 +302,8 @@ export const Tabstrip = forwardRef(function Tabstrip(
   }, [overflowMenuProp, activeTabIndex]);
 
   useIsomorphicLayoutEffect(() => {
-    if (React.Children.count(children) !== childCount.current) {
-      childCount.current = React.Children.count(children);
+    if (Children.count(children) !== childCount.current) {
+      childCount.current = Children.count(children);
       // TODO
       // resetOverflow();
     }
@@ -369,14 +373,14 @@ export const Tabstrip = forwardRef(function Tabstrip(
           selected,
         } as Partial<TabProps>;
 
-        if (React.isValidElement(element)) {
+        if (isValidElement(element)) {
           if (element.type === Tab) {
-            return React.cloneElement(element, { ...baseProps, ...tabProps });
+            return cloneElement(element, { ...baseProps, ...tabProps });
           }
-          return React.cloneElement(element, baseProps);
+          return cloneElement(element, baseProps);
         }
-        //@ts-ignore tab can only be a TabDescriptor here, but TypeScript seems to think it can be a number
-        return React.createElement(Tab, {
+
+        return createElement(Tab, {
           ...baseProps,
           ...tabProps,
           label: tab.label,

--- a/packages/lab/src/tabs/useKeyboardNavigation.ts
+++ b/packages/lab/src/tabs/useKeyboardNavigation.ts
@@ -217,7 +217,7 @@ export const useKeyboardNavigation = ({
   // then Left or Right Arrow keys are pressed, There will be no navigation
   // but focusVisible must be applied
   const navigateChildItems = useCallback(
-    (e: React.KeyboardEvent, forceFocusVisible = false) => {
+    (e: KeyboardEvent, forceFocusVisible = false) => {
       const direction = navigation[orientation][e.key];
       const nextIdx = nextFocusableItemIdx(direction, highlightedIdx);
       if (nextIdx !== highlightedIdx) {

--- a/packages/lab/src/toolbar/internal/renderToolbarItems.tsx
+++ b/packages/lab/src/toolbar/internal/renderToolbarItems.tsx
@@ -1,4 +1,4 @@
-import React, { type HTMLAttributes, type ReactElement } from "react";
+import { type HTMLAttributes, type ReactElement, cloneElement } from "react";
 
 import type { ToolbarAlignmentProps } from "../ToolbarProps";
 import { ToolbarField, type ToolbarFieldProps } from "../toolbar-field";
@@ -85,14 +85,14 @@ export const renderToolbarItems = (
       };
 
       if (item.element.type === Tooltray) {
-        return React.cloneElement(item.element, toolbarItemProps);
+        return cloneElement(item.element, toolbarItemProps);
       }
       switch (item.element.type) {
         case ToolbarField: {
           const props = item.element.props as ToolbarFieldProps;
-          return React.cloneElement(item.element, {
+          return cloneElement(item.element, {
             ...toolbarItemProps,
-            children: React.cloneElement(props.children as ReactElement, {
+            children: cloneElement(props.children as ReactElement, {
               // Inject an id that nested Control can use to query status via context
               id: `toolbar-control-${item.id}`,
             }),
@@ -104,7 +104,7 @@ export const renderToolbarItems = (
 
           return (
             <ToolbarField {...responsiveProps} {...toolbarItemProps}>
-              {React.cloneElement(item.element, {
+              {cloneElement(item.element, {
                 ...componentProps,
                 // Inject an id that nested Control can use to query status via context
                 id: `toolbar-control-${item.id}`,

--- a/packages/lab/src/toolbar/internal/renderTrayTools.tsx
+++ b/packages/lab/src/toolbar/internal/renderTrayTools.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode } from "react";
+import React, { cloneElement, type ReactNode } from "react";
 import type {
   OverflowCollectionHookResult,
   OverflowItem,
@@ -46,7 +46,7 @@ export const renderTrayTools = (
       orientation,
     };
     if (item.element.type === ToolbarField) {
-      return React.cloneElement(item.element, {
+      return cloneElement(item.element, {
         key: index,
         ...toolbarItemProps,
       });
@@ -64,7 +64,7 @@ export const renderTrayTools = (
           data-orientation={orientation}
         >
           {/* We clone here just to remove the responsive props */}
-          {React.cloneElement(item.element, { ...restProps })}
+          {cloneElement(item.element, { ...restProps })}
         </ToolbarField>
       );
     }
@@ -77,7 +77,7 @@ export const renderTrayTools = (
         key={index}
         data-orientation={orientation}
       >
-        {React.cloneElement(item.element, {
+        {cloneElement(item.element, {
           id: `tooltray-control-${item.id}`,
         })}
       </ToolbarField>

--- a/packages/lab/src/toolbar/overflow-panel/OverflowPanel.tsx
+++ b/packages/lab/src/toolbar/overflow-panel/OverflowPanel.tsx
@@ -6,11 +6,12 @@ import {
 } from "@salt-ds/core";
 import { OverflowMenuIcon } from "@salt-ds/icons";
 import { clsx } from "clsx";
-import React, {
+import {
   type ForwardedRef,
-  forwardRef,
   type MouseEvent,
   type ReactElement,
+  cloneElement,
+  forwardRef,
   useCallback,
   useRef,
 } from "react";
@@ -138,10 +139,7 @@ export const OverflowPanel = forwardRef(function DropdownPanel(
           } as ToolbarFieldProps;
 
           if (type === ToolbarField) {
-            return React.cloneElement(
-              item.value as ReactElement,
-              formFieldProps,
-            );
+            return cloneElement(item.value as ReactElement, formFieldProps);
           }
           return (
             <ToolbarField {...formFieldProps} key={item.id}>

--- a/site/src/components/css-display/AccordionView.tsx
+++ b/site/src/components/css-display/AccordionView.tsx
@@ -19,9 +19,7 @@ import { LineBlock } from "docs/components/LineBlock";
 import { OutlineBlock } from "docs/components/OutlineBlock";
 import { ShadowBlockCell } from "docs/components/ShadowBlock";
 import { TextBlock } from "docs/components/TextBlock";
-import type React from "react";
-import { useEffect, useState } from "react";
-import { Heading4 } from "../mdx/h4";
+import { type FC, useEffect, useState } from "react";
 import { Table } from "../mdx/table";
 import styles from "./AccordianView.module.css";
 import chars from "./descriptions";
@@ -59,7 +57,7 @@ const transform: string[] = new Array("textTransform");
 const fontFamily: string[] = new Array("fontFamily");
 const lineHeight: string[] = new Array("lineHeight");
 
-const BlockView: React.FC<{ name: string }> = ({ name }) => {
+const BlockView: FC<{ name: string }> = ({ name }) => {
   switch (true) {
     case color.some((c) => name.includes(c)):
       return <ColorBlock hideToken colorVar={name} />;
@@ -103,7 +101,7 @@ const handleCopyToClipboard = (text: string) => {
   textField.remove();
 };
 
-export const AccordionView: React.FC<{ value: string }> = ({ value }) => {
+export const AccordionView: FC<{ value: string }> = ({ value }) => {
   const [cssVariablesData, setCssVariablesData] =
     useState<CssVariableData | null>(null);
 

--- a/site/src/components/mdx/anchorHeading/AnchorHeading.tsx
+++ b/site/src/components/mdx/anchorHeading/AnchorHeading.tsx
@@ -72,7 +72,7 @@ export const AnchorHeading: FC<PropsWithChildren<AnchorHeadingProps>> = ({
 };
 
 type WithAnchorHeadingProps = JSX.IntrinsicAttributes &
-  AnchorHeadingProps & { children?: React.ReactNode };
+  AnchorHeadingProps & { children?: ReactNode };
 
 export const withAnchorHeading =
   (Component: FC<PropsWithChildren<TypographyProps>>) =>

--- a/site/src/components/mdx/link/A.tsx
+++ b/site/src/components/mdx/link/A.tsx
@@ -1,4 +1,4 @@
-import type React from "react";
+import type { FC, PropsWithChildren } from "react";
 
 import {
   Link as LinkComponent,
@@ -10,7 +10,7 @@ export interface MarkdownLinkProps extends LinkProps {
   href?: string;
 }
 
-export const Link: React.FC<React.PropsWithChildren<MarkdownLinkProps>> = ({
+export const Link: FC<PropsWithChildren<MarkdownLinkProps>> = ({
   href,
   ...rest
 }) => (

--- a/site/src/components/roadmap/Roadmap.tsx
+++ b/site/src/components/roadmap/Roadmap.tsx
@@ -16,7 +16,7 @@ import {
   ProgressInprogressIcon,
   ProgressTodoIcon,
 } from "@salt-ds/icons";
-import { type ReactNode, useEffect, useState } from "react";
+import { type FC, type ReactNode, useEffect, useState } from "react";
 import { Heading4 } from "../mdx/h4";
 
 import styles from "./style.module.css";
@@ -171,7 +171,7 @@ export const Roadmap = ({ endpoint }: RoadmapProps) => {
   );
 };
 
-const ColumnData: React.FC<{ item: RoadmapData; future?: boolean }> = ({
+const ColumnData: FC<{ item: RoadmapData; future?: boolean }> = ({
   item,
   future = true,
 }) => {

--- a/site/src/components/toc/TableOfContents.tsx
+++ b/site/src/components/toc/TableOfContents.tsx
@@ -1,11 +1,11 @@
 import { TableOfContents as MosaicTOC } from "@jpmorganchase/mosaic-site-components";
-import React, { type ComponentPropsWithoutRef, useEffect } from "react";
+import { type ComponentPropsWithoutRef, useEffect, useState } from "react";
 
 // This component is needed to fix the TOC not picking up lazily loaded mdx from next-remote-mdx.
 export function TableOfContents(
   props: ComponentPropsWithoutRef<typeof MosaicTOC>,
 ) {
-  const [showTOC, setShowTOC] = React.useState(false);
+  const [showTOC, setShowTOC] = useState(false);
 
   useEffect(() => {
     const handle = window.requestIdleCallback(() => {

--- a/site/src/examples/form-field/GroupedWithEmptySlot.tsx
+++ b/site/src/examples/form-field/GroupedWithEmptySlot.tsx
@@ -7,11 +7,11 @@ import {
   Input,
   StackLayout,
 } from "@salt-ds/core";
-import type { ReactElement } from "react";
+import type { CSSProperties, ReactElement } from "react";
 
 export const GroupedWithEmptySlot = (): ReactElement => (
   <StackLayout
-    style={{ "--saltFormField-label-width": "100px" } as React.CSSProperties}
+    style={{ "--saltFormField-label-width": "100px" } as CSSProperties}
     role={"group"}
   >
     <FormField>

--- a/site/src/examples/overlay/WithActions.tsx
+++ b/site/src/examples/overlay/WithActions.tsx
@@ -10,8 +10,7 @@ import {
   StackLayout,
   useId,
 } from "@salt-ds/core";
-import type { ChangeEvent } from "react";
-import React from "react";
+import { type ChangeEvent, useState } from "react";
 
 const checkboxesData = [
   {
@@ -30,11 +29,11 @@ interface WithActionsContentProps {
 }
 
 const WithActionsContent = ({ id, onClose }: WithActionsContentProps) => {
-  const [controlledValues, setControlledValues] = React.useState([
+  const [controlledValues, setControlledValues] = useState([
     checkboxesData[0].value,
   ]);
 
-  const [checkboxState, setCheckboxState] = React.useState({
+  const [checkboxState, setCheckboxState] = useState({
     checked: false,
     indeterminate: true,
   });
@@ -105,7 +104,7 @@ const WithActionsContent = ({ id, onClose }: WithActionsContentProps) => {
 };
 
 export const WithActions = () => {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
   const id = useId();
 
   const onOpenChange = (newOpen: boolean) => setOpen(newOpen);

--- a/site/src/layouts/DetailContentOnly/DetailContentOnly.tsx
+++ b/site/src/layouts/DetailContentOnly/DetailContentOnly.tsx
@@ -3,14 +3,14 @@ import { Breadcrumbs } from "@jpmorganchase/mosaic-site-components";
 import { useMeta } from "@jpmorganchase/mosaic-store";
 import { SaltProvider } from "@salt-ds/core";
 import clsx from "clsx";
-import type React from "react";
+import type { FC } from "react";
 import { AppHeader, Footer } from "../../components";
 import { LayoutFullWidth } from "../LayoutFullWidth";
 import layoutStyles from "../index.module.css";
 import type { LayoutProps } from "../types/index";
 import styles from "./DetailContentOnly.module.css";
 
-export const DetailContentOnly: React.FC<LayoutProps> = ({
+export const DetailContentOnly: FC<LayoutProps> = ({
   FooterProps,
   children,
 }) => {


### PR DESCRIPTION
A small clean up to avoid referencing `React.*`. Cleaned up the legacy form helper text types in lab. Should close #3831