### PR TITLE
Update FormField prop descriptions

### DIFF
--- a/packages/core/src/form-field/FormField.tsx
+++ b/packages/core/src/form-field/FormField.tsx
@@ -13,17 +13,17 @@ export interface FormFieldProps
   extends HTMLAttributes<HTMLDivElement>,
     A11yValueProps {
   /**
-   * If `true`, the control will be disabled
+   * If `true`, the field will be disabled.
    */
   disabled?: boolean;
   /**
-   * Location of the label relative to the control
+   * Location of the label relative to the control.
    *
-   * Either 'top', 'left', or 'right'`
+   * Either 'top', 'left', or 'right'`.
    */
   labelPlacement?: FormFieldLabelPlacement;
   /**
-   * If `true`, the control will be read-only
+   * If `true`, the field will be read-only.
    */
   readOnly?: boolean;
   /**

--- a/packages/core/src/form-field/FormField.tsx
+++ b/packages/core/src/form-field/FormField.tsx
@@ -13,15 +13,17 @@ export interface FormFieldProps
   extends HTMLAttributes<HTMLDivElement>,
     A11yValueProps {
   /**
-   * Disabled prop
+   * If `true`, the control will be disabled
    */
   disabled?: boolean;
   /**
-   * Location of the label, values: 'top' (default) or 'left'
+   * Location of the label relative to the control
+   *
+   * Either 'top', 'left', or 'right'`
    */
   labelPlacement?: FormFieldLabelPlacement;
   /**
-   * Readonly prop
+   * If `true`, the control will be read-only
    */
   readOnly?: boolean;
   /**


### PR DESCRIPTION
Closes #3516

- Updated the `labelPlacement` description to include the `'right'` option.
- Updated the `disabled` and `readOnly` prop descriptions to be consistent with other components.