### PR TITLE
Remove `--salt-size-selectable` from deprecated list

### DIFF
--- a/.changeset/odd-candles-argue.md
+++ b/.changeset/odd-candles-argue.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/theme": patch
+---
+
+Fixed `--salt-size-selectable` double defined in deprecated token list

--- a/packages/theme/css/deprecated/foundations.css
+++ b/packages/theme/css/deprecated/foundations.css
@@ -65,7 +65,6 @@
   --salt-size-adornmentGap: calc(0.75 * var(--salt-size-unit));
   --salt-size-container-spacing: calc(3 * var(--salt-size-unit));
   --salt-size-separator-strokeWidth: 1px;
-  --salt-size-selectable: calc(var(--salt-size-base) - (1.5 * var(--salt-size-unit)) - (0.5 * var(--salt-size-basis-unit)));
   --salt-size-separator-height: calc(var(--salt-size-compact) + 1.5 * var(--salt-size-basis-unit));
   --salt-size-sharktooth-height: 5px;
   --salt-size-sharktooth-width: 10px;


### PR DESCRIPTION
It is defined in `size.css` and not a deprecated token