### PR TITLE
Fix standalone ToggleButton corner radius

### DIFF
--- a/.changeset/heavy-mice-repeat.md
+++ b/.changeset/heavy-mice-repeat.md
@@ -2,4 +2,4 @@
 "@salt-ds/core": patch
 ---
 
-Fixed ToggleButton corner radius when not used within ToggleButtonGroup
+Fixed standalone ToggleButton's corner radius not aligning to Button.

--- a/.changeset/heavy-mice-repeat.md
+++ b/.changeset/heavy-mice-repeat.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Fixed ToggleButton corner radius when not used within ToggleButtonGroup

--- a/packages/core/src/toggle-button-group/ToggleButtonGroup.css
+++ b/packages/core/src/toggle-button-group/ToggleButtonGroup.css
@@ -11,6 +11,7 @@
 
 .saltToggleButtonGroup-horizontal .saltToggleButton {
   height: calc(var(--salt-size-base) - var(--salt-spacing-100));
+  border-radius: var(--salt-palette-corner-weaker, 0);
 }
 
 .saltToggleButtonGroup-vertical {

--- a/packages/core/src/toggle-button-group/ToggleButtonGroup.css
+++ b/packages/core/src/toggle-button-group/ToggleButtonGroup.css
@@ -9,9 +9,12 @@
   flex-direction: row;
 }
 
+.saltToggleButtonGroup .saltToggleButton {
+  border-radius: var(--salt-palette-corner-weaker, 0);
+}
+
 .saltToggleButtonGroup-horizontal .saltToggleButton {
   height: calc(var(--salt-size-base) - var(--salt-spacing-100));
-  border-radius: var(--salt-palette-corner-weaker, 0);
 }
 
 .saltToggleButtonGroup-vertical {

--- a/packages/core/src/toggle-button/ToggleButton.css
+++ b/packages/core/src/toggle-button/ToggleButton.css
@@ -5,7 +5,7 @@
   border-color: var(--toggleButton-borderColor, transparent);
   border-style: solid;
   border-width: var(--salt-size-border, 0);
-  border-radius: var(--salt-palette-corner-weaker, 0);
+  border-radius: var(--salt-palette-corner-weak, 0);
   color: var(--toggleButton-text-color);
   cursor: pointer;
   display: inline-flex;


### PR DESCRIPTION
When standalone toggle button is used, it should have same corner radius as button. Only when it is used within toggle button group, it should change to match "nested" corner.

[#4140](https://github.com/jpmorganchase/salt-ds/issues/4140)