### PR TITLE
Refactor stepper input

### DIFF
--- a/.changeset/polite-bags-act.md
+++ b/.changeset/polite-bags-act.md
@@ -1,0 +1,17 @@
+---
+"@salt-ds/lab": minor
+---
+
+- Changed `StepperInput`'s `onChange` to return a value and an optional event.
+- Replaced functionality of Page up and Page down keys in `StepperInput` with Shift + Up arrow and Shift + Down arrow. These keyboard controls change the value by the `block` amount.
+- The `block` amount now explicitly defines the value that is increment or decrement, not a multiplier of `step`.
+
+```tsx
+<StepperInput
+  block={100}
+  value={value}
+  onChange={(_event, value) => {
+    setValue(value);
+  }
+/>
+```

--- a/.changeset/polite-bags-act.md
+++ b/.changeset/polite-bags-act.md
@@ -2,13 +2,17 @@
 "@salt-ds/lab": minor
 ---
 
-- Changed `StepperInput`'s `onChange` to return a value and an optional event.
-- Replaced functionality of Page up and Page down keys in `StepperInput` with Shift + Up arrow and Shift + Down arrow. These keyboard controls change the value by the `block` amount.
-- The `block` amount now explicitly defines the value that is increment or decrement, not a multiplier of `step`.
+## StepperInput updates
+
+- Added `bordered` prop for a full border style
+- `StepperInputProps` extends `div` props instead of `Input`, so align with other similar components
+- Changed `onChange` to an optional event (when triggered by an synthetic event) and value.
+- Added more keyboard interactions, e.g. Shift + Up / Down, Home, End.
+- `stepBlock` replaceds `block` prop, which now explicitly defines the value that is increment or decrement, not a multiplier of `step`.
 
 ```tsx
 <StepperInput
-  block={100}
+  stepBlock={100}
   value={value}
   onChange={(_event, value) => {
     setValue(value);

--- a/.changeset/polite-bags-act.md
+++ b/.changeset/polite-bags-act.md
@@ -5,10 +5,10 @@
 ## StepperInput updates
 
 - Added `bordered` prop for a full border style
-- `StepperInputProps` extends `div` props instead of `Input`, so align with other similar components
-- Changed `onChange` to an optional event (when triggered by an synthetic event) and value.
+- Changed `StepperInputProps` to extend `div` props instead of `Input`, to align with other input components
+- Added an optional event to `onChange`, when triggered by synthetic event
 - Added more keyboard interactions, e.g. Shift + Up / Down, Home, End.
-- `stepBlock` replaceds `block` prop, which now explicitly defines the value that is increment or decrement, not a multiplier of `step`.
+- Replaced `block` with `stepBlock` prop, which now explicitly defines the value that is increment or decrement, not a multiplier of `step`.
 
 ```tsx
 <StepperInput

