### PR TITLE
Add controlled examples to site

### DIFF
--- a/site/docs/components/checkbox/examples.mdx
+++ b/site/docs/components/checkbox/examples.mdx
@@ -144,4 +144,12 @@ For more information, refer to the [form pattern](/salt/patterns/forms).
 You can add a description to a checkbox using a `StackLayout` in the `label` prop.
 
 </LivePreview>
+
+<LivePreview componentName="checkbox" exampleName="Controlled" >
+
+## Controlled
+
+A controlled CheckboxGroup will rely on the application to manually set the value through the `checkedValues` prop. The `onChange` event should be used to read the value and decide what the next value should be. This value is updated by changing the `checkedValues` prop.
+
+</LivePreview>
 </LivePreviewControls>

--- a/site/docs/components/input/examples.mdx
+++ b/site/docs/components/input/examples.mdx
@@ -121,4 +121,12 @@ To style Input with a full border, set `bordered={true}`.
 We recommend this styling when the field uses the same fill color as the background (i.e., a primary fill color on a primary background).
 
 </LivePreview>
+
+<LivePreview componentName="input" exampleName="Controlled" >
+
+## Controlled
+
+A controlled Input will rely on the application to manually set the value through the `value` prop. The `onChange` event should be used to read the value and decide what the next value should be. This value is updated by changing the `value` prop.
+
+</LivePreview>
 </LivePreviewControls>

--- a/site/docs/components/multiline-input/examples.mdx
+++ b/site/docs/components/multiline-input/examples.mdx
@@ -122,4 +122,12 @@ You can use a [button](../button) at the beginning or end of the multiline input
 If you've disabled the containing multiline input or set it to a read-only state, ensure your interactive buttons match that state.
 
 </LivePreview>
+
+<LivePreview componentName="multiline-input" exampleName="Controlled" >
+
+## Controlled
+
+A controlled Multiline Input will rely on the application to manually set the value through the `value` prop. The `onChange` event should be used to read the value and decide what the next value should be. This value is updated by changing the `value` prop.
+
+</LivePreview>
 </LivePreviewControls>

--- a/site/docs/components/radio-button/examples.mdx
+++ b/site/docs/components/radio-button/examples.mdx
@@ -124,4 +124,12 @@ For more information, refer to the [form field](/salt/patterns/forms) guidance.
 You can add a description to a checkbox using a `StackLayout` in the `label` prop.
 
 </LivePreview>
+
+<LivePreview componentName="radio-button" exampleName="Controlled" >
+
+## Controlled
+
+A controlled Radio will rely on the application to manually set the value through the `value` prop. The `onChange` event should be used to read the value and decide what the next value should be. This value is updated by changing the `value` prop.
+
+</LivePreview>
 </LivePreviewControls>

--- a/site/docs/components/switch/examples.mdx
+++ b/site/docs/components/switch/examples.mdx
@@ -64,4 +64,12 @@ Use a disabled checked state for switches that have permissions, dependencies or
 Use a form field if you need a left aligned label, avoid also having a switch label.
 
 </LivePreview>
+
+<LivePreview componentName="switch" exampleName="Controlled" >
+
+## Controlled
+
+A controlled Switch will rely on the application to manually set the value through the `checked` prop. The `onChange` event should be used to read the value and decide what the next value should be. This value is updated by changing the `checked` prop.
+
+</LivePreview>
 </LivePreviewControls>

--- a/site/docs/components/toggle-button/examples.mdx
+++ b/site/docs/components/toggle-button/examples.mdx
@@ -76,4 +76,12 @@ You can disable toggle buttons if required by context or user permissions. Disab
 By default, a toggle button group has horizontal alignment. If you can present the options in a stacked layout, orientate the group vertically using the `orientation=”vertical”` prop.
 
 </LivePreview>
+
+<LivePreview componentName="toggle-button" exampleName="Controlled">
+
+## Controlled
+
+A controlled Toggle Button will rely on the application to manually set the value through the `value` prop. The `onChange` event should be used to read the value and decide what the next value should be. This value is updated by changing the `value` prop.
+
+</LivePreview>
 </LivePreviewControls>

--- a/site/docs/components/toggle-button/examples.mdx
+++ b/site/docs/components/toggle-button/examples.mdx
@@ -77,7 +77,7 @@ By default, a toggle button group has horizontal alignment. If you can present t
 
 </LivePreview>
 
-<LivePreview componentName="toggle-button" exampleName="Controlled">
+<LivePreview componentName="toggle-button" exampleName="Controlled" >
 
 ## Controlled
 

--- a/site/src/examples/checkbox/Controlled.tsx
+++ b/site/src/examples/checkbox/Controlled.tsx
@@ -1,0 +1,22 @@
+import { Checkbox, CheckboxGroup } from "@salt-ds/core";
+import { type ChangeEvent, type ReactElement, useState } from "react";
+
+export const Controlled = (): ReactElement => {
+  const [checkedValues, setCheckedValues] = useState<string[]>([]);
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    const updatedCheckedValues = checkedValues.includes(value)
+      ? checkedValues.filter((checkedValue) => checkedValue !== value)
+      : [...checkedValues, value];
+    setCheckedValues(updatedCheckedValues);
+  };
+
+  return (
+    <CheckboxGroup checkedValues={checkedValues} onChange={handleChange}>
+      <Checkbox label="Alternatives" value="alternatives" />
+      <Checkbox label="Equities" value="equities" />
+      <Checkbox label="Fixed income" value="fixed income" />
+    </CheckboxGroup>
+  );
+};

