### PR TITLE
Remove ComboBox's button when it has nothing to show

### DIFF
--- a/.changeset/pink-bears-refuse.md
+++ b/.changeset/pink-bears-refuse.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Fixed ComboBox having a button when it has nothing to show.

--- a/packages/core/src/__tests__/__e2e__/combo-box/ComboBox.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/combo-box/ComboBox.cy.tsx
@@ -596,9 +596,10 @@ describe("Given a ComboBox", () => {
     cy.findByRole("listbox").should("exist");
   });
 
-  it("should not show a list with no options", () => {
+  it("should not show a list or trigger button with no options", () => {
     cy.mount(<ComboBox open />);
     cy.findByRole("listbox").should("not.exist");
+    cy.findByRole("button").should("not.exist");
   });
 
   it("should clear selected items when the input is cleared and the combo box is single-select", () => {
@@ -680,9 +681,9 @@ describe("Given a ComboBox", () => {
     cy.findByRole("combobox").realClick();
     cy.realType("UNKNOWN");
     cy.realPress("Home");
-    cy.findAllByRole("button").should("have.length", "4");
+    cy.findAllByTestId("pill").should("have.length", "3");
     cy.realPress("Backspace");
-    cy.findAllByRole("button").should("have.length", "3");
+    cy.findAllByTestId("pill").should("have.length", "2");
   });
 
   it("should render the custom floating component", () => {

--- a/packages/core/src/combo-box/ComboBox.tsx
+++ b/packages/core/src/combo-box/ComboBox.tsx
@@ -171,9 +171,12 @@ export const ComboBox = forwardRef(function ComboBox<Item>(
     }
   };
 
+  const hasValidChildren =
+    Children.toArray(children).filter(Boolean).length > 0;
+
   const { x, y, strategy, elements, floating, reference, context } =
     useFloatingUI({
-      open: openState && !readOnly && Children.count(children) > 0,
+      open: openState && !readOnly && hasValidChildren,
       onOpenChange: handleOpenChange,
       placement: "bottom-start",
       strategy: "fixed",
@@ -408,7 +411,7 @@ export const ComboBox = forwardRef(function ComboBox<Item>(
         endAdornment={
           <>
             {endAdornment}
-            {!readOnly ? (
+            {!readOnly && hasValidChildren ? (
               <Button
                 aria-labelledby={clsx(buttonId, formFieldLabelledBy)}
                 aria-label="Show options"
@@ -464,11 +467,7 @@ export const ComboBox = forwardRef(function ComboBox<Item>(
         }
       />
       <OptionList
-        open={
-          (openState || focusedState) &&
-          !readOnly &&
-          Children.count(children) > 0
-        }
+        open={(openState || focusedState) && !readOnly && hasValidChildren}
         collapsed={!openState}
         ref={handleListRef}
         id={listId}


### PR DESCRIPTION
Closes #3637

Updated ComboBox to hide it's trigger button when no content is available to show. This covers two main scenarios:

- When a filter has been applied, and nothing matches that filter.
- When there is no initial data present, but it will be fetched after typing.

# To-do
- [x] Fix / Add tests