### PR TITLE
Align form control styling

### DIFF
--- a/.changeset/cold-carrots-hide.md
+++ b/.changeset/cold-carrots-hide.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/lab": patch
+---
+
+Updated DatePicker to show validation status when set to read-only.

--- a/.changeset/hip-trainers-wash.md
+++ b/.changeset/hip-trainers-wash.md
@@ -1,0 +1,17 @@
+---
+"@salt-ds/core": patch
+---
+
+- Fixed bordered form controls' activation indicator and border combining to 3px instead of 2px in:
+
+  - Dropdown
+  - ComboBox
+  - Input
+  - MultilineInput
+
+- Fixed form controls' activation indicator changing color when an active field is hovered in:
+
+  - Input
+  - MultilineInput
+
+- Updated the token applied to form controls' activation indicator to use `--salt-size-border-strong` instead of `  --salt-editable-borderWidth-active`.

--- a/packages/core/src/dropdown/Dropdown.css
+++ b/packages/core/src/dropdown/Dropdown.css
@@ -24,7 +24,7 @@
 
 .saltDropdown:hover {
   background: var(--saltDropdown-background-hover, var(--dropdown-background-hover));
-  cursor: var(--salt-editable-cursor-hover);
+  cursor: var(--salt-selectable-cursor-hover);
 }
 
 .saltDropdown-bordered.saltDropdown {
@@ -166,19 +166,19 @@
 .saltDropdown:focus,
 .saltDropdown:focus:hover {
   background: var(--dropdown-background-active);
-  cursor: var(--salt-editable-cursor-active);
+  cursor: var(--salt-selectable-cursor-hover);
   outline: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--dropdown-outlineColor);
 }
 
 .saltDropdown.saltDropdown[aria-readonly="true"] {
   background: var(--dropdown-background-readonly);
-  cursor: var(--salt-editable-cursor-readonly);
+  cursor: var(--salt-selectable-cursor-readonly);
 }
 
 .saltDropdown.saltDropdown:disabled,
 .saltDropdown.saltDropdown:disabled:hover {
   background: var(--dropdown-background-disabled);
-  cursor: var(--salt-editable-cursor-disabled);
+  cursor: var(--salt-selectable-cursor-disabled);
   color: var(--salt-content-primary-foreground-disabled);
 }
 

--- a/packages/core/src/dropdown/Dropdown.css
+++ b/packages/core/src/dropdown/Dropdown.css
@@ -1,14 +1,4 @@
 .saltDropdown {
-  --dropdown-border: none;
-  --dropdown-borderColor: var(--salt-editable-borderColor);
-  --dropdown-color: var(--salt-content-primary-foreground);
-  --dropdown-cursor: var(--salt-selectable-cursor-hover);
-  --dropdown-borderStyle: var(--salt-editable-borderStyle);
-  --dropdown-outlineColor: var(--salt-focused-outlineColor);
-  --dropdown-borderWidth: var(--salt-size-border);
-}
-
-.saltDropdown {
   all: unset;
   box-sizing: border-box;
   min-width: 4em;
@@ -33,23 +23,163 @@
 }
 
 .saltDropdown:hover {
-  --dropdown-borderColor: var(--salt-editable-borderColor-hover);
-  --dropdown-borderStyle: var(--salt-editable-borderStyle-hover);
-  --dropdown-background: var(--saltDropdown-background-hover, var(--dropdown-background-hover));
+  background: var(--saltDropdown-background-hover, var(--dropdown-background-hover));
+  cursor: var(--salt-editable-cursor-hover);
 }
 
