### PR TITLE
Fix foreground secondary color token in Salt theme next

### DIFF
--- a/.changeset/popular-forks-doubt.md
+++ b/.changeset/popular-forks-doubt.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/theme": patch
+---
+
+Fixed foreground secondary color token not correctly reflecting design in Salt Next theme, corrected to gray 700/300.

--- a/packages/theme/css/palette/foreground-next.css
+++ b/packages/theme/css/palette/foreground-next.css
@@ -5,8 +5,8 @@
   --salt-palette-foreground-primary-disabled: var(--salt-color-black-40a);
   --salt-palette-foreground-primary-alt: var(--salt-color-white);
   --salt-palette-foreground-primary-alt-disabled: var(--salt-color-white-40a);
-  --salt-palette-foreground-secondary: var(--salt-color-gray-600);
-  --salt-palette-foreground-secondary-disabled: var(--salt-color-gray-600-40a);
+  --salt-palette-foreground-secondary: var(--salt-color-gray-700);
+  --salt-palette-foreground-secondary-disabled: var(--salt-color-gray-700-40a);
   --salt-palette-foreground-visited: var(--salt-color-purple-800);
 }
 .salt-theme.salt-theme-next[data-mode="dark"] {
@@ -16,7 +16,7 @@
   --salt-palette-foreground-primary-disabled: var(--salt-color-white-40a);
   --salt-palette-foreground-primary-alt: var(--salt-color-white);
   --salt-palette-foreground-primary-alt-disabled: var(--salt-color-white-40a);
-  --salt-palette-foreground-secondary: var(--salt-color-gray-400);
-  --salt-palette-foreground-secondary-disabled: var(--salt-color-gray-400-40a);
+  --salt-palette-foreground-secondary: var(--salt-color-gray-300);
+  --salt-palette-foreground-secondary-disabled: var(--salt-color-gray-300-40a);
   --salt-palette-foreground-visited: var(--salt-color-purple-200);
 }


### PR DESCRIPTION
Code and Figma got out of sync during early salt next design phase.

To fully prevent this, #4041 is needed.