### PR TITLE
Fix Dialog's content being collapsed on Safari

### DIFF
--- a/.changeset/unlucky-lobsters-arrive.md
+++ b/.changeset/unlucky-lobsters-arrive.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Fixed Dialog's content being collapsed on Safari.

--- a/packages/core/src/dialog/DialogContent.css
+++ b/packages/core/src/dialog/DialogContent.css
@@ -9,7 +9,8 @@
   padding-left: var(--salt-spacing-100);
   border-bottom: var(--salt-size-border) var(--salt-separable-borderStyle) transparent;
   box-shadow: none;
-  flex: 1;
+  /* auto is needed for support on Safari, due to webkit bugs with flex */
+  flex: 1 1 auto;
 }
 
 .saltDialogContent-scroll {


### PR DESCRIPTION
Closes #4066

Due to a bug in safari with flex, the fix is to add "auto" 