-.saltDropdown:active {
-  --dropdown-background: var(--saltDropdown-background-active, var(--dropdown-background-active));
-  --dropdown-borderColor: var(--salt-editable-borderColor-active);
-  --dropdown-borderWidth: var(--salt-editable-borderWidth-active);
-  --dropdown-borderStyle: var(--salt-editable-borderStyle-active);
+.saltDropdown-bordered.saltDropdown {
+  border: var(--salt-size-border) var(--salt-editable-borderStyle) var(--dropdown-borderColor);
 }
 
-.saltDropdown:focus {
-  outline: var(--salt-focused-outline);
-  --dropdown-borderColor: var(--salt-editable-borderColor-active);
-  --dropdown-borderWidth: var(--salt-editable-borderWidth-active);
-  --dropdown-borderStyle: var(--salt-editable-borderStyle-active);
+.saltDropdown-bordered.saltDropdown:hover {
+  border-style: var(--salt-editable-borderStyle-hover);
+  border-color: var(--dropdown-borderColor-hover);
+}
+
+/* Style applied if focused or active when `bordered={true}` */
+.saltDropdown-bordered.saltDropdown:focus,
+.saltDropdown-bordered.saltDropdown:focus:hover {
+  border-style: var(--salt-editable-borderStyle-active);
+  border-color: var(--dropdown-borderColor-active);
+}
+
+/* Styling when focused if `disabled={true}` or `readOnly={true}` when `bordered={true}` */
+.saltDropdown-bordered.saltDropdown[aria-readonly="true"],
+.saltDropdown-bordered.saltDropdown[aria-readonly="true"]:hover {
+  border-style: var(--salt-editable-borderStyle-readonly);
+  border-color: var(--dropdown-borderColor-readonly);
+}
+
+.saltDropdown-bordered.saltDropdown-disabled,
+.saltDropdown-bordered.saltDropdown-disabled:hover {
+  border-style: var(--salt-editable-borderStyle-disabled);
+  border-color: var(--dropdown-borderColor-disabled);
+}
+
+.saltDropdown-activationIndicator {
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  position: absolute;
+  border-bottom: var(--salt-size-border) var(--salt-editable-borderStyle) var(--dropdown-borderColor);
+}
+
+.saltDropdown:hover .saltDropdown-activationIndicator {
+  border-bottom-style: var(--salt-editable-borderStyle-hover);
+  border-bottom-color: var(--dropdown-borderColor-hover);
+}
+
+.saltDropdown:focus .saltDropdown-activationIndicator,
+.saltDropdown:focus:hover .saltDropdown-activationIndicator {
+  border-bottom: var(--salt-size-border-strong) var(--salt-editable-borderStyle-active) var(--dropdown-borderColor-active);
+}
+
+.saltDropdown[aria-readonly="true"] .saltDropdown-activationIndicator,
+.saltDropdown[aria-readonly="true"]:hover .saltDropdown-activationIndicator {
+  border-bottom-style: var(--salt-editable-borderStyle-readonly);
+  border-bottom-color: var(--dropdown-borderColor-readonly);
+}
+
+.saltDropdown-disabled .saltDropdown-activationIndicator,
+.saltDropdown-disabled:hover .saltDropdown-activationIndicator {
+  border-bottom-style: var(--salt-editable-borderStyle-disabled);
+  border-bottom-color: var(--dropdown-borderColor-disabled);
+}
+
+.saltDropdown-bordered .saltDropdown-activationIndicator,
+.saltDropdown-bordered.saltDropdown[aria-readonly="true"] .saltDropdown-activationIndicator,
+.saltDropdown-bordered.saltDropdown-disabled:hover .saltDropdown-activationIndicator {
+  border-bottom-width: 0;
+}
+
+.saltDropdown-bordered.saltDropdown:focus .saltDropdown-activationIndicator {
+  border-bottom-width: calc(var(--salt-size-border-strong) - var(--salt-size-border));
+}
+
+.saltDropdown-primary {
+  --dropdown-background: var(--salt-editable-primary-background);
+  --dropdown-background-active: var(--salt-editable-primary-background-active);
+  --dropdown-background-hover: var(--salt-editable-primary-background-hover);
+  --dropdown-background-disabled: var(--salt-editable-primary-background-disabled);
+  --dropdown-background-readonly: var(--salt-editable-primary-background-readonly);
+  --dropdown-borderColor: var(--salt-editable-borderColor);
+  --dropdown-borderColor-active: var(--salt-editable-borderColor-active);
+  --dropdown-borderColor-hover: var(--salt-editable-borderColor-hover);
+  --dropdown-borderColor-disabled: var(--salt-editable-borderColor-disabled);
+  --dropdown-borderColor-readonly: var(--salt-editable-borderColor-readonly);
+  --dropdown-outlineColor: var(--salt-focused-outlineColor);
+}
+
+.saltDropdown-secondary {
+  --dropdown-background: var(--salt-editable-secondary-background);
+  --dropdown-background-active: var(--salt-editable-secondary-background-active);
+  --dropdown-background-hover: var(--salt-editable-secondary-background-active);
+  --dropdown-background-disabled: var(--salt-editable-secondary-background-disabled);
+  --dropdown-background-readonly: var(--salt-editable-secondary-background-readonly);
+  --dropdown-borderColor: var(--salt-editable-borderColor);
+  --dropdown-borderColor-active: var(--salt-editable-borderColor-active);
+  --dropdown-borderColor-hover: var(--salt-editable-borderColor-hover);
+  --dropdown-borderColor-disabled: var(--salt-editable-borderColor-disabled);
+  --dropdown-borderColor-readonly: var(--salt-editable-borderColor-readonly);
+  --dropdown-outlineColor: var(--salt-focused-outlineColor);
+}
+
+.saltDropdown-error {
+  --dropdown-background: var(--salt-status-error-background);
+  --dropdown-background-active: var(--salt-status-error-background);
+  --dropdown-background-hover: var(--salt-status-error-background);
+  --dropdown-background-readonly: var(--salt-status-error-background);
+  --dropdown-borderColor: var(--salt-status-error-borderColor);
+  --dropdown-borderColor-active: var(--salt-status-error-borderColor);
+  --dropdown-borderColor-hover: var(--salt-status-error-borderColor);
+  --dropdown-borderColor-disabled: var(--salt-status-error-borderColor);
+  --dropdown-borderColor-readonly: var(--salt-status-error-borderColor);
+  --dropdown-outlineColor: var(--salt-status-error-borderColor);
+}
+
+.saltDropdown-warning {
+  --dropdown-background: var(--salt-status-warning-background);
+  --dropdown-background-active: var(--salt-status-warning-background);
+  --dropdown-background-hover: var(--salt-status-warning-background);
+  --dropdown-background-readonly: var(--salt-status-warning-background);
+  --dropdown-borderColor: var(--salt-status-warning-borderColor);
+  --dropdown-borderColor-active: var(--salt-status-warning-borderColor);
+  --dropdown-borderColor-hover: var(--salt-status-warning-borderColor);
+  --dropdown-borderColor-disabled: var(--salt-status-warning-borderColor);
+  --dropdown-borderColor-readonly: var(--salt-status-warning-borderColor);
+  --dropdown-outlineColor: var(--salt-status-warning-borderColor);
+}
+
+.saltDropdown-success {
+  --dropdown-background: var(--salt-status-success-background);
+  --dropdown-background-active: var(--salt-status-success-background);
+  --dropdown-background-hover: var(--salt-status-success-background);
+  --dropdown-background-readonly: var(--salt-status-success-background);
+  --dropdown-borderColor: var(--salt-status-success-borderColor);
+  --dropdown-borderColor-active: var(--salt-status-success-borderColor);
+  --dropdown-borderColor-hover: var(--salt-status-success-borderColor);
+  --dropdown-borderColor-disabled: var(--salt-status-success-borderColor);
+  --dropdown-borderColor-readonly: var(--salt-status-success-borderColor);
+  --dropdown-outlineColor: var(--salt-status-success-borderColor);
+}
+
+.saltDropdown:focus,
+.saltDropdown:focus:hover {
+  background: var(--dropdown-background-active);
+  cursor: var(--salt-editable-cursor-active);
+  outline: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--dropdown-outlineColor);
+}
+
+.saltDropdown.saltDropdown[aria-readonly="true"] {
+  background: var(--dropdown-background-readonly);
+  cursor: var(--salt-editable-cursor-readonly);
+}
+
+.saltDropdown.saltDropdown:disabled,
+.saltDropdown.saltDropdown:disabled:hover {
+  background: var(--dropdown-background-disabled);
+  cursor: var(--salt-editable-cursor-disabled);
+  color: var(--salt-content-primary-foreground-disabled);
 }
 
 .saltDropdown-content {
@@ -63,106 +193,4 @@
 .saltDropdown-placeholder {
   color: var(--salt-content-secondary-foreground);
   font-weight: var(--salt-text-fontWeight-small);
-}
-
-.saltDropdown-primary {
-  --dropdown-background: var(--salt-editable-primary-background);
-  --dropdown-background-active: var(--salt-editable-primary-background-active);
-  --dropdown-background-hover: var(--salt-editable-primary-background-hover);
-  --dropdown-background-disabled: var(--salt-editable-primary-background-disabled);
-  --dropdown-background-readonly: var(--salt-editable-primary-background-readonly);
-}
-
-.saltDropdown-secondary {
-  --dropdown-background: var(--salt-editable-secondary-background);
-  --dropdown-background-active: var(--salt-editable-secondary-background-active);
-  --dropdown-background-hover: var(--salt-editable-secondary-background-active);
-  --dropdown-background-disabled: var(--salt-editable-secondary-background-disabled);
-  --dropdown-background-readonly: var(--salt-editable-secondary-background-readonly);
-}
-
-.saltDropdown:disabled,
-.saltDropdown:disabled:active,
-.saltDropdown:disabled:hover,
-.saltDropdown:disabled:focus {
-  --dropdown-background: var(--dropdown-background-disabled);
-  --dropdown-borderColor: var(--salt-editable-borderColor-disabled);
-  --dropdown-color: var(--salt-content-primary-foreground-disabled);
-  --dropdown-cursor: var(--salt-selectable-cursor-disabled);
-  --dropdown-borderWidth: var(--salt-size-border);
-}
-
-.saltDropdown[aria-readonly="true"] {
-  --dropdown-borderColor: var(--salt-editable-borderColor-readonly);
-  --dropdown-color: var(--salt-content-primary-foreground);
-  --dropdown-cursor: var(--salt-selectable-cursor-readonly);
-  --dropdown-background: var(--dropdown-background-readonly);
-  --dropdown-borderWidth: var(--salt-size-border);
-}
-
-.saltDropdown[aria-readonly="true"]:hover,
-.saltDropdown[aria-readonly="true"]:focus {
-  --dropdown-background: var(--dropdown-background-readonly);
-  --dropdown-borderColor: var(--salt-editable-borderColor-readonly);
-}
-
-.saltDropdown-error,
-.saltDropdown-error:hover,
-.saltDropdown-error:focus {
-  --dropdown-background: var(--salt-status-error-background);
-  --dropdown-borderColor: var(--salt-status-error-borderColor);
-  --dropdown-background-active: var(--salt-status-error-background);
-  --dropdown-background-hover: var(--salt-status-error-background);
-  --dropdown-background-readonly: var(--salt-status-error-background);
-  outline-color: var(--salt-status-error-borderColor);
-}
-
-.saltDropdown-warning,
-.saltDropdown-warning:hover,
-.saltDropdown-warning:focus {
-  --dropdown-background: var(--salt-status-warning-background);
-  --dropdown-borderColor: var(--salt-status-warning-borderColor);
-  --dropdown-background-active: var(--salt-status-warning-background);
-  --dropdown-background-hover: var(--salt-status-warning-background);
-  --dropdown-background-readonly: var(--salt-status-warning-background);
-  outline-color: var(--salt-status-warning-borderColor);
-}
-
-.saltDropdown-success,
-.saltDropdown-success:hover,
-.saltDropdown-success:focus {
-  --dropdown-background: var(--salt-status-success-background);
-  --dropdown-borderColor: var(--salt-status-success-borderColor);
-  --dropdown-background-active: var(--salt-status-success-background);
-  --dropdown-background-hover: var(--salt-status-success-background);
-  --dropdown-background-readonly: var(--salt-status-success-background);
-  outline-color: var(--salt-status-success-borderColor);
-}
-
-.saltDropdown-activationIndicator {
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  position: absolute;
-  border-bottom: var(--dropdown-borderWidth) var(--dropdown-borderStyle) var(--dropdown-borderColor);
-}
-
-.saltDropdown-bordered {
-  --dropdown-border: var(--salt-size-border) var(--salt-container-borderStyle) var(--dropdown-borderColor);
-  --dropdown-borderWidth: 0;
-}
-
-/* Style applied if focused or active when `bordered={true}` */
-.saltDropdown-bordered.saltDropdown:focus,
-.saltDropdown-bordered:active {
-  --dropdown-borderWidth: var(--salt-editable-borderWidth-active);
-}
-
-/* Styling when focused if `disabled={true}` or `readOnly={true}` when `bordered={true}` */
-.saltDropdown-bordered[aria-readonly="true"],
-.saltDropdown-bordered[aria-readonly="true"]:hover,
-.saltDropdown[aria-readonly="true"]:focus,
-.saltDropdown-bordered.saltDropdown:disabled,
-.saltDropdown-bordered.saltDropdown:disabled:hover {
-  --dropdown-borderWidth: 0;
 }

--- a/packages/core/src/input/Input.css
+++ b/packages/core/src/input/Input.css
@@ -1,21 +1,15 @@
 /* Style applied to the root element */
 .saltInput {
-  --input-border: none;
-  --input-borderColor: var(--salt-editable-borderColor);
-  --input-borderStyle: var(--salt-editable-borderStyle);
-  --input-outlineColor: var(--salt-focused-outlineColor);
-  --input-borderWidth: var(--salt-size-border);
-
   align-items: center;
   background: var(--saltInput-background, var(--input-background));
-  border: var(--input-border);
   border-radius: var(--salt-palette-corner-weak, 0);
   color: var(--saltInput-color, var(--salt-content-primary-foreground));
   display: inline-flex;
   font-family: var(--salt-text-fontFamily);
   font-size: var(--saltInput-fontSize, var(--salt-text-fontSize));
-  height: var(--saltInput-height, var(--salt-size-base));
   line-height: var(--saltInput-lineHeight, var(--salt-text-lineHeight));
+  letter-spacing: var(--salt-text-letterSpacing);
+  height: var(--saltInput-height, var(--salt-size-base));
   min-height: var(--saltInput-minHeight, var(--salt-size-base));
   min-width: var(--saltInput-minWidth, 4em);
   padding-left: var(--saltInput-paddingLeft, var(--salt-spacing-100));
@@ -27,20 +21,76 @@
 }
 
 .saltInput:hover {
-  --input-borderStyle: var(--salt-editable-borderStyle-hover);
-  --input-borderColor: var(--salt-editable-borderColor-hover);
-
   background: var(--saltInput-background-hover, var(--input-background-hover));
   cursor: var(--salt-editable-cursor-hover);
 }
 
-.saltInput:active {
-  --input-borderColor: var(--salt-editable-borderColor-active);
-  --input-borderStyle: var(--salt-editable-borderStyle-active);
-  --input-borderWidth: var(--salt-editable-borderWidth-active);
+/* Style applied if `bordered={true}` */
+.saltInput-bordered.saltInput {
+  border: var(--salt-size-border) var(--salt-editable-borderStyle) var(--input-borderColor);
+}
 
-  background: var(--saltInput-background-active, var(--input-background-active));
-  cursor: var(--salt-editable-cursor-active);
+.saltInput-bordered.saltInput:hover {
+  border-style: var(--salt-editable-borderStyle-hover);
+  border-color: var(--input-borderColor-hover);
+}
+
+.saltInput-bordered.saltInput-focused,
+.saltInput-bordered.saltInput-focused:hover {
+  border-style: var(--salt-editable-borderStyle-active);
+  border-color: var(--input-borderColor-active);
+}
+
+.saltInput-bordered.saltInput-readOnly,
+.saltInput-bordered.saltInput-readOnly:hover {
+  border-style: var(--salt-editable-borderStyle-readonly);
+  border-color: var(--input-borderColor-readonly);
+}
+
+.saltInput-bordered.saltInput-disabled,
+.saltInput-bordered.saltInput-disabled:hover {
+  border-style: var(--salt-editable-borderStyle-disabled);
+  border-color: var(--input-borderColor-disabled);
+}
+
+.saltInput-activationIndicator {
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  position: absolute;
+  border-bottom: var(--salt-size-border) var(--salt-editable-borderStyle) var(--input-borderColor);
+}
+
+.saltInput:hover .saltInput-activationIndicator {
+  border-bottom-style: var(--salt-editable-borderStyle-hover);
+  border-bottom-color: var(--input-borderColor-hover);
+}
+
+.saltInput-focused .saltInput-activationIndicator,
+.saltInput-focused:hover .saltInput-activationIndicator {
+  border-bottom: var(--salt-size-border-strong) var(--salt-editable-borderStyle-active) var(--input-borderColor-active);
+}
+
+.saltInput-readOnly .saltInput-activationIndicator,
+.saltInput-readOnly:hover .saltInput-activationIndicator {
+  border-bottom-style: var(--salt-editable-borderStyle-readonly);
+  border-bottom-color: var(--input-borderColor-readonly);
+}
+
+.saltInput-disabled .saltInput-activationIndicator,
+.saltInput-disabled:hover .saltInput-activationIndicator {
+  border-bottom-style: var(--salt-editable-borderStyle-disabled);
+  border-bottom-color: var(--input-borderColor-disabled);
+}
+
+.saltInput-bordered .saltInput-activationIndicator,
+.saltInput-bordered.saltInput-readOnly .saltInput-activationIndicator,
+.saltInput-bordered.saltInput-disabled:hover .saltInput-activationIndicator {
+  border-bottom-width: 0;
+}
+
+.saltInput-bordered.saltInput-focused .saltInput-activationIndicator {
+  border-bottom-width: calc(var(--salt-size-border-strong) - var(--salt-size-border));
 }
 
 /* Class applied if `variant="primary"` */
@@ -50,6 +100,12 @@
   --input-background-hover: var(--salt-editable-primary-background-hover);
   --input-background-disabled: var(--salt-editable-primary-background-disabled);
   --input-background-readonly: var(--salt-editable-primary-background-readonly);
+  --input-borderColor: var(--salt-editable-borderColor);
+  --input-borderColor-active: var(--salt-editable-borderColor-active);
+  --input-borderColor-hover: var(--salt-editable-borderColor-hover);
+  --input-borderColor-disabled: var(--salt-editable-borderColor-disabled);
+  --input-borderColor-readonly: var(--salt-editable-borderColor-readonly);
+  --input-outlineColor: var(--salt-focused-outlineColor);
 }
 
 /* Class applied if `variant="secondary"` */
@@ -59,148 +115,76 @@
   --input-background-hover: var(--salt-editable-secondary-background-active);
   --input-background-disabled: var(--salt-editable-secondary-background-disabled);
   --input-background-readonly: var(--salt-editable-secondary-background-readonly);
+  --input-borderColor: var(--salt-editable-borderColor);
+  --input-borderColor-active: var(--salt-editable-borderColor-active);
+  --input-borderColor-hover: var(--salt-editable-borderColor-hover);
+  --input-borderColor-disabled: var(--salt-editable-borderColor-disabled);
+  --input-borderColor-readonly: var(--salt-editable-borderColor-readonly);
+  --input-outlineColor: var(--salt-focused-outlineColor);
 }
 
 /* Style applied to input if `validationState="error"` */
-.saltInput-error,
-.saltInput-error:hover {
+.saltInput-error {
   --input-background: var(--salt-status-error-background);
   --input-background-active: var(--salt-status-error-background);
   --input-background-hover: var(--salt-status-error-background);
-  --input-borderColor: var(--salt-status-error-borderColor);
-  --input-outlineColor: var(--salt-status-error-borderColor);
   --input-background-readonly: var(--salt-status-error-background);
+  --input-borderColor: var(--salt-status-error-borderColor);
+  --input-borderColor-active: var(--salt-status-error-borderColor);
+  --input-borderColor-hover: var(--salt-status-error-borderColor);
+  --input-borderColor-disabled: var(--salt-status-error-borderColor);
+  --input-borderColor-readonly: var(--salt-status-error-borderColor);
+  --input-outlineColor: var(--salt-status-error-borderColor);
 }
 
 /* Style applied to input if `validationState="warning"` */
-.saltInput-warning,
-.saltInput-warning:hover {
+.saltInput-warning {
   --input-background: var(--salt-status-warning-background);
   --input-background-active: var(--salt-status-warning-background);
   --input-background-hover: var(--salt-status-warning-background);
-  --input-borderColor: var(--salt-status-warning-borderColor);
-  --input-outlineColor: var(--salt-status-warning-borderColor);
   --input-background-readonly: var(--salt-status-warning-background);
+  --input-borderColor: var(--salt-status-warning-borderColor);
+  --input-borderColor-active: var(--salt-status-warning-borderColor);
+  --input-borderColor-hover: var(--salt-status-warning-borderColor);
+  --input-borderColor-disabled: var(--salt-status-warning-borderColor);
+  --input-borderColor-readonly: var(--salt-status-warning-borderColor);
+  --input-outlineColor: var(--salt-status-warning-borderColor);
 }
 
 /* Style applied to input if `validationState="success"` */
-.saltInput-success,
-.saltInput-success:hover {
+.saltInput-success {
   --input-background: var(--salt-status-success-background);
   --input-background-active: var(--salt-status-success-background);
   --input-background-hover: var(--salt-status-success-background);
-  --input-borderColor: var(--salt-status-success-borderColor);
-  --input-outlineColor: var(--salt-status-success-borderColor);
   --input-background-readonly: var(--salt-status-success-background);
-}
-
-/* Style applied to inner input component */
-.saltInput-input {
-  background: none;
-  border: none;
-  box-sizing: content-box;
-  color: inherit;
-  cursor: inherit;
-  display: block;
-  flex: 1;
-  font: inherit;
-  height: 100%;
-  letter-spacing: var(--saltInput-letterSpacing, 0);
-  margin: 0;
-  min-width: 0;
-  overflow: hidden;
-  padding: 0;
-  text-align: var(--input-textAlign);
-  width: 100%;
-}
-
-/* Reset in the  class */
-.saltInput-input:focus {
-  outline: none;
-}
-
-/* Style applied to selected input */
-.saltInput-input::selection {
-  background: var(--salt-content-foreground-highlight);
-}
-
-/* Style applied to placeholder text */
-.saltInput-input::placeholder {
-  color: var(--salt-content-secondary-foreground);
-  font-weight: var(--salt-text-fontWeight-small);
+  --input-borderColor: var(--salt-status-success-borderColor);
+  --input-borderColor-active: var(--salt-status-success-borderColor);
+  --input-borderColor-hover: var(--salt-status-success-borderColor);
+  --input-borderColor-disabled: var(--salt-status-success-borderColor);
+  --input-borderColor-readonly: var(--salt-status-success-borderColor);
+  --input-outlineColor: var(--salt-status-success-borderColor);
 }
 
 /* Styling when focused */
-.saltInput-focused {
-  --input-borderColor: var(--input-outlineColor);
-  --input-borderWidth: var(--salt-editable-borderWidth-active);
-
+.saltInput-focused,
+.saltInput-focused:hover {
+  background: var(--saltInput-background-active, var(--input-background-active));
+  cursor: var(--salt-editable-cursor-active);
   outline: var(--saltInput-outline, var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--input-outlineColor));
 }
 
 /* Style applied if `readOnly={true}` */
 .saltInput.saltInput-readOnly {
-  --input-borderColor: var(--salt-editable-borderColor-readonly);
-  --input-borderStyle: var(--salt-editable-borderStyle-readonly);
-  --input-borderWidth: var(--salt-size-border);
-
   background: var(--input-background-readonly);
   cursor: var(--salt-editable-cursor-readonly);
 }
 
-/* Styling when focused if `disabled={true}` */
-.saltInput-focused.saltInput-disabled {
-  --input-borderWidth: var(--salt-size-border);
-  outline: none;
-}
-
-/* Styling when focused if `readOnly={true}` */
-.saltInput-focused.saltInput-readOnly {
-  --input-borderWidth: var(--salt-size-border);
-}
-
-/* Style applied to selected input if `disabled={true}` */
-.saltInput-disabled .saltInput-input::selection {
-  background: none;
-}
-
 /* Style applied to input if `disabled={true}` */
 .saltInput.saltInput-disabled,
-.saltInput.saltInput-disabled:hover,
-.saltInput.saltInput-disabled:active {
-  --input-borderColor: var(--salt-editable-borderColor-disabled);
-  --input-borderStyle: var(--salt-editable-borderStyle-disabled);
-  --input-borderWidth: var(--salt-size-border);
-
+.saltInput.saltInput-disabled:hover {
   background: var(--input-background-disabled);
   cursor: var(--salt-editable-cursor-disabled);
   color: var(--saltInput-color-disabled, var(--salt-content-primary-foreground-disabled));
-}
-
-.saltInput-activationIndicator {
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  position: absolute;
-  border-bottom: var(--input-borderWidth) var(--input-borderStyle) var(--input-borderColor);
-}
-
-/* Style applied if `bordered={true}` */
-.saltInput.saltInput-bordered {
-  --input-border: var(--salt-size-border) var(--salt-container-borderStyle) var(--input-borderColor);
-  --input-borderWidth: 0;
-}
-
-/* Style applied if focused or active when `bordered={true}` */
-.saltInput-bordered.saltInput-focused,
-.saltInput-bordered:active {
-  --input-borderWidth: var(--salt-editable-borderWidth-active);
-}
-
-/* Styling when focused if `disabled={true}` or `readOnly={true}` when `bordered={true}` */
-.saltInput-bordered.saltInput-readOnly,
-.saltInput-bordered.saltInput-disabled:hover {
-  --input-borderWidth: 0;
 }
 
 /* Style applied to start adornments */
@@ -244,4 +228,45 @@
   --saltButton-padding: calc(var(--salt-spacing-50) - var(--salt-size-border));
   --saltButton-height: calc(var(--salt-size-base) - var(--salt-spacing-100));
   --saltButton-borderRadius: var(--salt-palette-corner-weaker);
+}
+
+/* Style applied to inner input component */
+.saltInput-input {
+  background: none;
+  border: none;
+  box-sizing: content-box;
+  color: inherit;
+  cursor: inherit;
+  display: block;
+  flex: 1;
+  font: inherit;
+  height: 100%;
+  letter-spacing: var(--saltInput-letterSpacing, 0);
+  margin: 0;
+  min-width: 0;
+  overflow: hidden;
+  padding: 0;
+  text-align: var(--input-textAlign, left);
+  width: 100%;
+}
+
+/* Reset in the  class */
+.saltInput-input:focus {
+  outline: none;
+}
+
+/* Style applied to selected input */
+.saltInput-input::selection {
+  background: var(--salt-content-foreground-highlight);
+}
+
+/* Style applied to placeholder text */
+.saltInput-input::placeholder {
+  color: var(--salt-content-secondary-foreground);
+  font-weight: var(--salt-text-fontWeight-small);
+}
+
+/* Style applied to selected input if `disabled={true}` */
+.saltInput-disabled .saltInput-input::selection {
+  background: none;
 }

--- a/packages/core/src/multiline-input/MultilineInput.css
+++ b/packages/core/src/multiline-input/MultilineInput.css
@@ -1,21 +1,15 @@
 /* Style applied to the root element */
 .saltMultilineInput {
-  --multilineInput-borderColor: var(--salt-editable-borderColor);
-  --multilineInput-borderStyle: var(--salt-editable-borderStyle);
-  --multilineInput-outlineColor: var(--salt-focused-outlineColor);
-  --multilineInput-border: none;
-  --multilineInput-activationIndicator-borderWidth: var(--salt-size-border);
-
   align-items: center;
   background: var(--multilineInput-background);
-  border: var(--multilineInput-border);
   border-radius: var(--salt-palette-corner-weak, 0);
   color: var(--salt-content-primary-foreground);
   display: inline-flex;
   font-family: var(--salt-text-fontFamily);
   font-size: var(--salt-text-fontSize);
-  height: auto;
   line-height: var(--salt-text-lineHeight);
+  letter-spacing: var(--salt-text-letterSpacing);
+  height: auto;
   min-height: var(--salt-size-base);
   min-width: 4em;
   padding-left: var(--salt-spacing-100);
@@ -28,21 +22,79 @@
 
 /* Style applied on hover */
 .saltMultilineInput:hover {
-  --multilineInput-borderStyle: var(--salt-editable-borderStyle-hover);
-  --multilineInput-borderColor: var(--salt-editable-borderColor-hover);
-
   background: var(--multilineInput-background-hover);
   cursor: var(--salt-editable-cursor-hover);
 }
 
-/* Style applied when active */
-.saltMultilineInput:active {
-  --multilineInput-borderColor: var(--salt-editable-borderColor-active);
-  --multilineInput-borderStyle: var(--salt-editable-borderStyle-active);
-  --multilineInput-activationIndicator-borderWidth: var(--salt-editable-borderWidth-active);
+/* Style applied if `bordered={true}` */
+.saltMultilineInput-bordered.saltMultilineInput {
+  border: var(--salt-size-border) var(--salt-editable-borderStyle) var(--multilineInput-borderColor);
+}
 
-  background: var(--multilineInput-background-active);
-  cursor: var(--salt-editable-cursor-active);
+.saltMultilineInput-bordered.saltMultilineInput:hover {
+  border-style: var(--salt-editable-borderStyle-hover);
+  border-color: var(--multilineInput-borderColor-hover);
+}
+
+/* Style applied if focused or active when `bordered={true}` */
+.saltMultilineInput-bordered.saltMultilineInput-focused,
+.saltMultilineInput-bordered.saltMultilineInput-focused:hover {
+  border-style: var(--salt-editable-borderStyle-active);
+  border-color: var(--multilineInput-borderColor-active);
+}
+
+/* Styling when focused if `disabled={true}` or `readOnly={true}` when `bordered={true}` */
+.saltMultilineInput-bordered.saltMultilineInput-readOnly,
+.saltMultilineInput-bordered.saltMultilineInput-readOnly:hover {
+  border-style: var(--salt-editable-borderStyle-readonly);
+  border-color: var(--multilineInput-borderColor-readonly);
+}
+
+.saltMultilineInput-bordered.saltMultilineInput-disabled,
+.saltMultilineInput-bordered.saltMultilineInput-disabled:hover {
+  border-style: var(--salt-editable-borderStyle-disabled);
+  border-color: var(--multilineInput-borderColor-disabled);
+}
+
+/* Style for activation indicator */
+.saltMultilineInput-activationIndicator {
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  position: absolute;
+  border-bottom: var(--salt-size-border) var(--salt-editable-borderStyle) var(--multilineInput-borderColor);
+}
+
+.saltMultilineInput:hover .saltMultilineInput-activationIndicator {
+  border-bottom-style: var(--salt-editable-borderStyle-hover);
+  border-bottom-color: var(--multilineInput-borderColor-hover);
+}
+
+.saltMultilineInput-focused .saltMultilineInput-activationIndicator,
+.saltMultilineInput-focused:hover .saltMultilineInput-activationIndicator {
+  border-bottom: var(--salt-size-border-strong) var(--salt-editable-borderStyle-active) var(--multilineInput-borderColor-active);
+}
+
+.saltMultilineInput-readOnly .saltMultilineInput-activationIndicator,
+.saltMultilineInput-readOnly:hover .saltMultilineInput-activationIndicator {
+  border-bottom-style: var(--salt-editable-borderStyle-readonly);
+  border-bottom-color: var(--multilineInput-borderColor-readonly);
+}
+
+.saltMultilineInput-disabled .saltMultilineInput-activationIndicator,
+.saltMultilineInput-disabled:hover .saltMultilineInput-activationIndicator {
+  border-bottom-style: var(--salt-editable-borderStyle-disabled);
+  border-bottom-color: var(--multilineInput-borderColor-disabled);
+}
+
+.saltMultilineInput-bordered .saltMultilineInput-activationIndicator,
+.saltMultilineInput-bordered.saltMultilineInput-readOnly .saltMultilineInput-activationIndicator,
+.saltMultilineInput-bordered.saltMultilineInput-disabled:hover .saltMultilineInput-activationIndicator {
+  border-bottom-width: 0;
+}
+
+.saltMultilineInput-bordered.saltMultilineInput-focused .saltMultilineInput-activationIndicator {
+  border-bottom-width: calc(var(--salt-size-border-strong) - var(--salt-size-border));
 }
 
 /* Class applied if `variant="primary"` */
@@ -52,6 +104,12 @@
   --multilineInput-background-hover: var(--salt-editable-primary-background-hover);
   --multilineInput-background-disabled: var(--salt-editable-primary-background-disabled);
   --multilineInput-background-readonly: var(--salt-editable-primary-background-readonly);
+  --multilineInput-borderColor: var(--salt-editable-borderColor);
+  --multilineInput-borderColor-active: var(--salt-editable-borderColor-active);
+  --multilineInput-borderColor-hover: var(--salt-editable-borderColor-hover);
+  --multilineInput-borderColor-disabled: var(--salt-editable-borderColor-disabled);
+  --multilineInput-borderColor-readonly: var(--salt-editable-borderColor-readonly);
+  --multilineInput-outlineColor: var(--salt-focused-outlineColor);
 }
 
 /* Class applied if `variant="secondary"` */
@@ -61,142 +119,81 @@
   --multilineInput-background-hover: var(--salt-editable-secondary-background-active);
   --multilineInput-background-disabled: var(--salt-editable-secondary-background-disabled);
   --multilineInput-background-readonly: var(--salt-editable-secondary-background-readonly);
+  --multilineInput-borderColor: var(--salt-editable-borderColor);
+  --multilineInput-borderColor-active: var(--salt-editable-borderColor-active);
+  --multilineInput-borderColor-hover: var(--salt-editable-borderColor-hover);
+  --multilineInput-borderColor-disabled: var(--salt-editable-borderColor-disabled);
+  --multilineInput-borderColor-readonly: var(--salt-editable-borderColor-readonly);
+  --multilineInput-outlineColor: var(--salt-focused-outlineColor);
 }
 
 /* Style applied to input if `validationState="error"` */
-.saltMultilineInput-error,
-.saltMultilineInput-error:hover {
+.saltMultilineInput-error {
   --multilineInput-background: var(--salt-status-error-background);
   --multilineInput-background-active: var(--salt-status-error-background);
   --multilineInput-background-hover: var(--salt-status-error-background);
-  --multilineInput-borderColor: var(--salt-status-error-borderColor);
-  --multilineInput-outlineColor: var(--salt-status-error-borderColor);
   --multilineInput-background-readonly: var(--salt-status-error-background);
+  --multilineInput-borderColor: var(--salt-status-error-borderColor);
+  --multilineInput-borderColor-active: var(--salt-status-error-borderColor);
+  --multilineInput-borderColor-hover: var(--salt-status-error-borderColor);
+  --multilineInput-borderColor-disabled: var(--salt-status-error-borderColor);
+  --multilineInput-borderColor-readonly: var(--salt-status-error-borderColor);
+  --multilineInput-outlineColor: var(--salt-status-error-borderColor);
 }
 
 /* Style applied to input if `validationState="warning"` */
-.saltMultilineInput-warning,
-.saltMultilineInput-warning:hover {
+.saltMultilineInput-warning {
   --multilineInput-background: var(--salt-status-warning-background);
   --multilineInput-background-active: var(--salt-status-warning-background);
   --multilineInput-background-hover: var(--salt-status-warning-background);
-  --multilineInput-borderColor: var(--salt-status-warning-borderColor);
-  --multilineInput-outlineColor: var(--salt-status-warning-borderColor);
   --multilineInput-background-readonly: var(--salt-status-warning-background);
+  --multilineInput-borderColor: var(--salt-status-warning-borderColor);
+  --multilineInput-borderColor-active: var(--salt-status-warning-borderColor);
+  --multilineInput-borderColor-hover: var(--salt-status-warning-borderColor);
+  --multilineInput-borderColor-disabled: var(--salt-status-warning-borderColor);
+  --multilineInput-borderColor-readonly: var(--salt-status-warning-borderColor);
+  --multilineInput-outlineColor: var(--salt-status-warning-borderColor);
 }
 
 /* Style applied to input if `validationState="success"` */
-.saltMultilineInput-success,
-.saltMultilineInput-success:hover {
+.saltMultilineInput-success {
   --multilineInput-background: var(--salt-status-success-background);
   --multilineInput-background-active: var(--salt-status-success-background);
   --multilineInput-background-hover: var(--salt-status-success-background);
-  --multilineInput-borderColor: var(--salt-status-success-borderColor);
-  --multilineInput-outlineColor: var(--salt-status-success-borderColor);
   --multilineInput-background-readonly: var(--salt-status-success-background);
+  --multilineInput-borderColor: var(--salt-status-success-borderColor);
+  --multilineInput-borderColor-active: var(--salt-status-success-borderColor);
+  --multilineInput-borderColor-hover: var(--salt-status-success-borderColor);
+  --multilineInput-borderColor-disabled: var(--salt-status-success-borderColor);
+  --multilineInput-borderColor-readonly: var(--salt-status-success-borderColor);
+  --multilineInput-outlineColor: var(--salt-status-success-borderColor);
+}
+
+/* Styling when focused */
+.saltMultilineInput-focused,
+.saltMultilineInput-focused:hover {
+  background: var(--multilineInput-background-active);
+  cursor: var(--salt-editable-cursor-active);
+  outline: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--multilineInput-outlineColor);
+}
+
+/* Style applied if `readOnly={true}` */
+.saltMultilineInput.saltMultilineInput-readOnly {
+  background: var(--multilineInput-background-readonly);
+  cursor: var(--salt-editable-cursor-readonly);
+}
+
+/* Style applied to input if `disabled={true}` */
+.saltMultilineInput.saltMultilineInput-disabled,
+.saltMultilineInput.saltMultilineInput-disabled:hover {
+  background: var(--input-background-disabled);
+  cursor: var(--salt-editable-cursor-disabled);
+  color: var(--salt-content-primary-foreground-disabled);
 }
 
 .saltMultilineInput.saltMultilineInput-withAdornmentRow {
   display: flex;
   flex-wrap: wrap;
-}
-
-/* Style applied to inner textarea element */
-.saltMultilineInput-textarea {
-  background: none;
-  border: none;
-  box-sizing: border-box;
-  color: inherit;
-  cursor: inherit;
-  flex-grow: 1;
-  font: inherit;
-  letter-spacing: 0;
-  line-height: var(--salt-text-lineHeight);
-  margin: var(--salt-spacing-75) 0;
-  min-width: 0;
-  min-height: 0;
-  resize: vertical;
-  padding: 0;
-}
-
-/* Style applied to placeholder */
-.saltMultilineInput-textarea::placeholder {
-  font-weight: var(--salt-text-fontWeight-small);
-}
-
-/* Reset in the  class */
-.saltMultilineInput-textarea:focus {
-  outline: none;
-}
-
-/* Style applied to selected input */
-.saltMultilineInput-textarea::selection {
-  background: var(--salt-content-foreground-highlight);
-}
-
-/* Styling when focused */
-.saltMultilineInput-focused {
-  --multilineInput-borderColor: var(--multilineInput-outlineColor);
-  --multilineInput-activationIndicator-borderWidth: var(--salt-editable-borderWidth-active);
-
-  outline: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--multilineInput-outlineColor);
-}
-
-/* Style applied if `readOnly={true}` */
-.saltMultilineInput-readOnly,
-.saltMultilineInput-readOnly:active,
-.saltMultilineInput-readOnly:hover {
-  --multilineInput-borderColor: var(--salt-editable-borderColor-readonly);
-  --multilineInput-borderStyle: var(--salt-editable-borderStyle-readonly);
-  --multilineInput-activationIndicator-borderWidth: var(--salt-size-border);
-
-  background: var(--multilineInput-background-readonly);
-  cursor: var(--salt-editable-cursor-readonly);
-}
-
-/* Style applied to selected text if `disabled={true}` */
-.saltMultilineInput-disabled .saltMultilineInput-textarea::selection {
-  background: none;
-}
-
-/* Style applied when `disabled={true}` */
-.saltMultilineInput-disabled,
-.saltMultilineInput-disabled:hover,
-.saltMultilineInput-disabled:active {
-  --multilineInput-borderColor: var(--salt-editable-borderColor-disabled);
-  --multilineInput-borderStyle: var(--salt-editable-borderStyle-disabled);
-  --multilineInput-activationIndicator-borderWidth: var(--salt-size-border);
-
-  background: var(--multilineInput-background-disabled);
-  cursor: var(--salt-editable-cursor-disabled);
-  color: var(--salt-content-primary-foreground-disabled);
-}
-
-/* Style for activation indicator */
-.saltMultilineInput-activationIndicator {
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  position: absolute;
-  border-bottom: var(--multilineInput-activationIndicator-borderWidth) var(--multilineInput-borderStyle) var(--multilineInput-borderColor);
-}
-
-/* Style applied if `bordered={true}` */
-.saltMultilineInput.saltMultilineInput-bordered {
-  --multilineInput-border: var(--salt-size-border) var(--salt-container-borderStyle) var(--multilineInput-borderColor);
-  --multilineInput-activationIndicator-borderWidth: 0;
-}
-
-/* Style applied if focused or active when `bordered={true}` */
-.saltMultilineInput-bordered.saltMultilineInput-focused,
-.saltMultilineInput-bordered:active {
-  --multilineInput-activationIndicator-borderWidth: var(--salt-editable-borderWidth-active);
-}
-
-/* Styling when focused if `disabled={true}` or `readOnly={true}` when `bordered={true}` */
-.saltMultilineInput-bordered.saltMultilineInput-readOnly,
-.saltMultilineInput-bordered.saltMultilineInput-disabled:hover {
-  --multilineInput-activationIndicator-borderWidth: 0;
 }
 
 /* Style applied to adornment containers */
@@ -259,4 +256,42 @@
   --saltButton-padding: calc(var(--salt-spacing-50) - var(--salt-size-border));
   --saltButton-height: calc(var(--salt-size-base) - var(--salt-spacing-100));
   --saltButton-borderRadius: var(--salt-palette-corner-weaker);
+}
+
+/* Style applied to inner textarea element */
+.saltMultilineInput-textarea {
+  background: none;
+  border: none;
+  box-sizing: border-box;
+  color: inherit;
+  cursor: inherit;
+  flex-grow: 1;
+  font: inherit;
+  letter-spacing: 0;
+  line-height: var(--salt-text-lineHeight);
+  margin: var(--salt-spacing-75) 0;
+  min-width: 0;
+  min-height: 0;
+  resize: vertical;
+  padding: 0;
+}
+
+/* Style applied to placeholder */
+.saltMultilineInput-textarea::placeholder {
+  font-weight: var(--salt-text-fontWeight-small);
+}
+
+/* Reset in the  class */
+.saltMultilineInput-textarea:focus {
+  outline: none;
+}
+
+/* Style applied to selected input */
+.saltMultilineInput-textarea::selection {
+  background: var(--salt-content-foreground-highlight);
+}
+
+/* Style applied to selected text if `disabled={true}` */
+.saltMultilineInput-disabled .saltMultilineInput-textarea::selection {
+  background: none;
 }

--- a/packages/core/src/pill-input/PillInput.css
+++ b/packages/core/src/pill-input/PillInput.css
@@ -1,20 +1,14 @@
 /* Style applied to the root element */
 .saltPillInput {
-  --pillInput-border: none;
-  --pillInput-borderColor: var(--salt-editable-borderColor);
-  --pillInput-borderStyle: var(--salt-editable-borderStyle);
-  --pillInput-outlineColor: var(--salt-focused-outlineColor);
-  --pillInput-borderWidth: var(--salt-size-border);
-
   align-items: center;
   background: var(--saltPillInput-background, var(--pillInput-background));
   border-radius: var(--salt-palette-corner-weak, 0);
-  border: var(--pillInput-border);
   color: var(--saltPillInput-color, var(--salt-content-primary-foreground));
   display: inline-flex;
   font-family: var(--salt-text-fontFamily);
   font-size: var(--saltPillInput-fontSize, var(--salt-text-fontSize));
   line-height: var(--saltPillInput-lineHeight, var(--salt-text-lineHeight));
+  letter-spacing: var(--salt-text-letterSpacing);
   min-height: var(--saltPillInput-minHeight, var(--salt-size-base));
   min-width: var(--saltPillInput-minWidth, 4em);
   padding-left: var(--saltPillInput-paddingLeft, var(--salt-spacing-100));
@@ -34,20 +28,82 @@
 }
 
 .saltPillInput:hover {
-  --pillInput-borderStyle: var(--salt-editable-borderStyle-hover);
-  --pillInput-borderColor: var(--salt-editable-borderColor-hover);
-
   background: var(--saltPillInput-background-hover, var(--pillInput-background-hover));
   cursor: var(--salt-editable-cursor-hover);
 }
 
-.saltPillInput:active {
-  --pillInput-borderColor: var(--salt-editable-borderColor-active);
-  --pillInput-borderStyle: var(--salt-editable-borderStyle-active);
-  --pillInput-borderWidth: var(--salt-editable-borderWidth-active);
+/* Style applied if `bordered={true}` */
+.saltPillInput-bordered.saltPillInput {
+  border: var(--salt-size-border) var(--salt-editable-borderStyle) var(--pillInput-borderColor);
+}
 
-  background: var(--saltPillInput-background-active, var(--pillInput-background-active));
-  cursor: var(--salt-editable-cursor-active);
+.saltPillInput-bordered.saltPillInput:hover {
+  border-style: var(--salt-editable-borderStyle-hover);
+  border-color: var(--pillInput-borderColor-hover);
+}
+
+/* Style applied if focused or active when `bordered={true}` */
+.saltPillInput-bordered.saltPillInput-focused,
+.saltPillInput-bordered:active {
+  --pillInput-borderWidth: calc(var(--salt-editable-borderWidth-active) - var(--salt-size-border));
+}
+
+.saltPillInput-bordered.saltPillInput-focused,
+.saltPillInput-bordered.saltPillInput-focused:hover {
+  border-style: var(--salt-editable-borderStyle-active);
+  border-color: var(--pillInput-borderColor-active);
+}
+
+.saltPillInput-bordered.saltPillInput-readOnly,
+.saltPillInput-bordered.saltPillInput-readOnly:hover {
+  border-style: var(--salt-editable-borderStyle-readonly);
+  border-color: var(--pillInput-borderColor-readonly);
+}
+
+.saltPillInput-bordered.saltPillInput-disabled,
+.saltPillInput-bordered.saltPillInput-disabled:hover {
+  border-style: var(--salt-editable-borderStyle-disabled);
+  border-color: var(--pillInput-borderColor-disabled);
+}
+
+.saltPillInput-activationIndicator {
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  position: absolute;
+  border-bottom: var(--salt-size-border) var(--salt-editable-borderStyle) var(--pillInput-borderColor);
+}
+
+.saltPillInput:hover .saltPillInput-activationIndicator {
+  border-bottom-style: var(--salt-editable-borderStyle-hover);
+  border-bottom-color: var(--pillInput-borderColor-hover);
+}
+
+.saltPillInput-focused .saltPillInput-activationIndicator,
+.saltPillInput-focused:hover .saltPillInput-activationIndicator {
+  border-bottom: var(--salt-size-border-strong) var(--salt-editable-borderStyle-active) var(--pillInput-borderColor-active);
+}
+
+.saltPillInput-readOnly .saltPillInput-activationIndicator,
+.saltPillInput-readOnly:hover .saltPillInput-activationIndicator {
+  border-bottom-style: var(--salt-editable-borderStyle-readonly);
+  border-bottom-color: var(--pillInput-borderColor-readonly);
+}
+
+.saltPillInput-disabled .saltPillInput-activationIndicator,
+.saltPillInput-disabled:hover .saltPillInput-activationIndicator {
+  border-bottom-style: var(--salt-editable-borderStyle-disabled);
+  border-bottom-color: var(--pillInput-borderColor-disabled);
+}
+
+.saltPillInput-bordered .saltPillInput-activationIndicator,
+.saltPillInput-bordered.saltPillInput-readOnly .saltPillInput-activationIndicator,
+.saltPillInput-bordered.saltPillInput-disabled:hover .saltPillInput-activationIndicator {
+  border-bottom-width: 0;
+}
+
+.saltPillInput-bordered.saltPillInput-focused .saltPillInput-activationIndicator {
+  border-bottom-width: calc(var(--salt-size-border-strong) - var(--salt-size-border));
 }
 
 /* Class applied if `variant="primary"` */
@@ -57,6 +113,12 @@
   --pillInput-background-hover: var(--salt-editable-primary-background-hover);
   --pillInput-background-disabled: var(--salt-editable-primary-background-disabled);
   --pillInput-background-readonly: var(--salt-editable-primary-background-readonly);
+  --pillInput-borderColor: var(--salt-editable-borderColor);
+  --pillInput-borderColor-active: var(--salt-editable-borderColor-active);
+  --pillInput-borderColor-hover: var(--salt-editable-borderColor-hover);
+  --pillInput-borderColor-disabled: var(--salt-editable-borderColor-disabled);
+  --pillInput-borderColor-readonly: var(--salt-editable-borderColor-readonly);
+  --pillInput-outlineColor: var(--salt-focused-outlineColor);
 }
 
 /* Class applied if `variant="secondary"` */
@@ -66,150 +128,76 @@
   --pillInput-background-hover: var(--salt-editable-secondary-background-active);
   --pillInput-background-disabled: var(--salt-editable-secondary-background-disabled);
   --pillInput-background-readonly: var(--salt-editable-secondary-background-readonly);
+  --pillInput-borderColor: var(--salt-editable-borderColor);
+  --pillInput-borderColor-active: var(--salt-editable-borderColor-active);
+  --pillInput-borderColor-hover: var(--salt-editable-borderColor-hover);
+  --pillInput-borderColor-disabled: var(--salt-editable-borderColor-disabled);
+  --pillInput-borderColor-readonly: var(--salt-editable-borderColor-readonly);
+  --pillInput-outlineColor: var(--salt-focused-outlineColor);
 }
 
 /* Style applied to input if `validationState="error"` */
-.saltPillInput-error,
-.saltPillInput-error:hover {
+.saltPillInput-error {
   --pillInput-background: var(--salt-status-error-background);
   --pillInput-background-active: var(--salt-status-error-background);
   --pillInput-background-hover: var(--salt-status-error-background);
-  --pillInput-borderColor: var(--salt-status-error-borderColor);
-  --pillInput-outlineColor: var(--salt-status-error-borderColor);
   --pillInput-background-readonly: var(--salt-status-error-background);
+  --pillInput-borderColor: var(--salt-status-error-borderColor);
+  --pillInput-borderColor-active: var(--salt-status-error-borderColor);
+  --pillInput-borderColor-hover: var(--salt-status-error-borderColor);
+  --pillInput-borderColor-disabled: var(--salt-status-error-borderColor);
+  --pillInput-borderColor-readonly: var(--salt-status-error-borderColor);
+  --pillInput-outlineColor: var(--salt-status-error-borderColor);
 }
 
 /* Style applied to input if `validationState="warning"` */
-.saltPillInput-warning,
-.saltPillInput-warning:hover {
+.saltPillInput-warning {
   --pillInput-background: var(--salt-status-warning-background);
   --pillInput-background-active: var(--salt-status-warning-background);
   --pillInput-background-hover: var(--salt-status-warning-background);
-  --pillInput-borderColor: var(--salt-status-warning-borderColor);
-  --pillInput-outlineColor: var(--salt-status-warning-borderColor);
   --pillInput-background-readonly: var(--salt-status-warning-background);
+  --pillInput-borderColor: var(--salt-status-warning-borderColor);
+  --pillInput-borderColor-active: var(--salt-status-warning-borderColor);
+  --pillInput-borderColor-hover: var(--salt-status-warning-borderColor);
+  --pillInput-borderColor-disabled: var(--salt-status-warning-borderColor);
+  --pillInput-borderColor-readonly: var(--salt-status-warning-borderColor);
+  --pillInput-outlineColor: var(--salt-status-warning-borderColor);
 }
 
 /* Style applied to input if `validationState="success"` */
-.saltPillInput-success,
-.saltPillInput-success:hover {
+.saltPillInput-success {
   --pillInput-background: var(--salt-status-success-background);
   --pillInput-background-active: var(--salt-status-success-background);
   --pillInput-background-hover: var(--salt-status-success-background);
-  --pillInput-borderColor: var(--salt-status-success-borderColor);
-  --pillInput-outlineColor: var(--salt-status-success-borderColor);
   --pillInput-background-readonly: var(--salt-status-success-background);
-}
-
-/* Style applied to inner input component */
-.saltPillInput-input {
-  background: none;
-  border: none;
-  box-sizing: content-box;
-  color: inherit;
-  cursor: inherit;
-  display: block;
-  flex: 1;
-  font: inherit;
-  height: 100%;
-  letter-spacing: var(--saltPillInput-letterSpacing, 0);
-  margin: 0;
-  min-width: 0;
-  overflow: hidden;
-  padding: 0;
-  text-align: var(--pillInput-textAlign);
-  width: 100%;
-}
-
-/* Reset in the  class */
-.saltPillInput-input:focus {
-  outline: none;
-}
-
-/* Style applied to selected input */
-.saltPillInput-input::selection {
-  background: var(--salt-content-foreground-highlight);
-}
-
-/* Style applied to placeholder text */
-.saltPillInput-input::placeholder {
-  color: var(--salt-content-secondary-foreground);
-  font-weight: var(--salt-text-fontWeight-small);
+  --pillInput-borderColor: var(--salt-status-success-borderColor);
+  --pillInput-borderColor-active: var(--salt-status-success-borderColor);
+  --pillInput-borderColor-hover: var(--salt-status-success-borderColor);
+  --pillInput-borderColor-disabled: var(--salt-status-success-borderColor);
+  --pillInput-borderColor-readonly: var(--salt-status-success-borderColor);
+  --pillInput-outlineColor: var(--salt-status-success-borderColor);
 }
 
 /* Styling when focused */
 .saltPillInput-focused,
 .saltPillInput-focused:hover {
-  --pillInput-borderColor: var(--pillInput-outlineColor);
-  --pillInput-borderWidth: var(--salt-editable-borderWidth-active);
-
+  background: var(--saltPillInput-background-active, var(--pillInput-background-active));
+  cursor: var(--salt-editable-cursor-active);
   outline: var(--saltPillInput-outline, var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--pillInput-outlineColor));
 }
 
 /* Style applied if `readOnly={true}` */
 .saltPillInput.saltPillInput-readOnly {
-  --pillInput-borderColor: var(--salt-editable-borderColor-readonly);
-  --pillInput-borderStyle: var(--salt-editable-borderStyle-readonly);
-  --pillInput-borderWidth: var(--salt-size-border);
-
   background: var(--pillInput-background-readonly);
   cursor: var(--salt-editable-cursor-readonly);
 }
 
 /* Styling when focused if `disabled={true}` */
-.saltPillInput-focused.saltPillInput-disabled {
-  --pillInput-borderWidth: var(--salt-size-border);
-  outline: none;
-}
-
-/* Styling when focused if `readOnly={true}` */
-.saltPillInput-focused.saltPillInput-readOnly {
-  --pillInput-borderWidth: var(--salt-size-border);
-}
-
-/* Style applied to selected input if `disabled={true}` */
-.saltPillInput-disabled .saltPillInput-input::selection {
-  background: none;
-}
-
-/* Style applied to input if `disabled={true}` */
-.saltPillInput.saltPillInput-disabled,
-.saltPillInput.saltPillInput-disabled:hover,
-.saltPillInput.saltPillInput-disabled:active {
-  --pillInput-borderColor: var(--salt-editable-borderColor-disabled);
-  --pillInput-borderStyle: var(--salt-editable-borderStyle-disabled);
-  --pillInput-borderWidth: var(--salt-size-border);
-
+.saltPillInput-disabled,
+.saltPillInput-disabled:hover {
   background: var(--pillInput-background-disabled);
   cursor: var(--salt-editable-cursor-disabled);
   color: var(--saltPillInput-color-disabled, var(--salt-content-primary-foreground-disabled));
-}
-
-.saltPillInput-activationIndicator {
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  position: absolute;
-  border-bottom: var(--pillInput-borderWidth) var(--pillInput-borderStyle) var(--pillInput-borderColor);
-}
-
-/* Style applied if `bordered={true}` */
-.saltPillInput.saltPillInput-bordered {
-  --pillInput-border: var(--salt-size-border) var(--salt-container-borderStyle) var(--pillInput-borderColor);
-  --pillInput-borderWidth: 0;
-}
-
-/* Style applied if focused or active when `bordered={true}` */
-.saltPillInput-bordered.saltPillInput-focused,
-.saltPillInput-bordered:active {
-  --pillInput-borderWidth: var(--salt-editable-borderWidth-active);
-}
-
-/* Styling when focused if `disabled={true}` or `readOnly={true}` when `bordered={true}` */
-.saltPillInput-bordered.saltPillInput-readOnly,
-.saltPillInput-bordered.saltPillInput-disabled:hover,
-.saltPillInput-bordered.saltPillInput-disabled.saltPillInput-focused {
-  --pillInput-borderWidth: 0;
 }
 
 /* Style applied to start adornments */
@@ -306,4 +294,45 @@
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+/* Style applied to inner input component */
+.saltPillInput-input {
+  background: none;
+  border: none;
+  box-sizing: content-box;
+  color: inherit;
+  cursor: inherit;
+  display: block;
+  flex: 1;
+  font: inherit;
+  height: 100%;
+  letter-spacing: var(--saltPillInput-letterSpacing, 0);
+  margin: 0;
+  min-width: 0;
+  overflow: hidden;
+  padding: 0;
+  text-align: var(--pillInput-textAlign, left);
+  width: 100%;
+}
+
+/* Reset in the  class */
+.saltPillInput-input:focus {
+  outline: none;
+}
+
+/* Style applied to selected input */
+.saltPillInput-input::selection {
+  background: var(--salt-content-foreground-highlight);
+}
+
+/* Style applied to selected input if `disabled={true}` */
+.saltPillInput-disabled .saltPillInput-input::selection {
+  background: none;
+}
+
+/* Style applied to placeholder text */
+.saltPillInput-input::placeholder {
+  color: var(--salt-content-secondary-foreground);
+  font-weight: var(--salt-text-fontWeight-small);
 }

--- a/packages/lab/src/date-input/DateInput.css
+++ b/packages/lab/src/date-input/DateInput.css
@@ -1,22 +1,16 @@
 /* Style applied to the root element */
 .saltDateInput {
-  --input-border: none;
-  --input-borderColor: var(--salt-editable-borderColor);
-  --input-borderStyle: var(--salt-editable-borderStyle);
-  --input-outlineColor: var(--salt-focused-outlineColor);
-  --input-borderWidth: var(--salt-size-border);
-
   align-items: center;
   background: var(--saltDateInput-background, var(--input-background));
-  border: var(--input-border);
   border-radius: var(--salt-palette-corner-weak, 0);
   color: var(--saltDateInput-color, var(--salt-content-primary-foreground));
   display: inline-flex;
   gap: var(--salt-spacing-50);
   font-family: var(--salt-text-fontFamily);
   font-size: var(--saltDateInput-fontSize, var(--salt-text-fontSize));
-  height: var(--saltDateInput-height, var(--salt-size-base));
   line-height: var(--saltDateInput-lineHeight, var(--salt-text-lineHeight));
+  letter-spacing: var(--salt-text-letterSpacing);
+  height: var(--saltDateInput-height, var(--salt-size-base));
   min-height: var(--saltDateInput-minHeight, var(--salt-size-base));
   min-width: var(--saltDateInput-minWidth, 4em);
   padding-left: var(--saltDateInput-paddingLeft, var(--salt-spacing-100));
@@ -28,20 +22,76 @@
 }
 
 .saltDateInput:hover {
-  --input-borderStyle: var(--salt-editable-borderStyle-hover);
-  --input-borderColor: var(--salt-editable-borderColor-hover);
-
   background: var(--saltDateInput-background-hover, var(--input-background-hover));
   cursor: var(--salt-editable-cursor-hover);
 }
 
-.saltDateInput:active {
-  --input-borderColor: var(--salt-editable-borderColor-active);
-  --input-borderStyle: var(--salt-editable-borderStyle-active);
-  --input-borderWidth: var(--salt-editable-borderWidth-active);
+/* Style applied if `bordered={true}` */
+.saltDateInput-bordered.saltDateInput {
+  border: var(--salt-size-border) var(--salt-editable-borderStyle) var(--input-borderColor);
+}
 
-  background: var(--saltDateInput-background-active, var(--input-background-active));
-  cursor: var(--salt-editable-cursor-active);
+.saltDateInput-bordered.saltDateInput:hover {
+  border-style: var(--salt-editable-borderStyle-hover);
+  border-color: var(--input-borderColor-hover);
+}
+
+.saltDateInput-bordered.saltDateInput-focused,
+.saltDateInput-bordered.saltDateInput-focused:hover {
+  border-style: var(--salt-editable-borderStyle-active);
+  border-color: var(--input-borderColor-active);
+}
+
+.saltDateInput-bordered.saltDateInput-readOnly,
+.saltDateInput-bordered.saltDateInput-readOnly:hover {
+  border-style: var(--salt-editable-borderStyle-readonly);
+  border-color: var(--input-borderColor-readonly);
+}
+
+.saltDateInput-bordered.saltDateInput-disabled,
+.saltDateInput-bordered.saltDateInput-disabled:hover {
+  border-style: var(--salt-editable-borderStyle-disabled);
+  border-color: var(--input-borderColor-disabled);
+}
+
+.saltDateInput-activationIndicator {
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  position: absolute;
+  border-bottom: var(--salt-size-border) var(--salt-editable-borderStyle) var(--input-borderColor);
+}
+
+.saltDateInput:hover .saltDateInput-activationIndicator {
+  border-bottom-style: var(--salt-editable-borderStyle-hover);
+  border-bottom-color: var(--input-borderColor-hover);
+}
+
+.saltDateInput-focused .saltDateInput-activationIndicator,
+.saltDateInput-focused:hover .saltDateInput-activationIndicator {
+  border-bottom: var(--salt-size-border-strong) var(--salt-editable-borderStyle-active) var(--input-borderColor-active);
+}
+
+.saltDateInput-readOnly .saltDateInput-activationIndicator,
+.saltDateInput-readOnly:hover .saltDateInput-activationIndicator {
+  border-bottom-style: var(--salt-editable-borderStyle-readonly);
+  border-bottom-color: var(--input-borderColor-readonly);
+}
+
+.saltDateInput-disabled .saltDateInput-activationIndicator,
+.saltDateInput-disabled:hover .saltDateInput-activationIndicator {
+  border-bottom-style: var(--salt-editable-borderStyle-disabled);
+  border-bottom-color: var(--input-borderColor-disabled);
+}
+
+.saltDateInput-bordered .saltDateInput-activationIndicator,
+.saltDateInput-bordered.saltDateInput-readOnly .saltDateInput-activationIndicator,
+.saltDateInput-bordered.saltDateInput-disabled:hover .saltDateInput-activationIndicator {
+  border-bottom-width: 0;
+}
+
+.saltDateInput-bordered.saltDateInput-focused .saltDateInput-activationIndicator {
+  border-bottom-width: calc(var(--salt-size-border-strong) - var(--salt-size-border));
 }
 
 /* Class applied if `variant="primary"` */
@@ -51,6 +101,12 @@
   --input-background-hover: var(--salt-editable-primary-background-hover);
   --input-background-disabled: var(--salt-editable-primary-background-disabled);
   --input-background-readonly: var(--salt-editable-primary-background-readonly);
+  --input-borderColor: var(--salt-editable-borderColor);
+  --input-borderColor-active: var(--salt-editable-borderColor-active);
+  --input-borderColor-hover: var(--salt-editable-borderColor-hover);
+  --input-borderColor-disabled: var(--salt-editable-borderColor-disabled);
+  --input-borderColor-readonly: var(--salt-editable-borderColor-readonly);
+  --input-outlineColor: var(--salt-focused-outlineColor);
 }
 
 /* Class applied if `variant="secondary"` */
@@ -60,36 +116,98 @@
   --input-background-hover: var(--salt-editable-secondary-background-active);
   --input-background-disabled: var(--salt-editable-secondary-background-disabled);
   --input-background-readonly: var(--salt-editable-secondary-background-readonly);
+  --input-borderColor: var(--salt-editable-borderColor);
+  --input-borderColor-active: var(--salt-editable-borderColor-active);
+  --input-borderColor-hover: var(--salt-editable-borderColor-hover);
+  --input-borderColor-disabled: var(--salt-editable-borderColor-disabled);
+  --input-borderColor-readonly: var(--salt-editable-borderColor-readonly);
+  --input-outlineColor: var(--salt-focused-outlineColor);
 }
 
 /* Style applied to input if `validationState="error"` */
-.saltDateInput-error,
-.saltDateInput-error:hover {
+.saltDateInput-error {
   --input-background: var(--salt-status-error-background);
   --input-background-active: var(--salt-status-error-background);
   --input-background-hover: var(--salt-status-error-background);
+  --input-background-readonly: var(--salt-status-error-background);
   --input-borderColor: var(--salt-status-error-borderColor);
+  --input-borderColor-active: var(--salt-status-error-borderColor);
+  --input-borderColor-hover: var(--salt-status-error-borderColor);
+  --input-borderColor-disabled: var(--salt-status-error-borderColor);
+  --input-borderColor-readonly: var(--salt-status-error-borderColor);
   --input-outlineColor: var(--salt-status-error-borderColor);
 }
 
 /* Style applied to input if `validationState="warning"` */
-.saltDateInput-warning,
-.saltDateInput-warning:hover {
+.saltDateInput-warning {
   --input-background: var(--salt-status-warning-background);
   --input-background-active: var(--salt-status-warning-background);
   --input-background-hover: var(--salt-status-warning-background);
+  --input-background-readonly: var(--salt-status-warning-background);
   --input-borderColor: var(--salt-status-warning-borderColor);
+  --input-borderColor-active: var(--salt-status-warning-borderColor);
+  --input-borderColor-hover: var(--salt-status-warning-borderColor);
+  --input-borderColor-disabled: var(--salt-status-warning-borderColor);
+  --input-borderColor-readonly: var(--salt-status-warning-borderColor);
   --input-outlineColor: var(--salt-status-warning-borderColor);
 }
 
 /* Style applied to input if `validationState="success"` */
-.saltDateInput-success,
-.saltDateInput-success:hover {
+.saltDateInput-success {
   --input-background: var(--salt-status-success-background);
   --input-background-active: var(--salt-status-success-background);
   --input-background-hover: var(--salt-status-success-background);
+  --input-background-readonly: var(--salt-status-success-background);
   --input-borderColor: var(--salt-status-success-borderColor);
+  --input-borderColor-active: var(--salt-status-success-borderColor);
+  --input-borderColor-hover: var(--salt-status-success-borderColor);
+  --input-borderColor-disabled: var(--salt-status-success-borderColor);
+  --input-borderColor-readonly: var(--salt-status-success-borderColor);
   --input-outlineColor: var(--salt-status-success-borderColor);
+}
+
+/* Styling when focused */
+.saltDateInput-focused,
+.saltDateInput-focused:hover {
+  background: var(--saltDateInput-background-active, var(--input-background-active));
+  cursor: var(--salt-editable-cursor-active);
+  outline: var(--saltDateInput-outline, var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--input-outlineColor));
+}
+
+/* Style applied if `readOnly={true}` */
+.saltDateInput.saltDateInput-readOnly {
+  background: var(--input-background-readonly);
+  cursor: var(--salt-editable-cursor-readonly);
+}
+
+/* Styling when focused if `disabled={true}` */
+.saltDateInput-disabled,
+.saltDateInput-disabled:hover {
+  background: var(--input-background-disabled);
+  cursor: var(--salt-editable-cursor-disabled);
+  color: var(--saltDateInput-color-disabled, var(--salt-content-primary-foreground-disabled));
+}
+
+/* Style applied to end adornments */
+.saltDateInput-endAdornmentContainer {
+  display: inline-flex;
+  padding-left: var(--salt-spacing-100);
+  column-gap: var(--salt-spacing-100);
+  margin-left: auto;
+  align-items: end;
+}
+
+.saltDateInput-endAdornmentContainer .saltButton ~ .saltButton {
+  margin-left: calc(-1 * var(--salt-spacing-50));
+}
+
+.saltDateInput-endAdornmentContainer .saltButton:last-child {
+  margin-right: calc(var(--salt-spacing-50) * -1);
+}
+
+.saltDateInput-endAdornmentContainer > .saltButton {
+  --saltButton-padding: var(--salt-spacing-50);
+  --saltButton-height: calc(var(--salt-size-base) - var(--salt-spacing-100));
 }
 
 /* Style applied to inner input component */
@@ -121,103 +239,13 @@
   background: var(--salt-content-foreground-highlight);
 }
 
-/* Style applied to placeholder text */
-.saltDateInput-input::placeholder {
-  color: var(--salt-content-secondary-foreground);
-  font-weight: var(--salt-text-fontWeight-small);
-}
-
-/* Styling when focused */
-.saltDateInput-focused {
-  --input-borderColor: var(--input-outlineColor);
-  --input-borderWidth: var(--salt-editable-borderWidth-active);
-
-  outline: var(--saltDateInput-outline, var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--input-outlineColor));
-}
-
-/* Style applied if `readOnly={true}` */
-.saltDateInput.saltDateInput-readOnly {
-  --input-borderColor: var(--salt-editable-borderColor-readonly);
-  --input-borderStyle: var(--salt-editable-borderStyle-readonly);
-  --input-borderWidth: var(--salt-size-border);
-
-  background: var(--input-background-readonly);
-  cursor: var(--salt-editable-cursor-readonly);
-}
-
-/* Styling when focused if `disabled={true}` */
-.saltDateInput-focused.saltDateInput-disabled {
-  --input-borderWidth: var(--salt-size-border);
-  outline: none;
-}
-
-/* Styling when focused if `readOnly={true}` */
-.saltDateInput-focused.saltDateInput-readOnly {
-  --input-borderWidth: var(--salt-size-border);
-}
-
 /* Style applied to selected input if `disabled={true}` */
 .saltDateInput-disabled .saltDateInput-input::selection {
   background: none;
 }
 
-/* Style applied to input if `disabled={true}` */
-.saltDateInput.saltDateInput-disabled,
-.saltDateInput.saltDateInput-disabled:hover,
-.saltDateInput.saltDateInput-disabled:active {
-  --input-borderColor: var(--salt-editable-borderColor-disabled);
-  --input-borderStyle: var(--salt-editable-borderStyle-disabled);
-  --input-borderWidth: var(--salt-size-border);
-
-  background: var(--input-background-disabled);
-  cursor: var(--salt-editable-cursor-disabled);
-  color: var(--saltDateInput-color-disabled, var(--salt-content-primary-foreground-disabled));
-}
-
-.saltDateInput-activationIndicator {
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  position: absolute;
-  border-bottom: var(--input-borderWidth) var(--input-borderStyle) var(--input-borderColor);
-}
-
-/* Style applied if `bordered={true}` */
-.saltDateInput.saltDateInput-bordered {
-  --input-border: var(--salt-size-border) var(--salt-container-borderStyle) var(--input-borderColor);
-  --input-borderWidth: 0;
-}
-
-/* Style applied if focused or active when `bordered={true}` */
-.saltDateInput-bordered.saltDateInput-focused,
-.saltDateInput-bordered:active {
-  --input-borderWidth: var(--salt-editable-borderWidth-active);
-}
-
-/* Styling when focused if `disabled={true}` or `readOnly={true}` when `bordered={true}` */
-.saltDateInput-bordered.saltDateInput-readOnly,
-.saltDateInput-bordered.saltDateInput-disabled:hover {
-  --input-borderWidth: 0;
-}
-
-/* Style applied to end adornments */
-.saltDateInput-endAdornmentContainer {
-  display: inline-flex;
-  padding-left: var(--salt-spacing-100);
-  column-gap: var(--salt-spacing-100);
-  margin-left: auto;
-  align-items: end;
-}
-
-.saltDateInput-endAdornmentContainer .saltButton ~ .saltButton {
-  margin-left: calc(-1 * var(--salt-spacing-50));
-}
-
-.saltDateInput-endAdornmentContainer .saltButton:last-child {
-  margin-right: calc(var(--salt-spacing-50) * -1);
-}
-
-.saltDateInput-endAdornmentContainer > .saltButton {
-  --saltButton-padding: var(--salt-spacing-50);
-  --saltButton-height: calc(var(--salt-size-base) - var(--salt-spacing-100));
+/* Style applied to placeholder text */
+.saltDateInput-input::placeholder {
+  color: var(--salt-content-secondary-foreground);
+  font-weight: var(--salt-text-fontWeight-small);
 }


### PR DESCRIPTION
Closes #3861
Closes #3596 

Fixed bordered form controls' activation indicator and border combining to 3px instead of 2px in:

  - Dropdown
  - ComboBox
  - Input
  - MultilineInput

Fixed form controls' activation indicator changing color when an active field is hovered in:

  - Input
  - MultilineInput

Updated the token applied to form controls' activation indicator to use `--salt-size-border-strong` instead of `  --salt-editable-borderWidth-active`.
Updated DatePicker to show validation status when set to read-only.