### PR TITLE
Add max-height multiline input example

### DIFF
--- a/.changeset/orange-tips-itch.md
+++ b/.changeset/orange-tips-itch.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Updated MultilineInput so that it is easier to set a max-height.

--- a/packages/core/src/multiline-input/MultilineInput.css
+++ b/packages/core/src/multiline-input/MultilineInput.css
@@ -262,6 +262,7 @@
   margin: var(--salt-spacing-75) 0;
   min-width: 0;
   min-height: 0;
+  max-height: inherit;
   resize: vertical;
   padding: 0;
 }

--- a/site/docs/components/multiline-input/examples.mdx
+++ b/site/docs/components/multiline-input/examples.mdx
@@ -126,7 +126,7 @@ If you've disabled the containing multiline input or set it to a read-only state
 
 ## Max height
 
-You can set a max height for the multiline input by passing a style object to the `TextAreaProp`. The style object should include a `maxHeight` property.
+You can set a max height for the multiline input by passing a style object to the `textAreaProps` prop. The style object should include a `maxHeight` property.
 
 </LivePreview>
 </LivePreviewControls>

--- a/site/docs/components/multiline-input/examples.mdx
+++ b/site/docs/components/multiline-input/examples.mdx
@@ -124,9 +124,9 @@ If you've disabled the containing multiline input or set it to a read-only state
 </LivePreview>
 <LivePreview componentName="multiline-input" exampleName="MaxHeight" >
 
-## Max height
+## Max rows
 
-You can set a max height for the multiline input by passing a style object to the `textAreaProps` prop. The style object should include a `maxHeight` property.
+To control the number of maximum rows visible, you can set a max height for the multiline input.
 
 </LivePreview>
 </LivePreviewControls>

--- a/site/docs/components/multiline-input/examples.mdx
+++ b/site/docs/components/multiline-input/examples.mdx
@@ -122,4 +122,11 @@ You can use a [button](../button) at the beginning or end of the multiline input
 If you've disabled the containing multiline input or set it to a read-only state, ensure your interactive buttons match that state.
 
 </LivePreview>
+<LivePreview componentName="multiline-input" exampleName="MaxHeight" >
+
+## Max height
+
+You can set a max height for the multiline input by passing a style object to the `TextAreaProp`. The style object should include a `maxHeight` property.
+
+</LivePreview>
 </LivePreviewControls>

--- a/site/src/examples/multiline-input/MaxHeight.tsx
+++ b/site/src/examples/multiline-input/MaxHeight.tsx
@@ -1,0 +1,10 @@
+import { MultilineInput } from "@salt-ds/core";
+import type { ReactElement } from "react";
+
+export const MaxHeight = (): ReactElement => (
+  <MultilineInput
+    defaultValue="Value"
+    style={{ maxWidth: "256px" }}
+    textAreaProps={{ style: { maxHeight: "256px" } }}
+  />
+);

--- a/site/src/examples/multiline-input/MaxHeight.tsx
+++ b/site/src/examples/multiline-input/MaxHeight.tsx
@@ -4,7 +4,6 @@ import type { ReactElement } from "react";
 export const MaxHeight = (): ReactElement => (
   <MultilineInput
     defaultValue="Value"
-    style={{ maxWidth: "256px" }}
-    textAreaProps={{ style: { maxHeight: "256px" } }}
+    style={{ maxWidth: "256px", maxHeight: "256px" }}
   />
 );

--- a/site/src/examples/multiline-input/index.ts
+++ b/site/src/examples/multiline-input/index.ts
@@ -9,3 +9,4 @@ export * from "./Readonly";
 export * from "./Secondary";
 export * from "./StaticAdornments";
 export * from "./ValidationStatus";
+export * from "./MaxHeight";


### PR DESCRIPTION
Closes #3964

- Added a max-height multiline input example to site docs.