### PR TITLE
Site quick responsiveness improvement

### DIFF
--- a/site/src/layouts/DetailBase/DetailBase.module.css
+++ b/site/src/layouts/DetailBase/DetailBase.module.css
@@ -17,11 +17,12 @@
 }
 
 .docsPageContent {
-  width: calc(100% - var(--toc-width));
+  flex-shrink: 1;
 }
 
 .sidebar {
   display: contents;
+  flex-shrink: 0;
 }
 
 .sidebarHeader {
@@ -32,7 +33,7 @@
   align-self: flex-start;
   position: sticky;
   top: var(--navbar-height);
-  width: var(--toc-width);
+  min-width: var(--toc-width);
   padding-top: var(--salt-spacing-300);
   padding-left: calc(5 * var(--salt-spacing-100));
   margin-top: 0;

--- a/site/src/layouts/DetailBase/DetailBase.tsx
+++ b/site/src/layouts/DetailBase/DetailBase.tsx
@@ -105,9 +105,11 @@ export const DetailBase: FC<LayoutProps> = ({
               >
                 {children}
               </div>
-              <SaltProvider density="medium" applyClassesTo="child">
-                <div className={styles.sidebar}>{sidebar}</div>
-              </SaltProvider>
+              {sidebar ? (
+                <SaltProvider density="medium" applyClassesTo="child">
+                  <div className={styles.sidebar}>{sidebar}</div>
+                </SaltProvider>
+              ) : null}
             </div>
           </SaltProvider>
           <div className={styles.docPaginator}>

--- a/site/src/layouts/LayoutColumns/LayoutColumns.module.css
+++ b/site/src/layouts/LayoutColumns/LayoutColumns.module.css
@@ -6,7 +6,7 @@
   display: grid;
   align-items: start;
   grid-template-areas: "layout-column-sidebar layout-column-main";
-  grid-template-columns: max-content calc(100vw - var(--site-sidebar-width));
+  grid-template-columns: max-content 1fr;
 }
 
 .main {
@@ -17,7 +17,7 @@
 }
 
 .main.showDrawer {
-  width: 100vw;
+  width: 100%;
 }
 
 .sidebar {
@@ -25,7 +25,7 @@
   position: sticky;
   top: var(--navbar-height);
   max-width: var(--site-sidebar-width);
-  height: 100vh;
+  height: calc(100vh - var(--navbar-height));
   background: var(--salt-container-primary-background);
 }
 


### PR DESCRIPTION
- Mobile drawer menu should be better now with global density change + [mosaic#663](https://github.com/jpmorganchase/mosaic/pull/663)
- Component page body & TOC spacing should be improved for viewport just above tablet
- Fixed component nav bar, so scrolling down would see last entry "Tooltip", before scrolling the whole page down


App header is constrained by Mosaic `LayoutBase`, with existing content, we'll need 5 specific breakpoints
- 1478+, full logo + menu items + search + buttons
- 1380+, mobile logo
- 1280+, remove buttons
- remaining, replace menu items with drawer