### PR TITLE
Add ag grid copy highlight color

### DIFF
--- a/.changeset/ag-theme-selection-highlight.md
+++ b/.changeset/ag-theme-selection-highlight.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/ag-grid-theme": minor
+---
+
+Added support for [range selection](https://www.ag-grid.com/react-data-grid/global-style-customisation-selections/#range-selections) highlight color, mapped to `--salt-overlayable-background-highlight`. Closes #3922.

--- a/.changeset/theme-background-highlight.md
+++ b/.changeset/theme-background-highlight.md
@@ -1,0 +1,10 @@
+---
+"@salt-ds/theme": minor
+---
+
+Added below new tokens
+
+- `--salt-overlayable-background-highlight`
+- `--salt-palette-neutral-highlight`
+- `--salt-color-black-fade-background-highlight`
+- `--salt-color-white-fade-background-highlight`

--- a/packages/ag-grid-theme/css/salt-ag-grid-theme.css
+++ b/packages/ag-grid-theme/css/salt-ag-grid-theme.css
@@ -36,6 +36,7 @@ div[class*="ag-theme-salt"] {
   --ag-popup-shadow: var(--salt-overlayable-shadow-modal);
   --ag-range-selection-background-color: var(--salt-overlayable-rangeSelection);
   --ag-range-selection-border-style: none;
+  --ag-range-selection-highlight-color: var(--salt-overlayable-background-highlight);
   --ag-row-group-indent-size: calc(var(--ag-icon-size) + var(--ag-cell-widget-spacing));
   --ag-row-hover-color: var(--salt-selectable-background-hover);
   --ag-secondary-border-color: var(--salt-separable-tertiary-borderColor);

--- a/packages/theme/css/characteristics/overlayable-next.css
+++ b/packages/theme/css/characteristics/overlayable-next.css
@@ -1,4 +1,5 @@
 .salt-theme.salt-theme-next {
   --salt-overlayable-background: var(--salt-palette-alpha-backdrop);
+  --salt-overlayable-background-highlight: var(--salt-palette-alpha);
   --salt-overlayable-rangeSelection: var(--salt-palette-alpha-weak);
 }

--- a/packages/theme/css/characteristics/overlayable.css
+++ b/packages/theme/css/characteristics/overlayable.css
@@ -8,5 +8,6 @@
   --salt-overlayable-shadow-modal: var(--salt-shadow-500);
 
   --salt-overlayable-background: var(--salt-palette-neutral-backdrop);
+  --salt-overlayable-background-highlight: var(--salt-palette-neutral-highlight);
   --salt-overlayable-rangeSelection: var(--salt-palette-neutral-selection);
 }

--- a/packages/theme/css/foundations/fade.css
+++ b/packages/theme/css/foundations/fade.css
@@ -77,6 +77,8 @@
 
   --salt-color-black-fade-background-hover: rgba(0, 0, 0, var(--salt-opacity-8));
   --salt-color-black-fade-background-selection: rgba(0, 0, 0, var(--salt-opacity-15));
+  --salt-color-black-fade-background-highlight: rgba(0, 0, 0, var(--salt-opacity-25));
   --salt-color-white-fade-background-hover: rgba(255, 255, 255, var(--salt-opacity-8));
   --salt-color-white-fade-background-selection: rgba(255, 255, 255, var(--salt-opacity-15));
+  --salt-color-white-fade-background-highlight: rgba(255, 255, 255, var(--salt-opacity-25));
 }

--- a/packages/theme/css/palette/neutral.css
+++ b/packages/theme/css/palette/neutral.css
@@ -14,14 +14,16 @@
   --salt-palette-neutral-secondary-border-disabled: var(--salt-color-gray-50-fade-border);
   --salt-palette-neutral-secondary-foreground: var(--salt-color-gray-200);
   --salt-palette-neutral-secondary-foreground-disabled: var(--salt-color-gray-200-fade-foreground);
-  --salt-palette-neutral-backdrop: var(--salt-color-white-fade-backdrop);
   --salt-palette-neutral-secondary-separator: var(--salt-color-black-fade-separatorOpacity-secondary);
-  --salt-palette-neutral-tertiary-separator: var(--salt-color-black-fade-separatorOpacity-tertiary);
-  --salt-palette-neutral-selection: var(--salt-color-black-fade-background-selection);
   --salt-palette-neutral-tertiary-background: var(--salt-color-gray-30);
   --salt-palette-neutral-tertiary-background-disabled: var(--salt-color-gray-30-fade-background);
   --salt-palette-neutral-tertiary-border: var(--salt-color-gray-50);
   --salt-palette-neutral-tertiary-border-disabled: var(--salt-color-gray-50-fade-background);
+  --salt-palette-neutral-tertiary-separator: var(--salt-color-black-fade-separatorOpacity-tertiary);
+
+  --salt-palette-neutral-backdrop: var(--salt-color-white-fade-backdrop);
+  --salt-palette-neutral-selection: var(--salt-color-black-fade-background-selection);
+  --salt-palette-neutral-highlight: var(--salt-color-black-fade-background-highlight);
 }
 
 .salt-theme[data-mode="dark"] {
@@ -40,12 +42,14 @@
   --salt-palette-neutral-secondary-border-disabled: var(--salt-color-gray-300-fade-border);
   --salt-palette-neutral-secondary-foreground: var(--salt-color-gray-70);
   --salt-palette-neutral-secondary-foreground-disabled: var(--salt-color-gray-70-fade-foreground);
-  --salt-palette-neutral-backdrop: var(--salt-color-black-fade-backdrop);
   --salt-palette-neutral-secondary-separator: var(--salt-color-white-fade-separatorOpacity-secondary);
   --salt-palette-neutral-tertiary-separator: var(--salt-color-white-fade-separatorOpacity-tertiary);
-  --salt-palette-neutral-selection: var(--salt-color-white-fade-background-selection);
   --salt-palette-neutral-tertiary-background: var(--salt-color-gray-500);
   --salt-palette-neutral-tertiary-background-disabled: var(--salt-color-gray-500-fade-background);
   --salt-palette-neutral-tertiary-border: var(--salt-color-gray-300);
   --salt-palette-neutral-tertiary-border-disabled: var(--salt-color-gray-300-fade-background);
+
+  --salt-palette-neutral-backdrop: var(--salt-color-black-fade-backdrop);
+  --salt-palette-neutral-selection: var(--salt-color-white-fade-background-selection);
+  --salt-palette-neutral-highlight: var(--salt-color-white-fade-background-highlight);
 }


### PR DESCRIPTION
Copy cells to see highlight color

Before release, double check `peerDependencies` is bumped in `@salt-ds/ag-grid-theme`

#3922