### PR TITLE
[Prototype] Enable theme next for site component examples

### DIFF
--- a/site/src/components/components/LivePreview.tsx
+++ b/site/src/components/components/LivePreview.tsx
@@ -1,4 +1,4 @@
-import { Switch } from "@salt-ds/core";
+import { SaltProviderNext, Switch } from "@salt-ds/core";
 import { SaltProvider } from "@salt-ds/core";
 import clsx from "clsx";
 import {
@@ -76,6 +76,9 @@ export const LivePreview: FC<LivePreviewProps> = ({
     mode,
     showCode: contextShowCode,
     onShowCodeToggle: contextOnShowCodeToggle,
+    accent,
+    corner,
+    themeNext,
   } = useLivePreviewControls();
 
   const handleShowCodeToggle = (event: ChangeEvent<HTMLInputElement>) => {
@@ -92,6 +95,8 @@ export const LivePreview: FC<LivePreviewProps> = ({
   // somewhere), then fallback to using own state
   const showCode = contextOnShowCodeToggle ? contextShowCode : ownShowCode;
 
+  const ChosenSaltProvider = themeNext ? SaltProviderNext : SaltProvider;
+
   return (
     <>
       {children}
@@ -102,23 +107,23 @@ export const LivePreview: FC<LivePreviewProps> = ({
           })}
         >
           {list && list}
-          <SaltProvider mode={mode}>
+          <ChosenSaltProvider mode={mode} accent={accent} corner={corner}>
             <div className={styles.exampleWithSwitch}>
               <div className={styles.example}>
-                <SaltProvider density={density}>
+                <ChosenSaltProvider density={density}>
                   {ComponentExample.Example && <ComponentExample.Example />}
-                </SaltProvider>
+                </ChosenSaltProvider>
               </div>
-              <SaltProvider density="medium">
+              <ChosenSaltProvider density="medium">
                 <Switch
                   checked={showCode}
                   onChange={handleShowCodeToggle}
                   className={styles.switch}
                   label="Show code"
                 />
-              </SaltProvider>
+              </ChosenSaltProvider>
             </div>
-          </SaltProvider>
+          </ChosenSaltProvider>
         </div>
 
         {showCode && (

--- a/site/src/components/components/LivePreviewControls.module.css
+++ b/site/src/components/components/LivePreviewControls.module.css
@@ -1,13 +1,16 @@
 .controls {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
   padding: calc(var(--salt-size-unit) * 2) 0;
   border-bottom: var(--salt-size-border) var(--salt-separable-borderStyle) var(--salt-separable-tertiary-borderColor);
   background-color: var(--salt-container-primary-background);
   position: sticky;
   top: var(--navbar-height);
   z-index: var(--salt-zIndex-default);
+}
+
+.controlsRow {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
   gap: calc(var(--salt-size-unit) * 3);
 }
 

--- a/site/src/components/components/LivePreviewControls.tsx
+++ b/site/src/components/components/LivePreviewControls.tsx
@@ -1,13 +1,19 @@
-import { Switch } from "@salt-ds/core";
 import {
+  type Accent,
+  type Corner,
   type Density,
+  FlexItem,
+  FlowLayout,
   type Mode,
   SaltProvider,
+  type SaltProviderNextProps,
+  StackLayout,
+  Switch,
+  Text,
   ToggleButton,
   ToggleButtonGroup,
 } from "@salt-ds/core";
 import { DarkIcon, LightIcon } from "@salt-ds/icons";
-import clsx from "clsx";
 import {
   type ChangeEvent,
   type FC,
@@ -34,9 +40,11 @@ const defaultDensity = densities[1];
 
 const defaultMode = modes[0];
 
-export type LivePreviewContextType = {
-  density?: Density;
-  mode?: Mode;
+export type LivePreviewContextType = Pick<
+  SaltProviderNextProps,
+  "accent" | "mode" | "density" | "corner"
+> & {
+  themeNext?: boolean;
   showCode?: boolean;
   onShowCodeToggle?: (showCode: boolean) => void;
 };
@@ -47,8 +55,10 @@ export const LivePreviewControls: FC<LivePreviewControlsProps> = ({
   children,
 }) => {
   const [density, setDensity] = useState<Density>(defaultDensity);
-
   const [mode, setMode] = useState<Mode>(defaultMode);
+  const [themeNext, setThemeNext] = useState(false);
+  const [accent, setAccent] = useState<Accent>("blue");
+  const [corner, setCorner] = useState<Corner>("sharp");
 
   const [showCode, setShowCode] = useState<boolean>(false);
 
@@ -81,62 +91,137 @@ export const LivePreviewControls: FC<LivePreviewControlsProps> = ({
   return (
     <>
       <SaltProvider density="medium">
-        <div className={styles.controls}>
-          {!isMobileView && (
-            <Switch
-              label="All examples"
-              checked={allExamplesView}
-              onChange={handleAllExamplesChange}
-            />
-          )}
-          <div className={styles.toggleButtonGroups}>
-            <div
-              className={clsx(styles.density, {
-                [styles.smallViewport]: isMobileView,
-              })}
-            >
-              <span>Density</span>
-              <ToggleButtonGroup
-                aria-label="Select density"
-                value={density}
-                onChange={handleDensityChange}
-              >
-                <ToggleButton aria-label="high density" value="high">
-                  {isMobileView ? "HD" : "High"}
-                </ToggleButton>
-                <ToggleButton aria-label="medium density" value="medium">
-                  {isMobileView ? "MD" : "Medium"}
-                </ToggleButton>
-                <ToggleButton aria-label="low density" value="low">
-                  {isMobileView ? "LD" : "Low"}
-                </ToggleButton>
-                <ToggleButton aria-label="touch density" value="touch">
-                  {isMobileView ? "TD" : "Touch"}
-                </ToggleButton>
-              </ToggleButtonGroup>
-            </div>
+        <StackLayout align="stretch" className={styles.controls} gap={1}>
+          <FlexItem className={styles.controlsRow}>
+            {!isMobileView && (
+              <Switch
+                label="All examples"
+                checked={allExamplesView}
+                onChange={handleAllExamplesChange}
+              />
+            )}
 
-            <div
-              className={clsx(styles.mode, {
-                [styles.smallViewport]: isMobileView,
-              })}
-            >
-              <span>Mode</span>
-              <ToggleButtonGroup
-                aria-label="Select mode"
-                onChange={handleModeChange}
-                value={mode}
+            <div className={styles.toggleButtonGroups}>
+              <StackLayout
+                gap={0.75}
+                align="baseline"
+                direction={{
+                  xs: "column",
+                  sm: "column",
+                  md: "row",
+                  lg: "row",
+                  xl: "row",
+                }}
               >
-                <ToggleButton aria-label="light mode" value="light">
-                  <LightIcon /> {!isMobileView && " Light"}
-                </ToggleButton>
-                <ToggleButton aria-label="dark mode" value="dark">
-                  <DarkIcon /> {!isMobileView && " Dark"}
-                </ToggleButton>
-              </ToggleButtonGroup>
+                <Text styleAs="label">Density</Text>
+                <ToggleButtonGroup
+                  aria-label="Select density"
+                  value={density}
+                  onChange={handleDensityChange}
+                >
+                  <ToggleButton aria-label="high density" value="high">
+                    {isMobileView ? "HD" : "High"}
+                  </ToggleButton>
+                  <ToggleButton aria-label="medium density" value="medium">
+                    {isMobileView ? "MD" : "Medium"}
+                  </ToggleButton>
+                  <ToggleButton aria-label="low density" value="low">
+                    {isMobileView ? "LD" : "Low"}
+                  </ToggleButton>
+                  <ToggleButton aria-label="touch density" value="touch">
+                    {isMobileView ? "TD" : "Touch"}
+                  </ToggleButton>
+                </ToggleButtonGroup>
+              </StackLayout>
+
+              <StackLayout
+                gap={0.75}
+                align="baseline"
+                direction={{
+                  xs: "column",
+                  sm: "column",
+                  md: "row",
+                  lg: "row",
+                  xl: "row",
+                }}
+              >
+                <Text styleAs="label">Mode</Text>
+                <ToggleButtonGroup
+                  aria-label="Select mode"
+                  onChange={handleModeChange}
+                  value={mode}
+                >
+                  <ToggleButton aria-label="light mode" value="light">
+                    <LightIcon /> {!isMobileView && " Light"}
+                  </ToggleButton>
+                  <ToggleButton aria-label="dark mode" value="dark">
+                    <DarkIcon /> {!isMobileView && " Dark"}
+                  </ToggleButton>
+                </ToggleButtonGroup>
+              </StackLayout>
             </div>
-          </div>
-        </div>
+          </FlexItem>
+          <FlexItem align="end">
+            <FlowLayout align="center">
+              <Switch
+                label="Theme next"
+                checked={themeNext}
+                onChange={() => setThemeNext((prev) => !prev)}
+              />
+
+              <StackLayout
+                gap={0.75}
+                align="baseline"
+                direction={{
+                  xs: "column",
+                  sm: "column",
+                  md: "row",
+                  lg: "row",
+                  xl: "row",
+                }}
+              >
+                <Text styleAs="label">Corner</Text>
+                <ToggleButtonGroup
+                  disabled={!themeNext}
+                  aria-label="Select corner"
+                  value={corner}
+                  onChange={() => {
+                    setCorner((prev) =>
+                      prev === "rounded" ? "sharp" : "rounded",
+                    );
+                  }}
+                >
+                  <ToggleButton value="sharp">Sharp</ToggleButton>
+                  <ToggleButton value="rounded">Rounded</ToggleButton>
+                </ToggleButtonGroup>
+              </StackLayout>
+
+              <StackLayout
+                gap={0.75}
+                align="baseline"
+                direction={{
+                  xs: "column",
+                  sm: "column",
+                  md: "row",
+                  lg: "row",
+                  xl: "row",
+                }}
+              >
+                <Text styleAs="label">Accent</Text>
+                <ToggleButtonGroup
+                  disabled={!themeNext}
+                  value={accent}
+                  onChange={() => {
+                    setAccent((prev) => (prev === "blue" ? "teal" : "blue"));
+                  }}
+                >
+                  <ToggleButton value="blue">Blue</ToggleButton>
+                  <ToggleButton value="teal">Teal</ToggleButton>
+                </ToggleButtonGroup>
+              </StackLayout>
+            </FlowLayout>
+          </FlexItem>
+        </StackLayout>
       </SaltProvider>
       <LivePreviewContext.Provider
         value={{
@@ -144,6 +229,9 @@ export const LivePreviewControls: FC<LivePreviewControlsProps> = ({
           mode,
           showCode,
           onShowCodeToggle: handleShowCodeToggle,
+          themeNext,
+          accent,
+          corner,
         }}
       >
         {allExamplesView ? children : <ExamplesListView examples={children} />}

--- a/site/src/css/theme/theme.css
+++ b/site/src/css/theme/theme.css
@@ -16,11 +16,3 @@
   --site-tertiary-accent-orange: var(--salt-color-orange-30);
   --color-dark-neutral-background-regular: var(--salt-palette-interact-primary-foreground-active);
 }
-
-.salt-theme[data-mode="light"],
-.salt-theme[data-mode="dark"] {
-  --salt-palette-text-fontFamily: var(--site-font-family);
-  --salt-palette-text-fontFamily-heading: var(--site-font-family);
-  --salt-palette-text-fontFamily-action: var(--site-font-family);
-  --salt-palette-text-fontFamily-code: var(--site-font-family-code);
-}

--- a/site/src/pages/_app.tsx
+++ b/site/src/pages/_app.tsx
@@ -5,41 +5,42 @@ import {
   getMarkdownComponents,
   withMarkdownSpacing,
 } from "@jpmorganchase/mosaic-components";
-import { LayoutProvider } from "@jpmorganchase/mosaic-layouts";
-import { layouts as mosaicLayouts } from "@jpmorganchase/mosaic-layouts";
+import {
+  LayoutProvider,
+  layouts as mosaicLayouts,
+} from "@jpmorganchase/mosaic-layouts";
 import {
   BaseUrlProvider,
   Image,
   Link,
-  Metadata,
 } from "@jpmorganchase/mosaic-site-components";
 import { Sitemap } from "@jpmorganchase/mosaic-sitemap-component";
 import { StoreProvider, useCreateStore } from "@jpmorganchase/mosaic-store";
 import { themeClassName } from "@jpmorganchase/mosaic-theme";
+import { SaltProvider, useCurrentBreakpoint } from "@salt-ds/core";
+import clsx from "clsx";
 import { SessionProvider } from "next-auth/react";
 import type { AppProps } from "next/app";
-import Head from "next/head";
+import { Open_Sans, PT_Mono } from "next/font/google";
 import { type ReactNode, useMemo } from "react";
-import "@salt-ds/theme/index.css";
-import "@jpmorganchase/mosaic-theme/index.css";
-import "@jpmorganchase/mosaic-theme/baseline.css";
+import * as saltComponents from "../components";
+import * as saltLayouts from "../layouts";
+import type { MyAppProps } from "../types/mosaic";
+import Homepage from "./index";
+
+import "@jpmorganchase/mosaic-components/index.css";
+import "@jpmorganchase/mosaic-content-editor-plugin/index.css";
+import "@jpmorganchase/mosaic-labs-components/index.css";
 import "@jpmorganchase/mosaic-layouts/index.css";
 import "@jpmorganchase/mosaic-site-components/index.css";
 import "@jpmorganchase/mosaic-sitemap-component/index.css";
-import "@jpmorganchase/mosaic-components/index.css";
-import "@jpmorganchase/mosaic-labs-components/index.css";
-import "@jpmorganchase/mosaic-content-editor-plugin/index.css";
+import "@jpmorganchase/mosaic-theme/baseline.css";
+import "@jpmorganchase/mosaic-theme/index.css";
+import "@salt-ds/theme/css/theme-next.css";
+import "@salt-ds/theme/index.css";
 import "prismjs/themes/prism.css";
 
-import { SaltProvider, useCurrentBreakpoint } from "@salt-ds/core";
-import { Open_Sans, PT_Mono } from "next/font/google";
-
 import "../css/index.css";
-import * as saltComponents from "../components";
-import * as saltLayouts from "../layouts";
-import Homepage from "./index";
-
-import type { MyAppProps } from "../types/mosaic";
 
 const components = {
   ...getMarkdownComponents(),
@@ -69,26 +70,13 @@ const ptMono = PT_Mono({
   weight: "400",
   subsets: ["latin"],
   display: "swap",
+  variable: "--salt-typography-fontFamily-ptMono",
 });
 const openSans = Open_Sans({
   subsets: ["latin"],
   display: "swap",
+  variable: "--salt-typography-fontFamily-openSans",
 });
-
-// Declare the --site-font-family* props so that they are available
-// anywhere on the page. This makes them visible in portals too and
-// ensures that text renders in the correct fonts there too.
-const HeadWithFontStyles = ({ children }: { children: ReactNode }) => (
-  <Head>
-    {children}
-    <style>{`
-    :root {
-      --site-font-family: ${openSans.style.fontFamily};
-      --site-font-family-code: ${ptMono.style.fontFamily};
-    }
-  `}</style>
-  </Head>
-);
 
 export default function MyApp({
   Component,
@@ -113,8 +101,13 @@ export default function MyApp({
   return (
     <SessionProvider>
       <StoreProvider value={createStore()}>
-        <Metadata Component={HeadWithFontStyles} />
-        <ThemeProvider className={themeClassName}>
+        <ThemeProvider
+          themeClassName={clsx(
+            themeClassName,
+            ptMono.variable,
+            openSans.variable,
+          )}
+        >
           <DensityProvider>
             <BaseUrlProvider>
               <ImageProvider value={Image}>


### PR DESCRIPTION
Adds a few theme next controls to component examples, just like mode and density

There should be some priorities  for the new styling options (accent/corner/headingFont/actionFont) for the user to try out. My first thought is two font options is not high priority (also we don't have font file available on the site anyway)

- [ ] Decide which options to show
- [ ] Decide which control to use, same switch / toggle button 
- [ ] Work on page responsiveness 

#3738