### PR TITLE
Add YARN_NPM_AUTH_TOKEN to release steps and only try remove the chromatic label on PRs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -93,6 +93,7 @@ jobs:
         env:
           LOG_LEVEL: "debug"
       - name: Remove Chromatic label
+        if: ${{ steps.chromatic_branch.outputs.branchName != 'main' }}
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
       - name: Run Storybook build

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -90,6 +90,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_ID: ${{ github.event.comment.id }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
         with:


### PR DESCRIPTION
De-risks #3894. YARN_NPM_AUTH_TOKEN is used by yarn to publish packages. The snapshot is failing on that branch because it's not available. Adding it to main so it can be available and that branch can then be tested.