--- a/docs/components/ResponsiveContainer.tsx
+++ b/docs/components/ResponsiveContainer.tsx
@@ -31,7 +31,7 @@ export const ResponsiveContainer = ({ children }: { children?: ReactNode }) => {
           value={containerWidth[0]}
           max={maxUnits}
           min={10}
-          onChange={(nextValue) => setWidth([nextValue] as number[])}
+          onChange={(_event, nextValue) => setWidth([nextValue as number])}
         />
         <Slider
           className="StoryContainer-slider"
@@ -45,7 +45,7 @@ export const ResponsiveContainer = ({ children }: { children?: ReactNode }) => {
           value={containerHeight[0]}
           max={maxUnits}
           min={10}
-          onChange={(nextValue) => setHeight([nextValue] as number[])}
+          onChange={(_event, nextValue) => setHeight([nextValue as number])}
         />
         <Slider
           className="StoryContainer-slider"

--- a/packages/lab/src/__tests__/__e2e__/stepper-input/StepperInput.accessibility.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/stepper-input/StepperInput.accessibility.cy.tsx
@@ -1,10 +1,16 @@
-import { FormField, FormFieldHelperText, FormFieldLabel } from "@salt-ds/core";
-import { StepperInput } from "@salt-ds/lab";
+import * as stepperInputStories from "@stories/stepper-input/stepper-input.stories";
+import { composeStories } from "@storybook/react";
+import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+
+const composedStories = composeStories(stepperInputStories);
+const { Default } = composedStories;
 
 describe("Stepper Input - Accessibility", () => {
+  checkAccessibility(composedStories);
+
   it("sets the correct default ARIA attributes on input", () => {
     cy.mount(
-      <StepperInput
+      <Default
         decimalPlaces={2}
         defaultValue={-20.1}
         max={250.23}
@@ -19,28 +25,22 @@ describe("Stepper Input - Accessibility", () => {
   });
 
   it("has the correct labelling when wrapped in a `FormField`", () => {
-    cy.mount(
-      <FormField>
-        <FormFieldLabel>Stepper Input</FormFieldLabel>
-        <StepperInput defaultValue={-10} min={0} />
-        <FormFieldHelperText>Please enter a value</FormFieldHelperText>
-      </FormField>,
-    );
+    cy.mount(<Default defaultValue={-10} min={0} />);
 
     cy.findByRole("spinbutton").should("have.accessibleName", "Stepper Input");
     cy.findByRole("spinbutton").should(
       "have.accessibleDescription",
-      "Please enter a value",
+      "Please enter a number",
     );
   });
 
   it("sets `aria-invalid=false` on input when the value is out of range", () => {
-    cy.mount(<StepperInput defaultValue={-10} min={0} />);
+    cy.mount(<Default defaultValue={-10} min={0} />);
     cy.findByRole("spinbutton").should("have.attr", "aria-invalid", "true");
   });
 
   it("sets the correct default ARIA attributes on the increment/decrement buttons", () => {
-    cy.mount(<StepperInput />);
+    cy.mount(<Default />);
     cy.findByLabelText("increment value")
       .should("have.attr", "tabindex", "-1")
       .and("have.attr", "aria-hidden", "true");

--- a/packages/lab/src/__tests__/__e2e__/stepper-input/StepperInput.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/stepper-input/StepperInput.cy.tsx
@@ -3,7 +3,7 @@ import { composeStories } from "@storybook/react";
 
 const composedStories = composeStories(stepperInputStories);
 
-const { Default } = composedStories;
+const { Default, MinAndMaxValue, RefreshAdornment } = composedStories;
 
 describe("Stepper Input", () => {
   it("renders with default props", () => {
@@ -34,7 +34,6 @@ describe("Stepper Input", () => {
   it("increments from an empty value on button click", () => {
     cy.mount(<Default />);
 
-    cy.findByRole("spinbutton").clear();
     cy.findByRole("spinbutton").should("have.value", "");
 
     cy.findByLabelText("increment value").realClick();
@@ -82,32 +81,60 @@ describe("Stepper Input", () => {
     cy.findByRole("spinbutton").should("have.value", "10.0000");
   });
 
-  it("increments by specified `step` value", () => {
+  it("increments specified `step` value when clicking increment button", () => {
     cy.mount(<Default defaultValue={10} step={10} />);
 
     cy.findByLabelText("increment value").realClick();
     cy.findByRole("spinbutton").should("have.value", "20");
   });
 
-  it("increments by specified floating point `step` value", () => {
+  it("increments specified floating point `step` value when clicking increment button", () => {
     cy.mount(<Default decimalPlaces={2} defaultValue={3.14} step={0.01} />);
 
     cy.findByLabelText("increment value").realClick();
     cy.findByRole("spinbutton").should("have.value", "3.15");
   });
 
-  it("decrements by specified `step` value", () => {
+  it("increments specified `step` and `stepBlock` value when using keyboards", () => {
+    cy.mount(
+      <Default defaultValue={10} step={10} stepBlock={100} max={2000} />,
+    );
+
+    cy.findByRole("spinbutton").focus().realPress("ArrowUp");
+    cy.findByRole("spinbutton").should("have.value", "20").realPress("PageUp");
+    cy.findByRole("spinbutton")
+      .should("have.value", "120")
+      .realPress(["Shift", "ArrowUp"]);
+    cy.findByRole("spinbutton").should("have.value", "220").realPress("End");
+    cy.findByRole("spinbutton").should("have.value", "2000");
+  });
+
+  it("decrements specified `step` value when clicking decrement button", () => {
     cy.mount(<Default defaultValue={0} step={10} />);
 
     cy.findByLabelText("decrement value").realClick();
     cy.findByRole("spinbutton").should("have.value", "-10");
   });
 
-  it("decrements by specified floating point `step` value", () => {
+  it("decrements specified floating point `step` value when clicking decrement button", () => {
     cy.mount(<Default decimalPlaces={2} defaultValue={0.0} step={0.01} />);
 
     cy.findByLabelText("decrement value").realClick();
     cy.findByRole("spinbutton").should("have.value", "-0.01");
+  });
+
+  it("decrements specified `step` and `stepBlock` value when using keyboards", () => {
+    cy.mount(
+      <Default defaultValue={10} step={10} stepBlock={100} min={-2000} />,
+    );
+
+    cy.findByRole("spinbutton").focus().realPress("ArrowDown");
+    cy.findByRole("spinbutton").should("have.value", "0").realPress("PageDown");
+    cy.findByRole("spinbutton")
+      .should("have.value", "-100")
+      .realPress(["Shift", "ArrowDown"]);
+    cy.findByRole("spinbutton").should("have.value", "-200").realPress("Home");
+    cy.findByRole("spinbutton").should("have.value", "-2000");
   });
 
   it("disables the increment button at `max`", () => {
@@ -311,5 +338,25 @@ describe("Stepper Input", () => {
     cy.realType("abc-12.3.+-def");
 
     cy.findByRole("spinbutton").should("have.value", "-12.3");
+  });
+
+  it("allows out of range input remains in the input and show status by the user", () => {
+    cy.mount(<MinAndMaxValue />);
+    cy.findByRole("spinbutton").focus();
+    cy.realType("2");
+    cy.realPress("Tab");
+
+    cy.findByRole("spinbutton").should("have.value", "22");
+    cy.findByLabelText("increment value").should("be.disabled");
+    cy.findByTestId("ErrorSolidIcon").should("exist");
+  });
+
+  it("refreshes to default value in RefreshAdornment example", () => {
+    cy.mount(<RefreshAdornment />);
+
+    cy.findByRole("spinbutton").focus().realPress("ArrowUp");
+    cy.findByRole("spinbutton").should("have.value", "11");
+    cy.findByRole("button", { name: "refresh" }).realClick();
+    cy.findByRole("spinbutton").should("have.value", "10");
   });
 });

--- a/packages/lab/src/__tests__/__e2e__/stepper-input/StepperInput.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/stepper-input/StepperInput.cy.tsx
@@ -1,8 +1,13 @@
-import { StepperInput } from "@salt-ds/lab";
+import * as stepperInputStories from "@stories/stepper-input/stepper-input.stories";
+import { composeStories } from "@storybook/react";
+
+const composedStories = composeStories(stepperInputStories);
+
+const { Default } = composedStories;
 
 describe("Stepper Input", () => {
   it("renders with default props", () => {
-    cy.mount(<StepperInput />);
+    cy.mount(<Default />);
     // Component should render with two buttons - increment, and decrement
     cy.findAllByRole("button", { hidden: true }).should("have.length", 2);
 
@@ -11,7 +16,7 @@ describe("Stepper Input", () => {
   });
 
   it("increments the default value on button click", () => {
-    cy.mount(<StepperInput />);
+    cy.mount(<Default />);
 
     cy.findByLabelText("increment value").realClick({ clickCount: 2 });
 
@@ -19,7 +24,7 @@ describe("Stepper Input", () => {
   });
 
   it("decrements the default value on button click", () => {
-    cy.mount(<StepperInput />);
+    cy.mount(<Default />);
 
     cy.findByLabelText("decrement value").realClick({ clickCount: 2 });
 
@@ -27,7 +32,7 @@ describe("Stepper Input", () => {
   });
 
   it("increments from an empty value on button click", () => {
-    cy.mount(<StepperInput />);
+    cy.mount(<Default />);
 
     cy.findByRole("spinbutton").clear();
     cy.findByRole("spinbutton").should("have.value", "");
@@ -38,7 +43,7 @@ describe("Stepper Input", () => {
   });
 
   it("decrements from an empty value on button click", () => {
-    cy.mount(<StepperInput />);
+    cy.mount(<Default />);
 
     cy.findByRole("spinbutton").clear();
     cy.findByRole("spinbutton").should("have.value", "");
@@ -49,7 +54,7 @@ describe("Stepper Input", () => {
   });
 
   it("increments to `1` from a minus symbol on button click", () => {
-    cy.mount(<StepperInput />);
+    cy.mount(<Default />);
 
     cy.findByRole("spinbutton").focus();
     cy.findByRole("spinbutton").clear();
@@ -61,7 +66,7 @@ describe("Stepper Input", () => {
   });
 
   it("decrements to `-1` from a minus symbol on button click", () => {
-    cy.mount(<StepperInput />);
+    cy.mount(<Default />);
 
     cy.findByRole("spinbutton").focus();
     cy.findByRole("spinbutton").clear();
@@ -73,56 +78,54 @@ describe("Stepper Input", () => {
   });
 
   it("renders with specified `defaultValue` and number of `decimalPlaces`", () => {
-    cy.mount(<StepperInput decimalPlaces={4} defaultValue={10} />);
+    cy.mount(<Default decimalPlaces={4} defaultValue={10} />);
     cy.findByRole("spinbutton").should("have.value", "10.0000");
   });
 
   it("increments by specified `step` value", () => {
-    cy.mount(<StepperInput defaultValue={10} step={10} />);
+    cy.mount(<Default defaultValue={10} step={10} />);
 
     cy.findByLabelText("increment value").realClick();
     cy.findByRole("spinbutton").should("have.value", "20");
   });
 
   it("increments by specified floating point `step` value", () => {
-    cy.mount(
-      <StepperInput decimalPlaces={2} defaultValue={3.14} step={0.01} />,
-    );
+    cy.mount(<Default decimalPlaces={2} defaultValue={3.14} step={0.01} />);
 
     cy.findByLabelText("increment value").realClick();
     cy.findByRole("spinbutton").should("have.value", "3.15");
   });
 
   it("decrements by specified `step` value", () => {
-    cy.mount(<StepperInput defaultValue={0} step={10} />);
+    cy.mount(<Default defaultValue={0} step={10} />);
 
     cy.findByLabelText("decrement value").realClick();
     cy.findByRole("spinbutton").should("have.value", "-10");
   });
 
   it("decrements by specified floating point `step` value", () => {
-    cy.mount(<StepperInput decimalPlaces={2} defaultValue={0.0} step={0.01} />);
+    cy.mount(<Default decimalPlaces={2} defaultValue={0.0} step={0.01} />);
 
     cy.findByLabelText("decrement value").realClick();
     cy.findByRole("spinbutton").should("have.value", "-0.01");
   });
 
   it("disables the increment button at `max`", () => {
-    cy.mount(<StepperInput defaultValue={9} max={10} />);
+    cy.mount(<Default defaultValue={9} max={10} />);
 
     cy.findByLabelText("increment value").realClick();
     cy.findByLabelText("increment value").should("be.disabled");
   });
 
   it("disables the decrement button at `min`", () => {
-    cy.mount(<StepperInput defaultValue={1} min={0} />);
+    cy.mount(<Default defaultValue={1} min={0} />);
 
     cy.findByLabelText("decrement value").realClick();
     cy.findByLabelText("decrement value").should("be.disabled");
   });
 
   it("displays value with correct number of decimal places on blur", () => {
-    cy.mount(<StepperInput decimalPlaces={2} />);
+    cy.mount(<Default decimalPlaces={2} />);
 
     cy.findByRole("spinbutton").focus();
     cy.findByRole("spinbutton").clear();
@@ -134,13 +137,13 @@ describe("Stepper Input", () => {
   it("calls the `onChange` callback when the value is decremented", () => {
     const changeSpy = cy.stub().as("changeSpy");
 
-    cy.mount(<StepperInput defaultValue={16} onChange={changeSpy} />);
+    cy.mount(<Default defaultValue={16} onChange={changeSpy} />);
 
     cy.findByLabelText("decrement value").realClick();
     cy.get("@changeSpy").should(
       "have.been.calledWith",
       Cypress.sinon.match.any,
-      "15"
+      "15",
     );
   });
 
@@ -148,7 +151,7 @@ describe("Stepper Input", () => {
     const changeSpy = cy.stub().as("changeSpy");
 
     cy.mount(
-      <StepperInput
+      <Default
         decimalPlaces={2}
         defaultValue={-109.46}
         onChange={changeSpy}
@@ -160,12 +163,12 @@ describe("Stepper Input", () => {
     cy.get("@changeSpy").should(
       "have.been.calledWith",
       Cypress.sinon.match.any,
-      "-109.44"
+      "-109.44",
     );
   });
 
   it("allows maximum safe integer", () => {
-    cy.mount(<StepperInput defaultValue={Number.MAX_SAFE_INTEGER} />);
+    cy.mount(<Default defaultValue={Number.MAX_SAFE_INTEGER} />);
 
     cy.findByRole("spinbutton").should(
       "have.value",
@@ -174,7 +177,7 @@ describe("Stepper Input", () => {
   });
 
   it("allows minimum safe integer", () => {
-    cy.mount(<StepperInput defaultValue={Number.MIN_SAFE_INTEGER} />);
+    cy.mount(<Default defaultValue={Number.MIN_SAFE_INTEGER} />);
 
     cy.findByRole("spinbutton").should(
       "have.value",
@@ -186,10 +189,7 @@ describe("Stepper Input", () => {
     const changeSpy = cy.stub().as("changeSpy");
 
     cy.mount(
-      <StepperInput
-        defaultValue={Number.MAX_SAFE_INTEGER}
-        onChange={changeSpy}
-      />,
+      <Default defaultValue={Number.MAX_SAFE_INTEGER} onChange={changeSpy} />,
     );
 
     cy.findByLabelText("increment value").realClick();
@@ -206,10 +206,7 @@ describe("Stepper Input", () => {
     const changeSpy = cy.stub().as("changeSpy");
 
     cy.mount(
-      <StepperInput
-        defaultValue={Number.MIN_SAFE_INTEGER}
-        onChange={changeSpy}
-      />,
+      <Default defaultValue={Number.MIN_SAFE_INTEGER} onChange={changeSpy} />,
     );
 
     cy.findByLabelText("decrement value").realClick();
@@ -224,7 +221,7 @@ describe("Stepper Input", () => {
 
   it("does not decrement below the minimum value", () => {
     const changeSpy = cy.stub().as("changeSpy");
-    cy.mount(<StepperInput defaultValue={-1} min={-1} onChange={changeSpy} />);
+    cy.mount(<Default defaultValue={-1} min={-1} onChange={changeSpy} />);
 
     cy.findByRole("spinbutton").should("have.value", -1);
 
@@ -235,7 +232,7 @@ describe("Stepper Input", () => {
 
   it("does not increment above the maximum value", () => {
     const changeSpy = cy.stub().as("changeSpy");
-    cy.mount(<StepperInput defaultValue={1} max={1} onChange={changeSpy} />);
+    cy.mount(<Default defaultValue={1} max={1} onChange={changeSpy} />);
 
     cy.findByRole("spinbutton").should("have.value", 1);
 
@@ -245,7 +242,7 @@ describe("Stepper Input", () => {
   });
 
   it("rounds up to correct number of decimal places", () => {
-    cy.mount(<StepperInput decimalPlaces={2} defaultValue={3.145} />);
+    cy.mount(<Default decimalPlaces={2} defaultValue={3.145} />);
 
     cy.findByRole("spinbutton").focus();
     cy.realPress("Tab");
@@ -253,7 +250,7 @@ describe("Stepper Input", () => {
   });
 
   it("rounds down to correct number of decimal places", () => {
-    cy.mount(<StepperInput decimalPlaces={3} defaultValue={-12.3324} />);
+    cy.mount(<Default decimalPlaces={3} defaultValue={-12.3324} />);
 
     cy.findByRole("spinbutton").focus();
     cy.realPress("Tab");
@@ -261,7 +258,7 @@ describe("Stepper Input", () => {
   });
 
   it("pads with zeros to correct number of decimal places", () => {
-    cy.mount(<StepperInput decimalPlaces={3} defaultValue={-5.8} />);
+    cy.mount(<Default decimalPlaces={3} defaultValue={-5.8} />);
 
     cy.findByRole("spinbutton").focus();
     cy.realPress("Tab");
@@ -269,7 +266,7 @@ describe("Stepper Input", () => {
   });
 
   it("increments the value on arrow up key press", () => {
-    cy.mount(<StepperInput />);
+    cy.mount(<Default />);
 
     cy.findByRole("spinbutton").focus();
     cy.realPress("ArrowUp");
@@ -278,7 +275,7 @@ describe("Stepper Input", () => {
   });
 
   it("decrements the value on arrow down key press", () => {
-    cy.mount(<StepperInput />);
+    cy.mount(<Default />);
 
     cy.findByRole("spinbutton").focus();
     cy.realPress("ArrowDown");
@@ -287,7 +284,7 @@ describe("Stepper Input", () => {
   });
 
   it("is disabled when the `disabled` prop is true", () => {
-    cy.mount(<StepperInput disabled />);
+    cy.mount(<Default disabled />);
 
     cy.findByRole("spinbutton").should("be.disabled");
     cy.findByLabelText("increment value").should("be.disabled");
@@ -295,7 +292,7 @@ describe("Stepper Input", () => {
   });
 
   it("is controlled when the `value` prop is provided", () => {
-    cy.mount(<StepperInput value={5} />);
+    cy.mount(<Default value={5} />);
 
     cy.findByRole("spinbutton").should("have.value", "5");
 
@@ -307,7 +304,7 @@ describe("Stepper Input", () => {
   });
 
   it("sanitizes input to only allow numbers, decimal points, and plus/minus symbols", () => {
-    cy.mount(<StepperInput />);
+    cy.mount(<Default />);
 
     cy.findByRole("spinbutton").focus();
     cy.findByRole("spinbutton").clear();

--- a/packages/lab/src/__tests__/__e2e__/stepper-input/StepperInput.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/stepper-input/StepperInput.cy.tsx
@@ -137,7 +137,11 @@ describe("Stepper Input", () => {
     cy.mount(<StepperInput defaultValue={16} onChange={changeSpy} />);
 
     cy.findByLabelText("decrement value").realClick();
-    cy.get("@changeSpy").should("have.been.calledWith", "15");
+    cy.get("@changeSpy").should(
+      "have.been.calledWith",
+      Cypress.sinon.match.any,
+      "15"
+    );
   });
 
   it("calls the `onChange` callback when the value is incremented", () => {
@@ -153,7 +157,11 @@ describe("Stepper Input", () => {
     );
 
     cy.findByLabelText("increment value").realClick();
-    cy.get("@changeSpy").should("have.been.calledWith", "-109.44");
+    cy.get("@changeSpy").should(
+      "have.been.calledWith",
+      Cypress.sinon.match.any,
+      "-109.44"
+    );
   });
 
   it("allows maximum safe integer", () => {
@@ -212,6 +220,28 @@ describe("Stepper Input", () => {
       "have.value",
       Number.MIN_SAFE_INTEGER.toString(),
     );
+  });
+
+  it("does not decrement below the minimum value", () => {
+    const changeSpy = cy.stub().as("changeSpy");
+    cy.mount(<StepperInput defaultValue={-1} min={-1} onChange={changeSpy} />);
+
+    cy.findByRole("spinbutton").should("have.value", -1);
+
+    cy.findByLabelText("decrement value").realClick();
+    cy.get("@changeSpy").should("not.have.been.called");
+    cy.findByRole("spinbutton").should("have.value", -1);
+  });
+
+  it("does not increment above the maximum value", () => {
+    const changeSpy = cy.stub().as("changeSpy");
+    cy.mount(<StepperInput defaultValue={1} max={1} onChange={changeSpy} />);
+
+    cy.findByRole("spinbutton").should("have.value", 1);
+
+    cy.findByLabelText("increment value").realClick();
+    cy.get("@changeSpy").should("not.have.been.called");
+    cy.findByRole("spinbutton").should("have.value", 1);
   });
 
   it("rounds up to correct number of decimal places", () => {

--- a/packages/lab/src/__tests__/__e2e__/stepper-input/StepperInput.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/stepper-input/StepperInput.cy.tsx
@@ -34,6 +34,7 @@ describe("Stepper Input", () => {
   it("increments from an empty value on button click", () => {
     cy.mount(<Default />);
 
+    cy.findByRole("spinbutton").clear();
     cy.findByRole("spinbutton").should("have.value", "");
 
     cy.findByLabelText("increment value").realClick();

--- a/packages/lab/src/stepper-input/StepperInput.css
+++ b/packages/lab/src/stepper-input/StepperInput.css
@@ -6,6 +6,18 @@
   gap: var(--salt-spacing-50);
 }
 
+.saltStepperInput-textAlignLeft {
+  text-align: left;
+}
+
+.saltStepperInput-textAlignCenter {
+  text-align: center;
+}
+
+.saltStepperInput-textAlignRight {
+  text-align: right;
+}
+
 /* Styles applied to stepper buttons container */
 .saltStepperInput-buttonContainer {
   display: flex;
@@ -14,7 +26,8 @@
 }
 
 /* Styles applied to stepper buttons */
-.saltStepperInput-stepperButton {
+.saltStepperInput-stepperButtonIncrement,
+.saltStepperInput-stepperButtonDecrement {
   --saltButton-height: calc((var(--salt-size-base) - var(--salt-spacing-50)) * 0.5);
   --saltButton-width: var(--salt-size-base);
 }

--- a/packages/lab/src/stepper-input/StepperInput.css
+++ b/packages/lab/src/stepper-input/StepperInput.css
@@ -1,33 +1,290 @@
 /* Styles applied to stepper container */
 .saltStepperInput {
+  --stepperInput-border: none;
+  --stepperInput-borderColor: var(--salt-editable-borderColor);
+  --stepperInput-borderStyle: var(--salt-editable-borderStyle);
+  --stepperInput-outlineColor: var(--salt-focused-outlineColor);
+  --stepperInput-borderWidth: var(--salt-size-border);
+
   align-items: center;
-  display: flex;
-  flex-direction: row;
+  color: var(--salt-content-primary-foreground);
+  display: inline-flex;
+  font-family: var(--salt-text-fontFamily);
+  font-size: var(--salt-text-fontSize);
+  height: var(--salt-size-base);
+  line-height: var(--salt-text-lineHeight);
+  min-height: var(--salt-size-base);
+  min-width: 4em;
+  width: 100%;
+  box-sizing: border-box;
+
   gap: var(--salt-spacing-50);
 }
 
-.saltStepperInput-textAlignLeft {
+.saltStepperInput:hover {
+  --stepperInput-borderStyle: var(--salt-editable-borderStyle-hover);
+  --stepperInput-borderColor: var(--salt-editable-borderColor-hover);
+
+  background: var(--stepperInput-background-hover);
+  cursor: var(--salt-editable-cursor-hover);
+}
+
+.saltStepperInput:active {
+  --stepperInput-borderColor: var(--salt-editable-borderColor-active);
+  --stepperInput-borderStyle: var(--salt-editable-borderStyle-active);
+  --stepperInput-borderWidth: var(--salt-editable-borderWidth-active);
+
+  background: var(--stepperInput-background-active);
+  cursor: var(--salt-editable-cursor-active);
+}
+
+/* Class applied if `variant="primary"` */
+.saltStepperInput-primary {
+  --stepperInput-background: var(--salt-editable-primary-background);
+  --stepperInput-background-active: var(--salt-editable-primary-background-active);
+  --stepperInput-background-hover: var(--salt-editable-primary-background-hover);
+  --stepperInput-background-disabled: var(--salt-editable-primary-background-disabled);
+  --stepperInput-background-readonly: var(--salt-editable-primary-background-readonly);
+}
+
+/* Class applied if `variant="secondary"` */
+.saltStepperInput-secondary {
+  --stepperInput-background: var(--salt-editable-secondary-background);
+  --stepperInput-background-active: var(--salt-editable-secondary-background-active);
+  --stepperInput-background-hover: var(--salt-editable-secondary-background-active);
+  --stepperInput-background-disabled: var(--salt-editable-secondary-background-disabled);
+  --stepperInput-background-readonly: var(--salt-editable-secondary-background-readonly);
+}
+
+/* Style applied to input if `validationState="error"` */
+.saltStepperInput-error,
+.saltStepperInput-error:hover {
+  --stepperInput-background: var(--salt-status-error-background);
+  --stepperInput-background-active: var(--salt-status-error-background);
+  --stepperInput-background-hover: var(--salt-status-error-background);
+  --stepperInput-borderColor: var(--salt-status-error-borderColor);
+  --stepperInput-outlineColor: var(--salt-status-error-borderColor);
+  --stepperInput-background-readonly: var(--salt-status-error-background);
+}
+
+/* Style applied to input if `validationState="warning"` */
+.saltStepperInput-warning,
+.saltStepperInput-warning:hover {
+  --stepperInput-background: var(--salt-status-warning-background);
+  --stepperInput-background-active: var(--salt-status-warning-background);
+  --stepperInput-background-hover: var(--salt-status-warning-background);
+  --stepperInput-borderColor: var(--salt-status-warning-borderColor);
+  --stepperInput-outlineColor: var(--salt-status-warning-borderColor);
+  --stepperInput-background-readonly: var(--salt-status-warning-background);
+}
+
+/* Style applied to input if `validationState="success"` */
+.saltStepperInput-success,
+.saltStepperInput-success:hover {
+  --stepperInput-background: var(--salt-status-success-background);
+  --stepperInput-background-active: var(--salt-status-success-background);
+  --stepperInput-background-hover: var(--salt-status-success-background);
+  --stepperInput-borderColor: var(--salt-status-success-borderColor);
+  --stepperInput-outlineColor: var(--salt-status-success-borderColor);
+  --stepperInput-background-readonly: var(--salt-status-success-background);
+}
+
+.saltStepperInput-inputContainer {
+  display: flex;
+  background: var(--stepperInput-background);
+  border-radius: var(--salt-palette-corner-weak, 0);
+  border: var(--stepperInput-border);
+  box-sizing: border-box;
+  height: var(--salt-size-base);
+  min-height: var(--salt-size-base);
+  overflow: hidden;
+  padding-left: var(--salt-spacing-100);
+  padding-right: var(--salt-spacing-100);
+  position: relative;
+}
+
+/* Style applied to inner input component */
+.saltStepperInput-input {
+  background: none;
+  border: none;
+  box-sizing: content-box;
+  color: inherit;
+  cursor: inherit;
+  display: block;
+  flex: 1;
+  font: inherit;
+  height: 100%;
+  letter-spacing: var(--saltStepperInput-letterSpacing, 0);
+  margin: 0;
+  min-width: 0;
+  overflow: hidden;
+  padding: 0;
+  text-align: var(--stepperInput-textAlign);
+  width: 100%;
+}
+
+.saltStepperInput-input:focus {
+  outline: none;
+}
+
+/* Style applied to selected input */
+.saltStepperInput-input::selection {
+  background: var(--salt-content-foreground-highlight);
+}
+
+/* Style applied to placeholder text */
+.saltStepperInput-input::placeholder {
+  color: var(--salt-content-secondary-foreground);
+  font-weight: var(--salt-text-fontWeight-small);
+}
+
+/* Styling when focused */
+.saltStepperInput-focused {
+  --stepperInput-borderColor: var(--stepperInput-outlineColor);
+  --stepperInput-borderWidth: var(--salt-editable-borderWidth-active);
+
+  outline: var(--saltStepperInput-outline, var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--stepperInput-outlineColor));
+}
+
+/* Style applied if `readOnly={true}` */
+.saltStepperInput-readOnly {
+  --stepperInput-borderColor: var(--salt-editable-borderColor-readonly);
+  --stepperInput-borderStyle: var(--salt-editable-borderStyle-readonly);
+  --stepperInput-borderWidth: var(--salt-size-border);
+
+  background: var(--stepperInput-background-readonly);
+  cursor: var(--salt-editable-cursor-readonly);
+}
+
+/* Styling when focused if `disabled={true}` */
+.saltStepperInput-focused.saltStepperInput-disabled {
+  --stepperInput-borderWidth: var(--salt-size-border);
+  outline: none;
+}
+
+/* Styling when focused if `readOnly={true}` */
+.saltStepperInput-focused.saltStepperInput-readOnly {
+  --stepperInput-borderWidth: var(--salt-size-border);
+}
+
+/* Style applied to selected input if `disabled={true}` */
+.saltStepperInput-disabled .saltStepperInput-input::selection {
+  background: none;
+}
+
+/* Style applied to input if `disabled={true}` */
+.saltStepperInput-disabled,
+.saltStepperInput-disabled:hover,
+.saltStepperInput-disabled:active {
+  --stepperInput-borderColor: var(--salt-editable-borderColor-disabled);
+  --stepperInput-borderStyle: var(--salt-editable-borderStyle-disabled);
+  --stepperInput-borderWidth: var(--salt-size-border);
+
+  background: var(--stepperInput-background-disabled);
+  cursor: var(--salt-editable-cursor-disabled);
+  color: var(--saltStepperInput-color-disabled, var(--salt-content-primary-foreground-disabled));
+}
+
+.saltStepperInput-activationIndicator {
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  position: absolute;
+  border-bottom: var(--stepperInput-borderWidth) var(--stepperInput-borderStyle) var(--stepperInput-borderColor);
+}
+
+/* Style applied if `bordered={true}` */
+.saltStepperInput-bordered {
+  --stepperInput-border: var(--salt-size-border) var(--salt-container-borderStyle) var(--stepperInput-borderColor);
+  --stepperInput-borderWidth: 0;
+}
+
+/* Style applied if focused or active when `bordered={true}` */
+.saltStepperInput-bordered.saltStepperInput-focused,
+.saltStepperInput-bordered:active {
+  --stepperInput-borderWidth: var(--salt-editable-borderWidth-active);
+}
+
+/* Styling when focused if `disabled={true}` or `readOnly={true}` when `bordered={true}` */
+.saltStepperInput-bordered.saltStepperInput-readOnly,
+.saltStepperInput-bordered.saltStepperInput-disabled:hover {
+  --stepperInput-borderWidth: 0;
+}
+
+/* Style applied to start adornments */
+.saltStepperInput-startAdornmentContainer {
+  align-items: center;
+  display: inline-flex;
+  padding-right: var(--salt-spacing-100);
+  column-gap: var(--salt-spacing-100);
+}
+
+/* Style applied to end adornments */
+.saltStepperInput-endAdornmentContainer {
+  align-items: center;
+  display: inline-flex;
+  padding-left: var(--salt-spacing-100);
+  column-gap: var(--salt-spacing-100);
+}
+
+.saltStepperInput-readOnly .saltStepperInput-startAdornmentContainer {
+  margin-left: var(--salt-spacing-50);
+}
+
+.saltStepperInput-startAdornmentContainer .saltButton ~ .saltButton {
+  margin-left: calc(-1 * var(--salt-spacing-50));
+}
+
+.saltStepperInput-endAdornmentContainer .saltButton ~ .saltButton {
+  margin-left: calc(-1 * var(--salt-spacing-50));
+}
+
+.saltStepperInput-startAdornmentContainer .saltButton:first-child {
+  margin-left: calc(var(--salt-spacing-50) * -1);
+}
+
+.saltStepperInput-endAdornmentContainer .saltButton:last-child {
+  margin-right: calc(var(--salt-spacing-50) * -1);
+}
+
+.saltStepperInput-startAdornmentContainer > .saltButton,
+.saltStepperInput-endAdornmentContainer > .saltButton {
+  --saltButton-padding: calc(var(--salt-spacing-50) - var(--salt-size-border));
+  --saltButton-height: calc(var(--salt-size-base) - var(--salt-spacing-100));
+  --saltButton-borderRadius: var(--salt-palette-corner-weaker);
+}
+
+.saltStepperInput-inputTextAlignLeft {
   text-align: left;
 }
 
-.saltStepperInput-textAlignCenter {
+.saltStepperInput-inputTextAlignCenter {
   text-align: center;
 }
 
-.saltStepperInput-textAlignRight {
+.saltStepperInput-inputTextAlignRight {
   text-align: right;
 }
 
+/* --- Buttons --- */
+
 /* Styles applied to stepper buttons container */
 .saltStepperInput-buttonContainer {
+  --stepperInput-buttonGap: var(--salt-size-border-strong);
   display: flex;
   flex-direction: column;
-  gap: var(--salt-spacing-50);
+  gap: var(--stepperInput-buttonGap);
 }
 
 /* Styles applied to stepper buttons */
-.saltStepperInput-stepperButtonIncrement,
-.saltStepperInput-stepperButtonDecrement {
-  --saltButton-height: calc((var(--salt-size-base) - var(--salt-spacing-50)) * 0.5);
+.saltStepperInput-stepperButton {
+  --saltButton-height: calc((var(--salt-size-base) - var(--stepperInput-buttonGap)) * 0.5);
   --saltButton-width: var(--salt-size-base);
+}
+
+.saltStepperInput-stepperButtonIncrement {
+  --saltButton-borderRadius: var(--salt-palette-corner-weak, 0) var(--salt-palette-corner-weak, 0) 0 0;
+}
+.saltStepperInput-stepperButtonDecrement {
+  --saltButton-borderRadius: 0 0 var(--salt-palette-corner-weak, 0) var(--salt-palette-corner-weak, 0);
 }

--- a/packages/lab/src/stepper-input/StepperInput.css
+++ b/packages/lab/src/stepper-input/StepperInput.css
@@ -101,6 +101,7 @@
   padding-left: var(--salt-spacing-100);
   padding-right: var(--salt-spacing-100);
   position: relative;
+  flex-grow: 1;
 }
 
 /* Style applied to inner input component */

--- a/packages/lab/src/stepper-input/StepperInput.tsx
+++ b/packages/lab/src/stepper-input/StepperInput.tsx
@@ -1,26 +1,49 @@
-import { Button, Input, type InputProps, makePrefixer } from "@salt-ds/core";
+import {
+  Button,
+  Input,
+  type InputProps,
+  type ValidationStatus,
+  capitalize,
+  makePrefixer,
+  useControlled,
+  useFormFieldProps,
+  useId,
+} from "@salt-ds/core";
 import { TriangleDownIcon, TriangleUpIcon } from "@salt-ds/icons";
 import { useComponentCssInjection } from "@salt-ds/styles";
 import { useWindow } from "@salt-ds/window";
 import { clsx } from "clsx";
 import {
+  type ComponentPropsWithoutRef,
   type FocusEventHandler,
+  type InputHTMLAttributes,
+  type ReactNode,
+  type Ref,
   type SyntheticEvent,
   forwardRef,
   useRef,
 } from "react";
-import { useStepperInput } from "./useStepperInput";
+import {
+  ACCEPT_INPUT,
+  isAllowedNonNumeric,
+  sanitizedInput,
+  toFixedDecimalPlaces,
+  toFloat,
+} from "./internal/utils";
 
 import stepperInputCss from "./StepperInput.css";
 
 const withBaseName = makePrefixer("saltStepperInput");
 
 export interface StepperInputProps
-  extends Omit<InputProps, "onChange" | "emptyReadOnlyMarker"> {
+  extends Omit<
+    ComponentPropsWithoutRef<"div">,
+    "onChange" | "emptyReadOnlyMarker"
+  > {
   /**
-   * The amount to change the value when the value is incremented or decremented by holding Shift and pressing Up arrow or Down arrow keys.
+   * A boolean. When `true`, the input will receive a full border.
    */
-  block?: number;
+  bordered?: boolean;
   /**
    * The number of decimal places to display.
    */
@@ -28,23 +51,44 @@ export interface StepperInputProps
   /**
    * Sets the initial default value of the component.
    */
-  defaultValue?: number;
+  defaultValue?: number | string;
+  /**
+   * If `true`, the stepper input will be disabled.
+   */
+  disabled?: boolean;
+  /**
+   * The marker to use in an empty read only Input.
+   * Use `''` to disable this feature. Defaults to '—'.
+   * @default '—'
+   */
+  emptyReadOnlyMarker?: string;
+  /**
+   * End adornment component
+   */
+  endAdornment?: ReactNode;
   /**
    * Whether to hide the stepper buttons. Defaults to `false`.
+   * @default false
    */
   hideButtons?: boolean;
   /**
-   * The maximum value that can be selected.
+   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `input` element.
+   */
+  inputProps?: InputHTMLAttributes<HTMLInputElement>;
+  /**
+   * Optional ref for the input component
+   */
+  inputRef?: Ref<HTMLInputElement>;
+  /**
+   * The maximum value that can be selected. Defaults to Number.MAX_SAFE_INTEGER.
+   * @default Number.MAX_SAFE_INTEGER
    */
   max?: number;
   /**
-   * The minimum value that can be selected.
+   * The minimum value that can be selected. Defaults to Number.MIN_SAFE_INTEGER.
+   * @default Number.MIN_SAFE_INTEGER
    */
   min?: number;
-  /**
-   * Callback when stepper input loses focus.
-   */
-  onBlur?: FocusEventHandler<HTMLInputElement>;
   /**
    * Callback when stepper input value is changed.
    */
@@ -53,35 +97,77 @@ export interface StepperInputProps
     value: number | string,
   ) => void;
   /**
-   * Callback when stepper input gains focus.
+   * A string. Displayed in a dimmed color when the input value is empty.
    */
-  onFocus?: FocusEventHandler<HTMLInputElement>;
+  placeholder?: string | undefined;
   /**
-   * The amount to increment or decrement the value by when using the stepper buttons or Up Arrow and Down Arrow keys.
+   * A boolean. If `true`, the component is not editable by the user.
+   */
+  readOnly?: boolean;
+  /**
+   * Start adornment component
+   */
+  startAdornment?: ReactNode;
+  /**
+   * The amount to increment or decrement the value by when using the stepper buttons or Up Arrow and Down Arrow keys. Default to 1.
+   * @default 1
    */
   step?: number;
   /**
-   * Determines the text alignment of the display value.
+   * The amount to change the value when the value is incremented or decremented by holding Shift and pressing Up arrow or Down arrow keys.
+   * Defaults to 10.
+   * @default 10
    */
-  textAlign?: "center" | "left" | "right";
+  stepBlock?: number;
+  /**
+   * Alignment of text within container. Defaults to "left".
+   * @default "left"
+   */
+  textAlign?: "left" | "center" | "right";
+  /**
+   * Validation status.
+   */
+  validationStatus?: Extract<ValidationStatus, "error" | "warning" | "success">;
+  /**
+   * Styling variant. Defaults to "primary".
+   * @default "primary"
+   */
+  variant?: "primary" | "secondary";
   /**
    * The value of the stepper input. The component will be controlled if this prop is provided.
    */
-  value?: number | string;
+  value?: number | string | undefined;
 }
 
 export const StepperInput = forwardRef<HTMLDivElement, StepperInputProps>(
-  function StepperInput(props, ref) {
-    const {
-      className,
+  function StepperInput(
+    {
+      bordered,
+      className: classNameProp,
+      decimalPlaces = 0,
+      defaultValue: defaultValueProp,
+      disabled,
+      emptyReadOnlyMarker = "—",
+      endAdornment,
       hideButtons,
-      onBlur,
+      id: idProp,
+      inputProps = {},
+      inputRef,
+      max = Number.MAX_SAFE_INTEGER,
+      min = Number.MIN_SAFE_INTEGER,
       onChange,
-      onFocus,
+      placeholder,
       readOnly,
-      ...rest
-    } = props;
-
+      step = 1,
+      stepBlock = 10,
+      textAlign = "left",
+      validationStatus: validationStatusProp,
+      value: valueProp,
+      variant = "primary",
+      ...restProps
+    },
+    ref,
+  ) {
     const targetWindow = useWindow();
     useComponentCssInjection({
       testId: "salt-stepper-input",
@@ -89,31 +175,79 @@ export const StepperInput = forwardRef<HTMLDivElement, StepperInputProps>(
       window: targetWindow,
     });
 
-    const inputRef = useRef<HTMLInputElement | null>(null);
+    const {
+      a11yProps: {
+        "aria-describedby": formFieldDescribedBy,
+        "aria-labelledby": formFieldLabelledBy,
+      } = {},
+      disabled: formFieldDisabled,
+      readOnly: formFieldReadOnly,
+      necessity: formFieldRequired,
+      validationStatus: formFieldValidationStatus,
+    } = useFormFieldProps();
 
-    const { getButtonProps, getInputProps } = useStepperInput(props, inputRef);
+    const {
+      "aria-describedby": inputDescribedBy,
+      "aria-labelledby": inputLabelledBy,
+      onBlur,
+      onChange: inputOnChange,
+      onFocus,
+      required: inputPropsRequired,
+      ...restInputProps
+    } = inputProps;
+
+    const inputId = useId(idProp);
+
+    const [value, setValue, isControlled] = useControlled({
+      controlled: valueProp,
+      default:
+        typeof defaultValueProp === "number"
+          ? toFixedDecimalPlaces(defaultValueProp, decimalPlaces)
+          : undefined,
+      name: "StepperInput",
+      state: "value",
+    });
+
+    const setNextValue = (
+      event: SyntheticEvent | undefined,
+      modifiedValue: number,
+    ) => {
+      if (readOnly) return;
+      let nextValue = modifiedValue;
+      if (nextValue < min) nextValue = min;
+      if (nextValue > max) nextValue = max;
+
+      const roundedValue = toFixedDecimalPlaces(nextValue, decimalPlaces);
+      if (Number.isNaN(toFloat(roundedValue))) return;
+
+      setValue(roundedValue);
+
+      onChange?.(event, roundedValue);
+    };
 
     return (
-      <div className={clsx(withBaseName(), className)} ref={ref}>
-        <Input
-          onBlur={onBlur}
-          onFocus={onFocus}
-          ref={inputRef}
-          readOnly={readOnly}
-          {...getInputProps(rest)}
-        />
+      <div
+        className={clsx(
+          withBaseName(),
+          withBaseName(variant),
+          withBaseName(`textAlign${capitalize(textAlign)}`),
+          classNameProp,
+        )}
+        {...restProps}
+        ref={ref}
+      >
         {!hideButtons && !readOnly && (
           <div className={withBaseName("buttonContainer")}>
             <Button
               aria-label="increment value"
-              className={withBaseName("stepperButton")}
+              className={withBaseName("stepperButtonIncrement")}
               {...getButtonProps("increment")}
             >
               <TriangleUpIcon aria-hidden />
             </Button>
             <Button
               aria-label="decrement value"
-              className={withBaseName("stepperButton")}
+              className={withBaseName("stepperButtonDecrement")}
               {...getButtonProps("decrement")}
             >
               <TriangleDownIcon aria-hidden />

--- a/packages/lab/src/stepper-input/StepperInput.tsx
+++ b/packages/lab/src/stepper-input/StepperInput.tsx
@@ -3,7 +3,12 @@ import { TriangleDownIcon, TriangleUpIcon } from "@salt-ds/icons";
 import { useComponentCssInjection } from "@salt-ds/styles";
 import { useWindow } from "@salt-ds/window";
 import { clsx } from "clsx";
-import { type FocusEventHandler, forwardRef, useRef } from "react";
+import {
+  type FocusEventHandler,
+  type SyntheticEvent,
+  forwardRef,
+  useRef,
+} from "react";
 import { useStepperInput } from "./useStepperInput";
 
 import stepperInputCss from "./StepperInput.css";
@@ -13,7 +18,7 @@ const withBaseName = makePrefixer("saltStepperInput");
 export interface StepperInputProps
   extends Omit<InputProps, "onChange" | "emptyReadOnlyMarker"> {
   /**
-   * A multiplier applied to the `step` when the value is incremented or decremented using the PageDown/PageUp keys.
+   * The amount to change the value when the value is incremented or decremented by holding Shift and pressing Up arrow or Down arrow keys.
    */
   block?: number;
   /**
@@ -25,6 +30,10 @@ export interface StepperInputProps
    */
   defaultValue?: number;
   /**
+   * Whether to hide the stepper buttons. Defaults to `false`.
+   */
+  hideButtons?: boolean;
+  /**
    * The maximum value that can be selected.
    */
   max?: number;
@@ -33,17 +42,16 @@ export interface StepperInputProps
    */
   min?: number;
   /**
-   * Whether to hide the stepper buttons. Defaults to `false`.
-   */
-  hideButtons?: boolean;
-  /**
    * Callback when stepper input loses focus.
    */
   onBlur?: FocusEventHandler<HTMLInputElement>;
   /**
    * Callback when stepper input value is changed.
    */
-  onChange?: (changedValue: number | string) => void;
+  onChange?: (
+    event: SyntheticEvent | undefined,
+    value: number | string,
+  ) => void;
   /**
    * Callback when stepper input gains focus.
    */

--- a/packages/lab/src/stepper-input/StepperInput.tsx
+++ b/packages/lab/src/stepper-input/StepperInput.tsx
@@ -1,7 +1,5 @@
 import {
   Button,
-  Input,
-  type InputProps,
   StatusAdornment,
   type ValidationStatus,
   capitalize,
@@ -9,7 +7,6 @@ import {
   useControlled,
   useForkRef,
   useFormFieldProps,
-  useId,
 } from "@salt-ds/core";
 import { TriangleDownIcon, TriangleUpIcon } from "@salt-ds/icons";
 import { useComponentCssInjection } from "@salt-ds/styles";
@@ -29,7 +26,6 @@ import {
   useState,
 } from "react";
 import {
-  ACCEPT_INPUT,
   isAllowedNonNumeric,
   isOutOfRange,
   sanitizedInput,

--- a/packages/lab/src/stepper-input/internal/useActivateWhileMouseDown.ts
+++ b/packages/lab/src/stepper-input/internal/useActivateWhileMouseDown.ts
@@ -4,7 +4,7 @@ import { useInterval } from "./useInterval";
 const INITIAL_DELAY = 500;
 const INTERVAL_DELAY = 100;
 
-function useSpinner(
+export function useActivateWhileMouseDown(
   activationFn: (event?: SyntheticEvent) => void,
   isAtLimit: boolean,
 ) {
@@ -47,5 +47,3 @@ function useSpinner(
 
   return { activate, buttonDown };
 }
-
-export { useSpinner };

--- a/packages/lab/src/stepper-input/internal/useActivateWhileMouseDown.ts
+++ b/packages/lab/src/stepper-input/internal/useActivateWhileMouseDown.ts
@@ -1,3 +1,4 @@
+import { useWindow } from "@salt-ds/window";
 import { type SyntheticEvent, useCallback, useEffect, useState } from "react";
 import { useInterval } from "./useInterval";
 
@@ -21,9 +22,14 @@ export function useActivateWhileMouseDown(
   }, [isAtLimit, cancelInterval]);
 
   useEffect(() => {
-    window.addEventListener("mouseup", cancelInterval);
+    const targetWindow = useWindow();
+    if (targetWindow) {
+      targetWindow.addEventListener("mouseup", cancelInterval);
+    }
     return () => {
-      window.removeEventListener("mouseup", cancelInterval);
+      if (targetWindow) {
+        targetWindow.removeEventListener("mouseup", cancelInterval);
+      }
     };
   }, [cancelInterval]);
 

--- a/packages/lab/src/stepper-input/internal/useActivateWhileMouseDown.ts
+++ b/packages/lab/src/stepper-input/internal/useActivateWhileMouseDown.ts
@@ -21,8 +21,9 @@ export function useActivateWhileMouseDown(
     if (isAtLimit) cancelInterval();
   }, [isAtLimit, cancelInterval]);
 
+  const targetWindow = useWindow();
+
   useEffect(() => {
-    const targetWindow = useWindow();
     if (targetWindow) {
       targetWindow.addEventListener("mouseup", cancelInterval);
     }
@@ -31,7 +32,7 @@ export function useActivateWhileMouseDown(
         targetWindow.removeEventListener("mouseup", cancelInterval);
       }
     };
-  }, [cancelInterval]);
+  }, [cancelInterval, targetWindow]);
 
   const activate = (event: SyntheticEvent) => {
     activationFn(event);

--- a/packages/lab/src/stepper-input/internal/utils.ts
+++ b/packages/lab/src/stepper-input/internal/utils.ts
@@ -1,0 +1,44 @@
+// The input should only accept numbers, decimal points, and plus/minus symbols
+export const ACCEPT_INPUT = /^[-+]?[0-9]*\.?([0-9]+)?/g;
+
+export const toFixedDecimalPlaces = (
+  inputNumber: number,
+  decimalPlaces: number,
+) => inputNumber.toFixed(decimalPlaces);
+
+export const isAllowedNonNumeric = (inputCharacter: number | string) => {
+  if (typeof inputCharacter === "number") return;
+  return (
+    ("-+".includes(inputCharacter) && inputCharacter.length === 1) ||
+    inputCharacter === ""
+  );
+};
+
+export const toFloat = (inputValue: number | string) => {
+  // Plus, minus, and empty characters are treated as 0
+  if (isAllowedNonNumeric(inputValue)) return 0;
+  return Number.parseFloat(inputValue.toString());
+};
+
+export const sanitizedInput = (numberString: string) =>
+  (numberString.match(ACCEPT_INPUT) || []).join("");
+
+export const isAtMax = (value: number | string | undefined, max: number) => {
+  if (value === undefined) return true;
+  return toFloat(value) >= max;
+};
+
+export const isAtMin = (value: number | string | undefined, min: number) => {
+  if (value === undefined) return true;
+  return toFloat(value) <= min;
+};
+
+export const isOutOfRange = (
+  value: number | string | undefined,
+  min: number,
+  max: number,
+) => {
+  if (value === undefined) return true;
+  const floatValue = toFloat(value);
+  return floatValue > max || floatValue < min;
+};

--- a/packages/lab/stories/stepper-input/stepper-input.qa.stories.tsx
+++ b/packages/lab/stories/stepper-input/stepper-input.qa.stories.tsx
@@ -9,7 +9,7 @@ export default {
 
 export const ExamplesGrid: StoryFn<QAContainerProps> = (props) => {
   return (
-    <QAContainer {...props}>
+    <QAContainer itemPadding={4} {...props}>
       <StepperInput
         decimalPlaces={2}
         defaultValue={0.5}
@@ -35,7 +35,7 @@ export const ExamplesGrid: StoryFn<QAContainerProps> = (props) => {
       />
       <StepperInput
         decimalPlaces={2}
-        defaultValue={0.5}
+        defaultValue="readOnly"
         max={10}
         min={-5}
         readOnly
@@ -43,12 +43,19 @@ export const ExamplesGrid: StoryFn<QAContainerProps> = (props) => {
       />
       <StepperInput
         decimalPlaces={2}
-        defaultValue={0.5}
+        defaultValue="disabled"
         disabled
         max={10}
         min={-5}
         step={0.5}
       />
+      <StepperInput value="bordered" bordered />
+      <StepperInput validationStatus="success" value="success" />
+      <StepperInput validationStatus="error" value="error" />
+      <StepperInput validationStatus="warning" value="warning" />
+      <StepperInput value="success" bordered validationStatus="success" />
+      <StepperInput value="error" bordered validationStatus="error" />
+      <StepperInput value="warning" bordered validationStatus="warning" />
     </QAContainer>
   );
 };

--- a/packages/lab/stories/stepper-input/stepper-input.qa.stories.tsx
+++ b/packages/lab/stories/stepper-input/stepper-input.qa.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryFn } from "@storybook/react";
 import { QAContainer, type QAContainerProps } from "docs/components";
 
 export default {
-  title: "Lab/Stepper Input/QA",
+  title: "Lab/Stepper Input/Stepper Input QA",
   component: StepperInput,
 } as Meta<typeof StepperInput>;
 

--- a/packages/lab/stories/stepper-input/stepper-input.stories.tsx
+++ b/packages/lab/stories/stepper-input/stepper-input.stories.tsx
@@ -4,7 +4,6 @@ import {
   FormFieldHelperText,
   FormFieldLabel,
   StackLayout,
-  Text,
 } from "@salt-ds/core";
 import { AddIcon, RefreshIcon, RemoveIcon } from "@salt-ds/icons";
 import { StepperInput } from "@salt-ds/lab";
@@ -44,6 +43,36 @@ export const DecimalPlaces: StoryFn = (args) => {
   );
 };
 
+export const Controlled: StoryFn = (args) => {
+  const [value, setValue] = useState<number | string>(1.11);
+
+  return (
+    <FormField>
+      <FormFieldLabel>Stepper Input</FormFieldLabel>
+      <StepperInput
+        {...args}
+        decimalPlaces={2}
+        value={value}
+        onChange={(_event, value) => {
+          setValue(value);
+        }}
+        endAdornment={
+          <Button
+            variant="secondary"
+            aria-label="refresh"
+            onClick={() => setValue(1.11)}
+          >
+            <RefreshIcon aria-hidden />
+          </Button>
+        }
+      />
+      <FormFieldHelperText>
+        The stepper input value is: {value}
+      </FormFieldHelperText>
+    </FormField>
+  );
+};
+
 export const MinAndMaxValue: StoryFn = (args) => {
   const [value, setValue] = useState<number | string>(2);
   const max = 5;
@@ -69,7 +98,9 @@ export const MinAndMaxValue: StoryFn = (args) => {
       <StepperInput
         {...args}
         value={value}
-        onChange={(changedValue) => setValue(changedValue)}
+        onChange={(_event, value) => {
+          setValue(value);
+        }}
         max={max}
         min={min}
         style={{ width: "250px" }}
@@ -110,7 +141,9 @@ export const RefreshAdornment: StoryFn = (args) => {
       <StepperInput
         {...args}
         value={value}
-        onChange={(changedValue) => setValue(changedValue)}
+        onChange={(_event, value) => {
+          setValue(value);
+        }}
         endAdornment={
           <Button
             variant="secondary"
@@ -136,11 +169,13 @@ export const HideButtons: StoryFn = (args) => {
         {...args}
         hideButtons
         textAlign="center"
+        onChange={(_event, value) => {
+          setValue(value);
+        }}
         value={value}
-        onChange={(changedValue) => setValue(changedValue)}
         startAdornment={
           <Button
-            aria-label="decerement value"
+            aria-label="decrement value"
             onClick={() =>
               setValue(
                 typeof value === "string"

--- a/packages/lab/stories/stepper-input/stepper-input.stories.tsx
+++ b/packages/lab/stories/stepper-input/stepper-input.stories.tsx
@@ -6,7 +6,7 @@ import {
   StackLayout,
 } from "@salt-ds/core";
 import { AddIcon, RefreshIcon, RemoveIcon } from "@salt-ds/icons";
-import { StepperInput } from "@salt-ds/lab";
+import { StepperInput, type StepperInputProps } from "@salt-ds/lab";
 import type { Meta, StoryFn } from "@storybook/react";
 import { useState } from "react";
 export default {
@@ -14,7 +14,7 @@ export default {
   component: StepperInput,
 } as Meta<typeof StepperInput>;
 
-export const Default: StoryFn = (args) => {
+export const Default: StoryFn<StepperInputProps> = (args) => {
   return (
     <FormField>
       <FormFieldLabel>Stepper Input</FormFieldLabel>
@@ -27,7 +27,7 @@ Default.args = {
   defaultValue: 0,
 };
 
-export const Secondary: StoryFn = (args) => {
+export const Secondary: StoryFn<StepperInputProps> = (args) => {
   return (
     <FormField>
       <FormFieldLabel>Stepper Input</FormFieldLabel>
@@ -40,7 +40,7 @@ Secondary.args = {
   defaultValue: 0,
 };
 
-export const Bordered: StoryFn = (args) => {
+export const Bordered: StoryFn<StepperInputProps> = (args) => {
   return (
     <FormField>
       <FormFieldLabel>Stepper Input</FormFieldLabel>
@@ -52,7 +52,7 @@ Bordered.args = {
   bordered: true,
 };
 
-export const ReadOnly: StoryFn = (args) => {
+export const ReadOnly: StoryFn<StepperInputProps> = (args) => {
   return (
     <FormField>
       <FormFieldLabel>Stepper Input</FormFieldLabel>
@@ -65,7 +65,7 @@ ReadOnly.args = {
   defaultValue: 5,
 };
 
-export const Disabled: StoryFn = (args) => {
+export const Disabled: StoryFn<StepperInputProps> = (args) => {
   return (
     <FormField>
       <FormFieldLabel>Stepper Input</FormFieldLabel>
@@ -97,7 +97,7 @@ export const Validation: StoryFn<typeof StepperInput> = (args) => {
   );
 };
 
-export const DecimalPlaces: StoryFn = (args) => {
+export const DecimalPlaces: StoryFn<StepperInputProps> = (args) => {
   return (
     <FormField>
       <FormFieldLabel>Stepper Input</FormFieldLabel>
@@ -110,7 +110,7 @@ DecimalPlaces.args = {
   defaultValue: 0,
 };
 
-export const Controlled: StoryFn = (args) => {
+export const Controlled: StoryFn<StepperInputProps> = (args) => {
   const [value, setValue] = useState<number | string>(1.11);
 
   return (
@@ -140,7 +140,7 @@ export const Controlled: StoryFn = (args) => {
   );
 };
 
-export const MinAndMaxValue: StoryFn = (args) => {
+export const MinAndMaxValue: StoryFn<StepperInputProps> = (args) => {
   const [value, setValue] = useState<number | string>(2);
   const max = 5;
   const min = 0;
@@ -179,7 +179,22 @@ export const MinAndMaxValue: StoryFn = (args) => {
   );
 };
 
-export const Alignment: StoryFn = (args) => (
+export const CustomStep: StoryFn<StepperInputProps> = (args) => {
+  return (
+    <FormField>
+      <FormFieldLabel>Stepper Input</FormFieldLabel>
+      <StepperInput {...args} />
+      <FormFieldHelperText>Custom step 5 and step block 50</FormFieldHelperText>
+    </FormField>
+  );
+};
+CustomStep.args = {
+  defaultValue: 1,
+  step: 5,
+  stepBlock: 50,
+};
+
+export const TextAlignment: StoryFn<StepperInputProps> = (args) => (
   <StackLayout>
     <FormField>
       <FormFieldLabel>Left aligned</FormFieldLabel>
@@ -198,11 +213,11 @@ export const Alignment: StoryFn = (args) => (
     </FormField>
   </StackLayout>
 );
-Alignment.args = {
+TextAlignment.args = {
   defaultValue: 0,
 };
 
-export const RefreshAdornment: StoryFn = (args) => {
+export const RefreshAdornment: StoryFn<StepperInputProps> = (args) => {
   const [value, setValue] = useState<number | string>(10);
 
   return (
@@ -229,7 +244,7 @@ export const RefreshAdornment: StoryFn = (args) => {
   );
 };
 
-export const CustomButtons: StoryFn = (args) => {
+export const CustomButtons: StoryFn<StepperInputProps> = (args) => {
   const [value, setValue] = useState<number | string>(10);
 
   return (

--- a/packages/lab/stories/stepper-input/stepper-input.stories.tsx
+++ b/packages/lab/stories/stepper-input/stepper-input.stories.tsx
@@ -17,30 +17,97 @@ export default {
 export const Default: StoryFn = (args) => {
   return (
     <FormField>
-      <FormFieldLabel>Default Stepper Input</FormFieldLabel>
+      <FormFieldLabel>Stepper Input</FormFieldLabel>
       <StepperInput {...args} />
       <FormFieldHelperText>Please enter a number</FormFieldHelperText>
     </FormField>
   );
 };
+Default.args = {
+  defaultValue: 0,
+};
 
 export const Secondary: StoryFn = (args) => {
   return (
     <FormField>
-      <FormFieldLabel>Default Stepper Input</FormFieldLabel>
+      <FormFieldLabel>Stepper Input</FormFieldLabel>
       <StepperInput {...args} variant="secondary" />
       <FormFieldHelperText>Please enter a number</FormFieldHelperText>
     </FormField>
   );
 };
+Secondary.args = {
+  defaultValue: 0,
+};
+
+export const Bordered: StoryFn = (args) => {
+  return (
+    <FormField>
+      <FormFieldLabel>Stepper Input</FormFieldLabel>
+      <StepperInput {...args} />
+    </FormField>
+  );
+};
+Bordered.args = {
+  bordered: true,
+};
+
+export const ReadOnly: StoryFn = (args) => {
+  return (
+    <FormField>
+      <FormFieldLabel>Stepper Input</FormFieldLabel>
+      <StepperInput {...args} />
+    </FormField>
+  );
+};
+ReadOnly.args = {
+  readOnly: true,
+  defaultValue: 5,
+};
+
+export const Disabled: StoryFn = (args) => {
+  return (
+    <FormField>
+      <FormFieldLabel>Stepper Input</FormFieldLabel>
+      <StepperInput {...args} />
+    </FormField>
+  );
+};
+Disabled.args = {
+  disabled: true,
+  defaultValue: 5,
+};
+
+export const Validation: StoryFn<typeof StepperInput> = (args) => {
+  return (
+    <StackLayout>
+      <FormField validationStatus="error">
+        <FormFieldLabel>Error Stepper Input</FormFieldLabel>
+        <StepperInput defaultValue={"Error value"} {...args} />
+      </FormField>
+      <FormField validationStatus="warning">
+        <FormFieldLabel>Warning Stepper Input</FormFieldLabel>
+        <StepperInput defaultValue={"Warning value"} {...args} />
+      </FormField>
+      <FormField validationStatus="success">
+        <FormFieldLabel>Success Stepper Input</FormFieldLabel>
+        <StepperInput defaultValue={"Success value"} {...args} />
+      </FormField>
+    </StackLayout>
+  );
+};
+
 export const DecimalPlaces: StoryFn = (args) => {
   return (
     <FormField>
-      <FormFieldLabel>Default Stepper Input</FormFieldLabel>
+      <FormFieldLabel>Stepper Input</FormFieldLabel>
       <StepperInput decimalPlaces={2} step={0.01} {...args} />
       <FormFieldHelperText>Please enter a number</FormFieldHelperText>
     </FormField>
   );
+};
+DecimalPlaces.args = {
+  defaultValue: 0,
 };
 
 export const Controlled: StoryFn = (args) => {
@@ -131,6 +198,9 @@ export const Alignment: StoryFn = (args) => (
     </FormField>
   </StackLayout>
 );
+Alignment.args = {
+  defaultValue: 0,
+};
 
 export const RefreshAdornment: StoryFn = (args) => {
   const [value, setValue] = useState<number | string>(10);
@@ -159,7 +229,7 @@ export const RefreshAdornment: StoryFn = (args) => {
   );
 };
 
-export const HideButtons: StoryFn = (args) => {
+export const CustomButtons: StoryFn = (args) => {
   const [value, setValue] = useState<number | string>(10);
 
   return (
@@ -203,15 +273,6 @@ export const HideButtons: StoryFn = (args) => {
         }
       />
       <FormFieldHelperText>Please enter a value</FormFieldHelperText>
-    </FormField>
-  );
-};
-
-export const ReadOnly: StoryFn = (args) => {
-  return (
-    <FormField>
-      <FormFieldLabel>Stepper Input</FormFieldLabel>
-      <StepperInput {...args} readOnly />
     </FormField>
   );
 };


### PR DESCRIPTION
No site doc in this PR, will be in #3586

---

- Refactored stepper input to not use `Input` component, which causes the props to be inconsistent (e.g. needing `InputProps.inputProps`)
- Added full border examples, supports theme next rounded corner styling options
- Updated increment / decrement button gap to be `border-strong` (suggested in #3878)
- Added more keyboard interactions, suggested by [APG spinbutton](https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton/), i.e., home/end, page up/down

---

to do ..

- [x] rewrite changeset, API props change, & design change
- [x] add more test
- [x] add more visual snapshot, e.g., status, bordered, readonly, disabled

#1855, #3878