### PR TITLE
Update relatedComponents in component docs

### DIFF
--- a/site/docs/components/card/index.mdx
+++ b/site/docs/components/card/index.mdx
@@ -11,7 +11,6 @@ data:
   relatedComponents:
     [
       { name: "Panel", relationship: "similarTo" },
-      { name: "Tile", relationship: "similarTo" },
       { name: "Link", relationship: "contains" },
       { name: "Button", relationship: "contains" },
     ]

--- a/site/docs/components/dialog/index.mdx
+++ b/site/docs/components/dialog/index.mdx
@@ -10,7 +10,6 @@ data:
   relatedComponents:
     [
       { name: "Banner", relationship: "similarTo" },
-      { name: "Content status", relationship: "similarTo" },
       { name: "Toast", relationship: "similarTo" },
     ]
   relatedPatterns: ["Preferences dialog"]

--- a/site/docs/components/list-box/index.mdx
+++ b/site/docs/components/list-box/index.mdx
@@ -11,7 +11,6 @@ data:
       # related component here (separated by commas).
       # Permitted values for relationship are: "similarTo" or
       # "contains".
-      { name: "Vertical navigation item", relationship: "similarTo" },
       { name: "Combo box", relationship: "similarTo" },
       { name: "Dropdown", relationship: "similarTo" },
     ]

--- a/site/docs/components/pagination/index.mdx
+++ b/site/docs/components/pagination/index.mdx
@@ -13,7 +13,6 @@ data:
       { name: "Form field", relationship: "contains" },
       { name: "Input", relationship: "contains" },
       { name: "Icon", relationship: "contains" },
-      { name: "Carousel", relationship: "similarTo" },
       { name: "Stepped tracker", relationship: "similarTo" },
     ]
 

--- a/site/docs/components/pagination/index.mdx
+++ b/site/docs/components/pagination/index.mdx
@@ -13,7 +13,6 @@ data:
       { name: "Form field", relationship: "contains" },
       { name: "Input", relationship: "contains" },
       { name: "Icon", relationship: "contains" },
-      { name: "Stepped tracker", relationship: "similarTo" },
     ]
 
 layout: DetailComponent

--- a/site/docs/components/panel/index.mdx
+++ b/site/docs/components/panel/index.mdx
@@ -7,10 +7,7 @@ data:
     name: "@salt-ds/core"
     initialVersion: "1.1.0"
   alsoKnownAs: ["Container", "Pane"]
-  relatedComponents:
-    [
-      { name: "Card", relationship: "similarTo" },
-    ]
+  relatedComponents: [{ name: "Card", relationship: "similarTo" }]
 
 layout: DetailComponent
 ---

--- a/site/docs/components/panel/index.mdx
+++ b/site/docs/components/panel/index.mdx
@@ -10,7 +10,6 @@ data:
   relatedComponents:
     [
       { name: "Card", relationship: "similarTo" },
-      { name: "Tile", relationship: "contains" },
     ]
 
 layout: DetailComponent

--- a/site/docs/components/switch/index.mdx
+++ b/site/docs/components/switch/index.mdx
@@ -20,7 +20,6 @@ data:
       { name: "Pill", relationship: "similarTo" },
       { name: "Radio button", relationship: "similarTo" },
       { name: "Toggle button", relationship: "similarTo" },
-      { name: "Toggle button group", relationship: "similarTo" },
     ]
 
 # Leave this as is

--- a/site/docs/components/tooltip/index.mdx
+++ b/site/docs/components/tooltip/index.mdx
@@ -10,7 +10,6 @@ data:
   relatedComponents:
     [
       { name: "Banner", relationship: "similarTo" },
-      { name: "Content status", relationship: "similarTo" },
       { name: "Overlay", relationship: "similarTo" },
       { name: "Status indicator", relationship: "contains" },
     ]


### PR DESCRIPTION
Removed "similar to" links for nonexistent components: tile, content status, vertical navigation item, carousel, toggle button group and content status 