--- a/site/src/examples/checkbox/index.ts
+++ b/site/src/examples/checkbox/index.ts
@@ -11,3 +11,4 @@ export * from "./WrapGroup";
 export * from "./Indeterminate";
 export * from "./WithFormField";
 export * from "./WithDescription";
+export * from "./Controlled";

--- a/site/src/examples/input/Controlled.tsx
+++ b/site/src/examples/input/Controlled.tsx
@@ -1,0 +1,15 @@
+import { Input } from "@salt-ds/core";
+import { type ChangeEvent, type ReactElement, useState } from "react";
+
+export const Controlled = (): ReactElement => {
+  const [value, setValue] = useState<string>("Value");
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setValue(value);
+  };
+
+  return (
+    <Input value={value} onChange={handleChange} style={{ width: "256px" }} />
+  );
+};

--- a/site/src/examples/input/index.ts
+++ b/site/src/examples/input/index.ts
@@ -11,3 +11,4 @@ export * from "./Primary";
 export * from "./TextAlignment";
 export * from "./Validation";
 export * from "./Bordered";
+export * from "./Controlled";

--- a/site/src/examples/multiline-input/Controlled.tsx
+++ b/site/src/examples/multiline-input/Controlled.tsx
@@ -1,0 +1,19 @@
+import { MultilineInput } from "@salt-ds/core";
+import { type ChangeEvent, type ReactElement, useState } from "react";
+
+export const Controlled = (): ReactElement => {
+  const [value, setValue] = useState<string>("Value");
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setValue(value);
+  };
+
+  return (
+    <MultilineInput
+      value={value}
+      onChange={handleChange}
+      style={{ width: "256px" }}
+    />
+  );
+};

--- a/site/src/examples/multiline-input/index.ts
+++ b/site/src/examples/multiline-input/index.ts
@@ -9,3 +9,4 @@ export * from "./Readonly";
 export * from "./Secondary";
 export * from "./StaticAdornments";
 export * from "./ValidationStatus";
+export * from "./Controlled";

--- a/site/src/examples/radio-button/Controlled.tsx
+++ b/site/src/examples/radio-button/Controlled.tsx
@@ -1,0 +1,19 @@
+import { RadioButton, RadioButtonGroup } from "@salt-ds/core";
+import { type ChangeEvent, type ReactElement, useState } from "react";
+
+export const Controlled = (): ReactElement => {
+  const [value, setValue] = useState<string>("");
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const updatedValue = event.target.value;
+    setValue(updatedValue);
+  };
+
+  return (
+    <RadioButtonGroup value={value} onChange={handleChange}>
+      <RadioButton label="NAMR" value="namr" />
+      <RadioButton label="APAC" value="apac" />
+      <RadioButton label="EMEA" value="emea" />
+    </RadioButtonGroup>
+  );
+};

--- a/site/src/examples/radio-button/index.ts
+++ b/site/src/examples/radio-button/index.ts
@@ -9,3 +9,4 @@ export * from "./Wrap";
 export * from "./LongText";
 export * from "./WithFormField";
 export * from "./WithDescription";
+export * from "./Controlled";

--- a/site/src/examples/switch/Controlled.tsx
+++ b/site/src/examples/switch/Controlled.tsx
@@ -1,0 +1,15 @@
+import { Switch } from "@salt-ds/core";
+import { type ChangeEvent, type ReactElement, useState } from "react";
+
+export const Controlled = (): ReactElement => {
+  const [checked, setChecked] = useState<boolean>(false);
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const updatedChecked = event.target.checked;
+    setChecked(updatedChecked);
+  };
+
+  return (
+    <Switch label="Controlled" checked={checked} onChange={handleChange} />
+  );
+};

--- a/site/src/examples/switch/index.ts
+++ b/site/src/examples/switch/index.ts
@@ -3,3 +3,4 @@ export * from "./DefaultChecked";
 export * from "./DisabledChecked";
 export * from "./Disabled";
 export * from "./LeftAlignedLabel";
+export * from "./Controlled";

--- a/site/src/examples/toggle-button/Controlled.tsx
+++ b/site/src/examples/toggle-button/Controlled.tsx
@@ -1,0 +1,29 @@
+import { ToggleButton, ToggleButtonGroup } from "@salt-ds/core";
+import { AppSwitcherIcon, FolderClosedIcon, VisibleIcon } from "@salt-ds/icons";
+import { type SyntheticEvent, type ReactElement, useState } from "react";
+
+export const Controlled = (): ReactElement => {
+  const [value, setValue] = useState<string>("");
+
+  const handleChange = (event: SyntheticEvent<HTMLButtonElement>) => {
+    const updatedValue = event.currentTarget.value;
+    setValue(updatedValue);
+  };
+
+  return (
+    <ToggleButtonGroup value={value} onChange={handleChange}>
+      <ToggleButton value="all">
+        <AppSwitcherIcon aria-hidden />
+        All
+      </ToggleButton>
+      <ToggleButton value="active">
+        <VisibleIcon aria-hidden />
+        Active
+      </ToggleButton>
+      <ToggleButton value="search">
+        <FolderClosedIcon aria-hidden />
+        Archived
+      </ToggleButton>
+    </ToggleButtonGroup>
+  );
+};

--- a/site/src/examples/toggle-button/index.ts
+++ b/site/src/examples/toggle-button/index.ts
@@ -4,3 +4,4 @@ export * from "./ToggleButtonGroupVertical";
 export * from "./Disabled";
 export * from "./IconOnly";
 export * from "./TextOnly";
+export * from "./Controlled";


### PR DESCRIPTION
Closes #3250

- Added controlled examples to the site docs for the following components:
   - Switch
   - Radio
   - Checkbox
   - Input
   - Multiline Input
   - Toggle Button