### PR TITLE
New Header for Overlay and Dialog

### DIFF
--- a/packages/core/src/__tests__/__e2e__/dialog/Dialog.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/dialog/Dialog.cy.tsx
@@ -165,23 +165,23 @@ describe("GIVEN a Dialog", () => {
       cy.mount(<Default />);
       cy.findByRole("button", { name: "Open dialog" }).realClick();
       cy.findByRole("dialog").should("be.visible");
+      cy.findAllByRole("button", { name: "Close dialog" }).should("be.focused");
+      cy.realPress("Tab");
       cy.findAllByRole("button", { name: "Cancel" }).should("be.focused");
       cy.realPress("Tab");
       cy.findAllByRole("button", { name: "Previous" }).should("be.focused");
       cy.realPress("Tab");
       cy.findAllByRole("button", { name: "Next" }).should("be.focused");
       cy.realPress("Tab");
-      cy.findAllByRole("button", { name: "Close dialog" }).should("be.focused");
-      cy.realPress("Tab");
       //back to the first button
-      cy.findAllByRole("button", { name: "Cancel" }).should("be.focused");
+      cy.findAllByRole("button", { name: "Close dialog" }).should("be.focused");
     });
 
     it("THEN should support initialFocus being set", () => {
       cy.mount(<Default initialFocus={2} />);
       cy.findByRole("button", { name: "Open dialog" }).realClick();
       cy.findByRole("dialog").should("be.visible");
-      cy.findByRole("button", { name: "Next" }).should("be.focused");
+      cy.findByRole("button", { name: "Previous" }).should("be.focused");
     });
   });
 });

--- a/packages/core/src/__tests__/__e2e__/overlay/Overlay.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/overlay/Overlay.cy.tsx
@@ -36,7 +36,9 @@ describe("GIVEN an Overlay", () => {
       cy.realPress("Enter");
       cy.findByRole("dialog").should("be.visible");
       //focus into overlay
-      cy.findByRole("button", { name: /Close Overlay/i }).should("be.focused");
+      cy.findAllByRole("button", { name: "Close overlay" }).should(
+        "be.focused",
+      );
       cy.realPress("Tab");
     });
 
@@ -45,11 +47,11 @@ describe("GIVEN an Overlay", () => {
 
       cy.findByRole("button", { name: /Show Overlay/i }).realClick();
       cy.findByRole("dialog").should("be.visible");
-      cy.findByRole("button", { name: /Close Overlay/i }).should("be.focused");
+      cy.findByRole("button", { name: /Close overlay/i }).should("be.focused");
       cy.realPress("Tab");
       cy.findByRole("button", { name: /Hover me/i }).should("be.focused");
       cy.realPress("Tab");
-      cy.findByRole("button", { name: /Close Overlay/i }).should("be.focused");
+      cy.findByRole("button", { name: /Close overlay/i }).should("be.focused");
     });
   });
 
@@ -119,7 +121,8 @@ describe("GIVEN an Overlay", () => {
       cy.findByRole("dialog").should("be.visible");
       cy.get("@onOpenChangeSpy").should("have.callCount", 1);
 
-      cy.findByRole("button", { name: /Close Overlay/i }).realClick();
+      cy.findByRole("button", { name: /Close overlay/i }).realClick();
+
       cy.findByRole("dialog").should("not.exist");
 
       cy.findByRole("button", { name: /Show Overlay/i }).realClick();

--- a/packages/core/src/__tests__/__e2e__/overlay/Overlay.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/overlay/Overlay.cy.tsx
@@ -3,7 +3,7 @@ import { composeStories } from "@storybook/react";
 import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
 
 const composedStories = composeStories(overlayStories);
-const { Default, Right, Bottom, Left, CloseButton } = composedStories;
+const { Default, Right, Bottom, Left, HeaderWithCloseButton } = composedStories;
 
 describe("GIVEN an Overlay", () => {
   checkAccessibility(composedStories);
@@ -30,7 +30,7 @@ describe("GIVEN an Overlay", () => {
     });
 
     it("THEN it should focus into the overlay when opened", () => {
-      cy.mount(<CloseButton />);
+      cy.mount(<HeaderWithCloseButton />);
 
       cy.realPress("Tab");
       cy.realPress("Enter");
@@ -41,7 +41,7 @@ describe("GIVEN an Overlay", () => {
     });
 
     it("THEN it should trap focus within Overlay once opened", () => {
-      cy.mount(<CloseButton />);
+      cy.mount(<HeaderWithCloseButton />);
 
       cy.findByRole("button", { name: /Show Overlay/i }).realClick();
       cy.findByRole("dialog").should("be.visible");
@@ -112,7 +112,7 @@ describe("GIVEN an Overlay", () => {
   describe("WHEN a Close Button is used", () => {
     it("THEN it should remain open until outside Overlay click or close button click", () => {
       const onOpenChangeSpy = cy.stub().as("onOpenChangeSpy");
-      cy.mount(<CloseButton onOpenChange={onOpenChangeSpy} />);
+      cy.mount(<HeaderWithCloseButton onOpenChange={onOpenChangeSpy} />);
 
       cy.realPress("Tab");
       cy.realPress("Enter");

--- a/packages/core/src/dialog/DialogHeader.css
+++ b/packages/core/src/dialog/DialogHeader.css
@@ -1,6 +1,6 @@
 /* Styles applied to the root element */
 .saltDialogHeader {
-  padding-bottom: var(--salt-spacing-100);
+  padding-bottom: var(--salt-spacing-300);
   padding-left: var(--salt-spacing-300);
   padding-right: var(--salt-spacing-300);
   align-items: center;
@@ -10,8 +10,20 @@
   box-sizing: border-box;
 }
 
+.saltDialogHeader-body {
+  flex-grow: 1;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--salt-spacing-50);
+}
+
 .saltDialogHeader-header {
   margin: 0;
+}
+
+.saltDialogHeader-endAdornmentContainer {
+  align-self: flex-start;
 }
 
 /* Styles applied to the status indicator icon overriding its default size */
@@ -29,7 +41,7 @@
   position: absolute;
   top: 0;
   left: 0;
-  bottom: var(--salt-spacing-100);
+  bottom: var(--salt-spacing-300);
   width: var(--salt-size-bar);
   background: var(--salt-accent-background);
 }

--- a/packages/core/src/dialog/DialogHeader.tsx
+++ b/packages/core/src/dialog/DialogHeader.tsx
@@ -30,15 +30,25 @@ export interface DialogHeaderProps extends ComponentPropsWithoutRef<"div"> {
    * Displays the preheader just above the header
    **/
   preheader?: ReactNode;
+  /**
+   * Description text is displayed just below the header
+   **/
+  description?: string;
+  /**
+   * End adornment component
+   */
+  endAdornment?: ReactNode;
 }
 
 export const DialogHeader = forwardRef<HTMLDivElement, DialogHeaderProps>(
   function DialogHeader(props, ref) {
     const {
       className,
+      description,
+      disableAccent,
+      endAdornment,
       header,
       preheader,
-      disableAccent,
       status: statusProp,
       ...rest
     } = props;
@@ -68,14 +78,22 @@ export const DialogHeader = forwardRef<HTMLDivElement, DialogHeaderProps>(
         {...rest}
       >
         {status && <StatusIndicator status={status} />}
-        <H2 className={withBaseName("header")}>
+        <div className={withBaseName("body")}>
           {preheader && (
-            <Text variant="secondary" className={withBaseName("preheader")}>
-              {preheader}
+            <Text className={withBaseName("preheader")}>{preheader}</Text>
+          )}
+          <H2 className={withBaseName("header")}>{header}</H2>
+          {description && (
+            <Text color="secondary" className={withBaseName("description")}>
+              {description}
             </Text>
           )}
-          <div>{header}</div>
-        </H2>
+        </div>
+        {endAdornment && (
+          <div className={withBaseName("endAdornmentContainer")}>
+            {endAdornment}
+          </div>
+        )}
       </div>
     );
   },

--- a/packages/core/src/overlay/OverlayHeader.css
+++ b/packages/core/src/overlay/OverlayHeader.css
@@ -1,0 +1,31 @@
+.saltOverlayHeader {
+  padding: var(--salt-spacing-100);
+  width: 100%;
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: stretch;
+  gap: var(--salt-spacing-100);
+  box-sizing: border-box;
+}
+
+.saltOverlayHeader-body {
+  flex-grow: 1;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--salt-spacing-50);
+}
+
+.saltOverlayHeader-header {
+  margin: 0;
+}
+
+.saltOverlayHeader-endAdornmentContainer {
+  align-self: flex-start;
+}
+
+/* Overrides */
+.saltOverlayHeader ~ .saltOverlayPanelContent {
+  padding-top: 0;
+}

--- a/packages/core/src/overlay/OverlayHeader.css
+++ b/packages/core/src/overlay/OverlayHeader.css
@@ -9,7 +9,7 @@
   box-sizing: border-box;
 }
 
-.saltOverlayHeader-body {
+.saltOverlayHeader-container {
   flex-grow: 1;
   margin: 0;
   display: flex;
@@ -21,7 +21,7 @@
   margin: 0;
 }
 
-.saltOverlayHeader-endAdornmentContainer {
+.saltOverlayHeader-actionsContainer {
   align-self: flex-start;
 }
 

--- a/packages/core/src/overlay/OverlayHeader.tsx
+++ b/packages/core/src/overlay/OverlayHeader.tsx
@@ -1,0 +1,84 @@
+import { useComponentCssInjection } from "@salt-ds/styles";
+import { useWindow } from "@salt-ds/window";
+import clsx from "clsx";
+import {
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+  forwardRef,
+} from "react";
+import { H3, Text } from "../text";
+import { makePrefixer } from "../utils";
+import overlayHeaderCss from "./OverlayHeader.css";
+
+const withBaseName = makePrefixer("saltOverlayHeader");
+
+export interface OverlayPanelContentProps
+  extends ComponentPropsWithoutRef<"div"> {
+  /**
+   * Description text is displayed just below the header
+   **/
+  description?: string;
+  /**
+   * End adornment component
+   */
+  endAdornment?: ReactNode;
+  /**
+   * Header text
+   */
+  header?: string;
+  /**
+   * The id of the Overlay Header, used for aria-labelledby on OverlayPanel
+   **/
+  id?: string;
+  /**
+   * Preheader text is displayed just above the header
+   **/
+  preheader?: string;
+}
+
+export const OverlayHeader = forwardRef<
+  HTMLDivElement,
+  OverlayPanelContentProps
+>(function OverlayPanelContent(props, ref) {
+  const targetWindow = useWindow();
+  useComponentCssInjection({
+    testId: "salt-overlay-panel-content",
+    css: overlayHeaderCss,
+    window: targetWindow,
+  });
+
+  const {
+    className,
+    description,
+    header,
+    endAdornment,
+    id,
+    preheader,
+    ...rest
+  } = props;
+
+  return (
+    <div className={clsx(withBaseName(), className)} {...rest} ref={ref}>
+      <div className={withBaseName("body")}>
+        {preheader && (
+          <Text className={withBaseName("preheader")}>{preheader}</Text>
+        )}
+        {header && (
+          <H3 id={id} className={withBaseName("header")}>
+            {header}
+          </H3>
+        )}
+        {description && (
+          <Text color="secondary" className={withBaseName("description")}>
+            {description}
+          </Text>
+        )}
+      </div>
+      {endAdornment && (
+        <div className={withBaseName("endAdornmentContainer")}>
+          {endAdornment}
+        </div>
+      )}
+    </div>
+  );
+});

--- a/packages/core/src/overlay/OverlayHeader.tsx
+++ b/packages/core/src/overlay/OverlayHeader.tsx
@@ -6,7 +6,7 @@ import {
   type ReactNode,
   forwardRef,
 } from "react";
-import { H3, Text } from "../text";
+import { H4, Text } from "../text";
 import { makePrefixer } from "../utils";
 import overlayHeaderCss from "./OverlayHeader.css";
 
@@ -17,15 +17,15 @@ export interface OverlayPanelContentProps
   /**
    * Description text is displayed just below the header
    **/
-  description?: string;
+  description?: ReactNode;
   /**
    * End adornment component
    */
-  endAdornment?: ReactNode;
+  actions?: ReactNode;
   /**
    * Header text
    */
-  header?: string;
+  header?: ReactNode;
   /**
    * The id of the Overlay Header, used for aria-labelledby on OverlayPanel
    **/
@@ -33,7 +33,7 @@ export interface OverlayPanelContentProps
   /**
    * Preheader text is displayed just above the header
    **/
-  preheader?: string;
+  preheader?: ReactNode;
 }
 
 export const OverlayHeader = forwardRef<
@@ -47,26 +47,19 @@ export const OverlayHeader = forwardRef<
     window: targetWindow,
   });
 
-  const {
-    className,
-    description,
-    header,
-    endAdornment,
-    id,
-    preheader,
-    ...rest
-  } = props;
+  const { className, description, header, actions, id, preheader, ...rest } =
+    props;
 
   return (
     <div className={clsx(withBaseName(), className)} {...rest} ref={ref}>
-      <div className={withBaseName("body")}>
+      <div className={withBaseName("container")}>
         {preheader && (
           <Text className={withBaseName("preheader")}>{preheader}</Text>
         )}
         {header && (
-          <H3 id={id} className={withBaseName("header")}>
+          <H4 id={id} className={withBaseName("header")}>
             {header}
-          </H3>
+          </H4>
         )}
         {description && (
           <Text color="secondary" className={withBaseName("description")}>
@@ -74,10 +67,8 @@ export const OverlayHeader = forwardRef<
           </Text>
         )}
       </div>
-      {endAdornment && (
-        <div className={withBaseName("endAdornmentContainer")}>
-          {endAdornment}
-        </div>
+      {actions && (
+        <div className={withBaseName("actionsContainer")}>{actions}</div>
       )}
     </div>
   );

--- a/packages/core/src/overlay/OverlayPanelContent.css
+++ b/packages/core/src/overlay/OverlayPanelContent.css
@@ -1,6 +1,12 @@
 .saltOverlayPanelContent {
   animation: var(--salt-animation-fade-in-center);
   position: relative;
-  overflow: auto;
+  overflow-y: auto;
   padding: var(--saltOverlay-content-padding, var(--salt-spacing-100));
+}
+
+.saltOverlayPanelContent-scroll {
+  border-bottom: var(--salt-size-border) var(--salt-separable-borderStyle) var(--salt-separable-tertiary-borderColor);
+  box-shadow: var(--salt-overlayable-shadow-scroll);
+  margin-bottom: calc(0 - var(--salt-size-border));
 }

--- a/packages/core/src/overlay/OverlayPanelContent.css
+++ b/packages/core/src/overlay/OverlayPanelContent.css
@@ -1,12 +1,18 @@
-.saltOverlayPanelContent {
+.saltOverlayPanelContent-container {
   animation: var(--salt-animation-fade-in-center);
   position: relative;
-  overflow-y: auto;
+  overflow: hidden;
   padding: var(--saltOverlay-content-padding, var(--salt-spacing-100));
+  padding-top: 0;
 }
-
+.saltOverlayPanelContent  {
+  overflow-y: auto;
+}
+.saltOverlayPanelContent-separator {
+  border-top: var(--salt-size-border) var(--salt-separable-borderStyle) transparent;
+}
 .saltOverlayPanelContent-scroll {
-  border-bottom: var(--salt-size-border) var(--salt-separable-borderStyle) var(--salt-separable-tertiary-borderColor);
+  border-top: var(--salt-size-border) var(--salt-separable-borderStyle) var(--salt-separable-tertiary-borderColor);
   box-shadow: var(--salt-overlayable-shadow-scroll);
-  margin-bottom: calc(0 - var(--salt-size-border));
+  margin-top: calc(0 - var(--salt-size-border));
 }

--- a/packages/core/src/overlay/OverlayPanelContent.tsx
+++ b/packages/core/src/overlay/OverlayPanelContent.tsx
@@ -4,15 +4,16 @@ import clsx from "clsx";
 import {
   type ComponentPropsWithoutRef,
   type ReactNode,
+  type UIEvent,
   forwardRef,
+  useState,
 } from "react";
 import { makePrefixer } from "../utils";
 import overlayPanelContentCss from "./OverlayPanelContent.css";
 
 const withBaseName = makePrefixer("saltOverlayPanelContent");
 
-export interface OverlayPanelContentProps
-  extends ComponentPropsWithoutRef<"div"> {
+export interface OverlayHeaderProps extends ComponentPropsWithoutRef<"div"> {
   /**
    * The content of Overlay Panel Content
    */
@@ -21,7 +22,7 @@ export interface OverlayPanelContentProps
 
 export const OverlayPanelContent = forwardRef<
   HTMLDivElement,
-  OverlayPanelContentProps
+  OverlayHeaderProps
 >(function OverlayPanelContent(props, ref) {
   const targetWindow = useWindow();
   useComponentCssInjection({
@@ -31,10 +32,23 @@ export const OverlayPanelContent = forwardRef<
   });
 
   const { children, className, ...rest } = props;
+  const [scrollTop, setScrollTop] = useState(0);
+
+  const handleScroll = (event: UIEvent<HTMLElement>) => {
+    setScrollTop(event.currentTarget.scrollTop);
+  };
 
   return (
-    <div className={clsx(withBaseName(), className)} {...rest} ref={ref}>
-      {children}
-    </div>
+    <>
+      <div className={clsx({ [withBaseName("scroll")]: scrollTop > 0 })} />
+      <div
+        className={clsx(withBaseName(), className)}
+        onScroll={handleScroll}
+        {...rest}
+        ref={ref}
+      >
+        {children}
+      </div>
+    </>
   );
 });

--- a/packages/core/src/overlay/OverlayPanelContent.tsx
+++ b/packages/core/src/overlay/OverlayPanelContent.tsx
@@ -40,14 +40,20 @@ export const OverlayPanelContent = forwardRef<
 
   return (
     <>
-      <div className={clsx({ [withBaseName("scroll")]: scrollTop > 0 })} />
       <div
-        className={clsx(withBaseName(), className)}
-        onScroll={handleScroll}
-        {...rest}
-        ref={ref}
-      >
-        {children}
+        className={clsx(withBaseName("separator"), {
+          [withBaseName("scroll")]: scrollTop > 0,
+        })}
+      />
+      <div className={clsx(withBaseName("container"))}>
+        <div
+          className={clsx(withBaseName(), className)}
+          onScroll={handleScroll}
+          {...rest}
+          ref={ref}
+        >
+          {children}
+        </div>
       </div>
     </>
   );

--- a/packages/core/src/overlay/index.ts
+++ b/packages/core/src/overlay/index.ts
@@ -1,4 +1,5 @@
 export * from "./Overlay";
+export * from "./OverlayHeader";
 export * from "./OverlayTrigger";
 export * from "./OverlayPanel";
 export * from "./OverlayPanelCloseButton";

--- a/packages/core/stories/dialog/dialog.stories.tsx
+++ b/packages/core/stories/dialog/dialog.stories.tsx
@@ -2,13 +2,13 @@ import {
   Button,
   Dialog,
   DialogActions,
-  DialogCloseButton,
   DialogContent,
   type DialogContentProps,
   DialogHeader,
   type DialogProps,
   StackLayout,
 } from "@salt-ds/core";
+import { CloseIcon } from "@salt-ds/icons";
 import type { Meta, StoryFn } from "@storybook/react";
 import {
   type ComponentProps,
@@ -23,7 +23,10 @@ export default {
   title: "Core/Dialog",
   component: Dialog,
   args: {
-    header: "Congratulations! You have created a Dialog.",
+    open: true,
+    preheader: "Settlements",
+    header: "Terms and conditions",
+    description: "Effective date: August 29, 2024",
     content:
       "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
   },
@@ -40,12 +43,16 @@ const UnmountLogger = () => {
 
 const DialogTemplate: StoryFn<
   Omit<DialogProps, "content"> &
-    Pick<ComponentProps<typeof DialogHeader>, "header" | "preheader"> & {
+    Pick<
+      ComponentProps<typeof DialogHeader>,
+      "header" | "preheader" | "description"
+    > & {
       content: DialogContentProps["children"];
     }
 > = ({
   header,
   preheader,
+  description,
   content,
   id,
   size,
@@ -66,6 +73,12 @@ const DialogTemplate: StoryFn<
     setOpen(false);
   };
 
+  const CloseButton = () => (
+    <Button aria-label="Close dialog" variant="secondary" onClick={handleClose}>
+      <CloseIcon aria-hidden />
+    </Button>
+  );
+
   return (
     <>
       <Button data-testid="dialog-button" onClick={handleRequestOpen}>
@@ -78,7 +91,12 @@ const DialogTemplate: StoryFn<
         id={id}
         size={size}
       >
-        <DialogHeader header={header} preheader={preheader} />
+        <DialogHeader
+          header={header}
+          preheader={preheader}
+          description={description}
+          endAdornment={<CloseButton />}
+        />
         <DialogContent>
           {content}
           <UnmountLogger />
@@ -92,7 +110,6 @@ const DialogTemplate: StoryFn<
             Next
           </Button>
         </DialogActions>
-        <DialogCloseButton onClick={handleClose} />
       </Dialog>
     </>
   );
@@ -349,13 +366,22 @@ export const StickyFooter: StoryFn<typeof Dialog> = ({
     setOpen(false);
   };
 
+  const CloseButton = () => (
+    <Button aria-label="Close dialog" variant="secondary" onClick={handleClose}>
+      <CloseIcon aria-hidden />
+    </Button>
+  );
+
   return (
     <>
       <Button data-testid="dialog-button" onClick={handleRequestOpen}>
         Click to open dialog
       </Button>
       <Dialog open={open} onOpenChange={onOpenChange} className="longDialog">
-        <DialogHeader header="Congratulations! You have created a Dialog." />
+        <DialogHeader
+          header="Congratulations! You have created a Dialog."
+          endAdornment={<CloseButton />}
+        />
         <DialogContent>
           Lorem Ipsum is simply dummy text of the printing and typesetting
           industry. Lorem Ipsum has been the industry's standard dummy text ever
@@ -371,7 +397,6 @@ export const StickyFooter: StoryFn<typeof Dialog> = ({
             Next
           </Button>
         </DialogActions>
-        <DialogCloseButton onClick={handleClose} />
       </Dialog>
     </>
   );

--- a/packages/core/stories/dialog/dialog.stories.tsx
+++ b/packages/core/stories/dialog/dialog.stories.tsx
@@ -23,7 +23,6 @@ export default {
   title: "Core/Dialog",
   component: Dialog,
   args: {
-    open: true,
     preheader: "Settlements",
     header: "Terms and conditions",
     description: "Effective date: August 29, 2024",

--- a/packages/core/stories/overlay/overlay.qa.stories.tsx
+++ b/packages/core/stories/overlay/overlay.qa.stories.tsx
@@ -1,15 +1,14 @@
 import {
   Button,
   Overlay,
+  OverlayHeader,
   OverlayPanel,
-  OverlayPanelCloseButton,
   OverlayPanelContent,
   OverlayTrigger,
 } from "@salt-ds/core";
 import type { Meta, StoryFn } from "@storybook/react";
 import { QAContainer, type QAContainerProps } from "docs/components";
-
-import "./overlay.stories.css";
+import { CloseIcon } from "@salt-ds/icons";
 
 export default {
   title: "Core/Overlay/Overlay QA",
@@ -31,8 +30,8 @@ export const Default: StoryFn<QAContainerProps> = (props) => {
           <Button>Show Overlay</Button>
         </OverlayTrigger>
         <OverlayPanel>
+          <OverlayHeader header="Title" />
           <OverlayPanelContent>
-            <h3 className="content-heading">Title</h3>
             <div>Content of Overlay</div>
           </OverlayPanelContent>
         </OverlayPanel>
@@ -46,6 +45,15 @@ Default.parameters = {
 };
 
 export const CloseButton: StoryFn<QAContainerProps> = (props) => {
+  const CloseButton = () => (
+    <Button
+      aria-label="Close overlay"
+      appearance="transparent"
+      sentiment="neutral"
+    >
+      <CloseIcon aria-hidden />
+    </Button>
+  );
   return (
     <QAContainer
       height={800}
@@ -60,9 +68,8 @@ export const CloseButton: StoryFn<QAContainerProps> = (props) => {
           <Button>Show Overlay</Button>
         </OverlayTrigger>
         <OverlayPanel>
-          <OverlayPanelCloseButton />
+          <OverlayHeader header="Title" actions={<CloseButton />} />
           <OverlayPanelContent>
-            <h3 className="content-heading">Title</h3>
             <div>Content of Overlay</div>
           </OverlayPanelContent>
         </OverlayPanel>

--- a/packages/core/stories/overlay/overlay.stories.css
+++ b/packages/core/stories/overlay/overlay.stories.css
@@ -1,5 +1,0 @@
-.content-heading {
-  margin: 0 0 var(--salt-spacing-50);
-  font-size: var(--salt-text-fontSize);
-  font-weight: var(--salt-text-fontWeight-strong);
-}

--- a/packages/core/stories/overlay/overlay.stories.tsx
+++ b/packages/core/stories/overlay/overlay.stories.tsx
@@ -18,8 +18,6 @@ import { CloseIcon } from "@salt-ds/icons";
 import type { Meta, StoryFn } from "@storybook/react";
 import { type ChangeEvent, useState } from "react";
 
-import "./overlay.stories.css";
-
 export default {
   title: "Core/Overlay",
 } as Meta<typeof Overlay>;
@@ -34,12 +32,8 @@ export const Default: StoryFn<OverlayProps> = ({ ...args }) => {
       </OverlayTrigger>
 
       <OverlayPanel aria-labelledby={id}>
-        <OverlayPanelContent>
-          <h3 id={id} className="content-heading">
-            Title
-          </h3>
-          <div>Content of Overlay</div>
-        </OverlayPanelContent>
+        <OverlayHeader id={id} header="Title" />
+        <OverlayPanelContent>Content of Overlay</OverlayPanelContent>
       </OverlayPanel>
     </Overlay>
   );
@@ -116,7 +110,8 @@ export const HeaderWithCloseButton = ({ onOpenChange }: OverlayProps) => {
   const CloseButton = () => (
     <Button
       aria-label="Close overlay"
-      variant="secondary"
+      appearance="transparent"
+      sentiment="neutral"
       onClick={handleClose}
     >
       <CloseIcon aria-hidden />
@@ -137,7 +132,7 @@ export const HeaderWithCloseButton = ({ onOpenChange }: OverlayProps) => {
         <OverlayHeader
           id={id}
           header="Header block"
-          endAdornment={<CloseButton />}
+          actions={<CloseButton />}
         />
         <OverlayPanelContent>
           <StackLayout gap={1}>
@@ -173,7 +168,8 @@ export const LongContent = () => {
   const CloseButton = () => (
     <Button
       aria-label="Close overlay"
-      variant="secondary"
+      appearance="transparent"
+      sentiment="neutral"
       onClick={handleClose}
     >
       <CloseIcon aria-hidden />
@@ -186,23 +182,14 @@ export const LongContent = () => {
         <Button>Show Overlay</Button>
       </OverlayTrigger>
       <OverlayPanel aria-labelledby={id} style={{ width: 300 }}>
-        <OverlayHeader
-          id={id}
-          header="New feature"
-          endAdornment={<CloseButton />}
-        />
-        <OverlayPanelContent
-          style={{
-            height: 100,
-            overflow: "auto",
-          }}
-        >
+        <OverlayHeader id={id} header="New feature" actions={<CloseButton />} />
+        <OverlayPanelContent style={{ height: 100 }}>
           <StackLayout gap={1}>
             <Text>
               A global leader, we deliver strategic advice and solutions,
               including capital raising, risk management, and trade finance to
               corporations, institutions and governments. A global leader, we
-              deliver strategic advice and solutions, including capitai raising,
+              deliver strategic advice and solutions, including capital raising,
               risk management, and trade finance to corporations, institutions
               and governments. A global leader, we deliver strategic advice and
               solutions, including capital raising, risk management, and trade

--- a/packages/core/stories/overlay/overlay.stories.tsx
+++ b/packages/core/stories/overlay/overlay.stories.tsx
@@ -61,7 +61,7 @@ Right.args = {
 };
 
 export const Header = ({ onOpenChange }: OverlayProps) => {
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(false);
   const id = useId();
 
   const onChange = (newOpen: boolean) => {
@@ -103,7 +103,7 @@ export const Header = ({ onOpenChange }: OverlayProps) => {
 };
 
 export const HeaderWithCloseButton = ({ onOpenChange }: OverlayProps) => {
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(false);
   const id = useId();
 
   const onChange = (newOpen: boolean) => {
@@ -112,6 +112,16 @@ export const HeaderWithCloseButton = ({ onOpenChange }: OverlayProps) => {
   };
 
   const handleClose = () => setOpen(false);
+
+  const CloseButton = () => (
+    <Button
+      aria-label="Close overlay"
+      variant="secondary"
+      onClick={handleClose}
+    >
+      <CloseIcon aria-hidden />
+    </Button>
+  );
 
   return (
     <Overlay open={open} onOpenChange={onChange}>
@@ -127,15 +137,7 @@ export const HeaderWithCloseButton = ({ onOpenChange }: OverlayProps) => {
         <OverlayHeader
           id={id}
           header="Header block"
-          endAdornment={
-            <Button
-              aria-label="Close dialog"
-              variant="secondary"
-              onClick={handleClose}
-            >
-              <CloseIcon aria-hidden />
-            </Button>
-          }
+          endAdornment={<CloseButton />}
         />
         <OverlayPanelContent>
           <StackLayout gap={1}>

--- a/packages/core/stories/overlay/overlay.stories.tsx
+++ b/packages/core/stories/overlay/overlay.stories.tsx
@@ -4,15 +4,17 @@ import {
   CheckboxGroup,
   Divider,
   Overlay,
+  OverlayHeader,
   OverlayPanel,
-  OverlayPanelCloseButton,
   OverlayPanelContent,
   type OverlayProps,
   OverlayTrigger,
   StackLayout,
+  Text,
   Tooltip,
   useId,
 } from "@salt-ds/core";
+import { CloseIcon } from "@salt-ds/icons";
 import type { Meta, StoryFn } from "@storybook/react";
 import { type ChangeEvent, useState } from "react";
 
@@ -58,8 +60,50 @@ Right.args = {
   placement: "right",
 };
 
-export const CloseButton = ({ onOpenChange }: OverlayProps) => {
-  const [open, setOpen] = useState(false);
+export const Header = ({ onOpenChange }: OverlayProps) => {
+  const [open, setOpen] = useState(true);
+  const id = useId();
+
+  const onChange = (newOpen: boolean) => {
+    setOpen(newOpen);
+    onOpenChange?.(newOpen);
+  };
+
+  return (
+    <Overlay open={open} onOpenChange={onChange}>
+      <OverlayTrigger>
+        <Button>Show Overlay</Button>
+      </OverlayTrigger>
+      <OverlayPanel
+        aria-labelledby={id}
+        style={{
+          width: 500,
+        }}
+      >
+        <OverlayHeader id={id} header="Header block" />
+        <OverlayPanelContent>
+          <StackLayout gap={1}>
+            <Text>
+              Content of Overlay. Lorem Ipsum is simply dummy text of the
+              printing and typesetting industry. Lorem Ipsum has been the
+              industry's standard dummy text ever since the 1500s. When an
+              unknown printer took a galley of type and scrambled it to make a
+              type specimen book.
+            </Text>
+            <div>
+              <Tooltip content={"I'm a tooltip"}>
+                <Button>hover me</Button>
+              </Tooltip>
+            </div>
+          </StackLayout>
+        </OverlayPanelContent>
+      </OverlayPanel>
+    </Overlay>
+  );
+};
+
+export const HeaderWithCloseButton = ({ onOpenChange }: OverlayProps) => {
+  const [open, setOpen] = useState(true);
   const id = useId();
 
   const onChange = (newOpen: boolean) => {
@@ -74,20 +118,40 @@ export const CloseButton = ({ onOpenChange }: OverlayProps) => {
       <OverlayTrigger>
         <Button>Show Overlay</Button>
       </OverlayTrigger>
-      <OverlayPanel aria-labelledby={id}>
-        <OverlayPanelCloseButton onClick={handleClose} />
+      <OverlayPanel
+        aria-labelledby={id}
+        style={{
+          width: 500,
+        }}
+      >
+        <OverlayHeader
+          id={id}
+          header="Header block"
+          endAdornment={
+            <Button
+              aria-label="Close dialog"
+              variant="secondary"
+              onClick={handleClose}
+            >
+              <CloseIcon aria-hidden />
+            </Button>
+          }
+        />
         <OverlayPanelContent>
-          <h3 id={id} className="content-heading">
-            Title
-          </h3>
-          <div>
-            Content of Overlay
-            <br />
-            <br />
-            <Tooltip content={"I'm a tooltip"}>
-              <Button>hover me</Button>
-            </Tooltip>
-          </div>
+          <StackLayout gap={1}>
+            <Text>
+              Content of Overlay. Lorem Ipsum is simply dummy text of the
+              printing and typesetting industry. Lorem Ipsum has been the
+              industry's standard dummy text ever since the 1500s. When an
+              unknown printer took a galley of type and scrambled it to make a
+              type specimen book.
+            </Text>
+            <div>
+              <Tooltip content={"I'm a tooltip"}>
+                <Button>hover me</Button>
+              </Tooltip>
+            </div>
+          </StackLayout>
         </OverlayPanelContent>
       </OverlayPanel>
     </Overlay>
@@ -95,42 +159,73 @@ export const CloseButton = ({ onOpenChange }: OverlayProps) => {
 };
 
 export const LongContent = () => {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(true);
+  const id = useId();
 
   const onOpenChange = (newOpen: boolean) => {
     setOpen(newOpen);
   };
 
   const handleClose = () => setOpen(false);
+
+  const CloseButton = () => (
+    <Button
+      aria-label="Close overlay"
+      variant="secondary"
+      onClick={handleClose}
+    >
+      <CloseIcon aria-hidden />
+    </Button>
+  );
+
   return (
-    <Overlay placement="right" open={open} onOpenChange={onOpenChange}>
+    <Overlay open={open} onOpenChange={onOpenChange}>
       <OverlayTrigger>
         <Button>Show Overlay</Button>
       </OverlayTrigger>
-      <OverlayPanel
-        style={{
-          width: 300,
-          height: 200,
-          overflow: "auto",
-        }}
-      >
-        <OverlayPanelCloseButton onClick={handleClose} />
-        <OverlayPanelContent>
-          <StackLayout>
-            <div>
-              Lorem Ipsum is simply dummy text of the printing and typesetting
-              industry. Lorem Ipsum has been the industry's standard dummy text
-              ever since the 1500s, when an unknown printer took a galley of
-              type and scrambled it to make a type specimen book.
-            </div>
-            <div>
-              It has survived not only five centuries, but also the leap into
-              electronic typesetting, remaining essentially unchanged. It was
-              popularised in the 1960s with the release of Letraset sheets
-              containing Lorem Ipsum passages, and more recently with desktop
-              publishing software like Aldus PageMaker including versions of
-              Lorem Ipsum.
-            </div>
+      <OverlayPanel aria-labelledby={id} style={{ width: 300 }}>
+        <OverlayHeader
+          id={id}
+          header="New feature"
+          endAdornment={<CloseButton />}
+        />
+        <OverlayPanelContent
+          style={{
+            height: 100,
+            overflow: "auto",
+          }}
+        >
+          <StackLayout gap={1}>
+            <Text>
+              A global leader, we deliver strategic advice and solutions,
+              including capital raising, risk management, and trade finance to
+              corporations, institutions and governments. A global leader, we
+              deliver strategic advice and solutions, including capitai raising,
+              risk management, and trade finance to corporations, institutions
+              and governments. A global leader, we deliver strategic advice and
+              solutions, including capital raising, risk management, and trade
+              finance to corporations, institutions and governments.
+            </Text>
+            <Text>
+              A global leader, we deliver strategic advice and solutions,
+              including capital raising, risk management, and trade finance to
+              corporations, institutions and governments. A global leader, we
+              deliver strategic advice and solutions, including capital raising,
+              risk management, and trade finance to corporations, institutions
+              and governments. A global leader, we deliver strategic advice and
+              solutions, including capital raising, risk management, and trade
+              finance to corporations, institutions and governments. A global
+              leader, we deliver strategic advice and solutions, including
+              capital raising, risk management, and trade finance to
+              corporations, institutions and governments.
+            </Text>
+            <Text>Markets</Text>
+            <Text>
+              Serving the world's largest corporate clients and institutional
+              investors, we support the investment cycle with market-leading
+              research, analytics and trade execution across multiple asset
+              classes.
+            </Text>
           </StackLayout>
         </OverlayPanelContent>
       </OverlayPanel>

--- a/site/src/examples/overlay/CloseButton.tsx
+++ b/site/src/examples/overlay/CloseButton.tsx
@@ -1,15 +1,14 @@
 import {
   Button,
   Overlay,
+  OverlayHeader,
   OverlayPanel,
-  OverlayPanelCloseButton,
   OverlayPanelContent,
   OverlayTrigger,
   useId,
 } from "@salt-ds/core";
 import { type ReactElement, useState } from "react";
-
-import styles from "./index.module.css";
+import { CloseIcon } from "@salt-ds/icons";
 
 export const CloseButton = (): ReactElement => {
   const [open, setOpen] = useState(false);
@@ -18,18 +17,24 @@ export const CloseButton = (): ReactElement => {
   const onOpenChange = (newOpen: boolean) => setOpen(newOpen);
 
   const handleClose = () => setOpen(false);
-
+  const CloseButton = () => (
+    <Button
+      aria-label="Close overlay"
+      appearance="transparent"
+      sentiment="neutral"
+      onClick={handleClose}
+    >
+      <CloseIcon aria-hidden />
+    </Button>
+  );
   return (
     <Overlay placement="right" open={open} onOpenChange={onOpenChange}>
       <OverlayTrigger>
         <Button>Show Overlay</Button>
       </OverlayTrigger>
       <OverlayPanel aria-labelledby={id}>
-        <OverlayPanelCloseButton onClick={handleClose} />
+        <OverlayHeader id={id} header="Title" actions={<CloseButton />} />
         <OverlayPanelContent>
-          <h3 className={styles.contentHeading} id={id}>
-            Title
-          </h3>
           <div>Content of Overlay</div>
         </OverlayPanelContent>
       </OverlayPanel>

--- a/site/src/examples/overlay/Default.tsx
+++ b/site/src/examples/overlay/Default.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   Overlay,
+  OverlayHeader,
   OverlayPanel,
   OverlayPanelContent,
   OverlayTrigger,
@@ -8,8 +9,6 @@ import {
   useId,
 } from "@salt-ds/core";
 import type { ReactElement } from "react";
-
-import styles from "./index.module.css";
 
 export const Default = (): ReactElement => {
   const id = useId();
@@ -19,10 +18,8 @@ export const Default = (): ReactElement => {
         <Button>Show Overlay</Button>
       </OverlayTrigger>
       <OverlayPanel aria-labelledby={id}>
+        <OverlayHeader id={id} header="Title" />
         <OverlayPanelContent>
-          <h3 className={styles.contentHeading} id={id}>
-            Title
-          </h3>
           <div>
             Content of Overlay
             <br />

--- a/site/src/examples/overlay/LongContent.tsx
+++ b/site/src/examples/overlay/LongContent.tsx
@@ -1,13 +1,14 @@
 import {
   Button,
   Overlay,
+  OverlayHeader,
   OverlayPanel,
-  OverlayPanelCloseButton,
   OverlayPanelContent,
   OverlayTrigger,
   StackLayout,
 } from "@salt-ds/core";
 import { type ReactElement, useState } from "react";
+import { CloseIcon } from "@salt-ds/icons";
 
 export const LongContent = (): ReactElement => {
   const [open, setOpen] = useState(false);
@@ -15,7 +16,16 @@ export const LongContent = (): ReactElement => {
   const onOpenChange = (newOpen: boolean) => setOpen(newOpen);
 
   const handleClose = () => setOpen(false);
-
+  const CloseButton = () => (
+    <Button
+      aria-label="Close overlay"
+      appearance="transparent"
+      sentiment="neutral"
+      onClick={handleClose}
+    >
+      <CloseIcon aria-hidden />
+    </Button>
+  );
   return (
     <Overlay placement="right" open={open} onOpenChange={onOpenChange}>
       <OverlayTrigger>
@@ -24,12 +34,11 @@ export const LongContent = (): ReactElement => {
       <OverlayPanel
         style={{
           width: 300,
-          height: 200,
           overflow: "auto",
         }}
       >
-        <OverlayPanelCloseButton onClick={handleClose} />
-        <OverlayPanelContent>
+        <OverlayHeader actions={<CloseButton />} />
+        <OverlayPanelContent style={{ height: 100 }}>
           <StackLayout>
             <div>
               Lorem Ipsum is simply dummy text of the printing and typesetting

--- a/site/src/examples/overlay/Placement.tsx
+++ b/site/src/examples/overlay/Placement.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   Overlay,
+  OverlayHeader,
   OverlayPanel,
   OverlayPanelContent,
   type OverlayProps,
@@ -9,7 +10,6 @@ import {
   useId,
 } from "@salt-ds/core";
 import type { ReactElement } from "react";
-import styles from "./index.module.css";
 
 export const OverlayTemplate = (props: OverlayProps): ReactElement => {
   const { placement, ...rest } = props;
@@ -21,10 +21,8 @@ export const OverlayTemplate = (props: OverlayProps): ReactElement => {
         <Button>{placement}</Button>
       </OverlayTrigger>
       <OverlayPanel aria-labelledby={id}>
+        <OverlayHeader id={id} header="Title" />
         <OverlayPanelContent>
-          <h3 id={id} className={styles.contentHeading}>
-            Title
-          </h3>
           <div>
             Content of Overlay
             <br />

--- a/site/src/examples/overlay/WithActions.tsx
+++ b/site/src/examples/overlay/WithActions.tsx
@@ -4,6 +4,7 @@ import {
   CheckboxGroup,
   Divider,
   Overlay,
+  OverlayHeader,
   OverlayPanel,
   OverlayPanelContent,
   OverlayTrigger,
@@ -71,35 +72,27 @@ const WithActionsContent = ({ id, onClose }: WithActionsContentProps) => {
   };
 
   return (
-    <>
-      <h3 id={id} style={{ marginTop: 0, paddingBottom: 10 }}>
+    <StackLayout gap={1}>
+      <Checkbox
+        indeterminate={indeterminate}
+        checked={!indeterminate}
+        label={`${controlledValues.length} of 2 selected`}
+        onChange={handleChange}
+      />
+      <Divider variant="secondary" />
+      <CheckboxGroup
+        checkedValues={controlledValues}
+        onChange={handleGroupChange}
+      >
+        {checkboxesData.map((data) => (
+          <Checkbox key={data.value} {...data} />
+        ))}
+      </CheckboxGroup>
+      <Divider variant="secondary" />
+      <Button style={{ float: "right", marginRight: 2 }} onClick={handleExport}>
         Export
-      </h3>
-      <StackLayout gap={1}>
-        <Checkbox
-          indeterminate={indeterminate}
-          checked={!indeterminate}
-          label={`${controlledValues.length} of 2 selected`}
-          onChange={handleChange}
-        />
-        <Divider variant="secondary" />
-        <CheckboxGroup
-          checkedValues={controlledValues}
-          onChange={handleGroupChange}
-        >
-          {checkboxesData.map((data) => (
-            <Checkbox key={data.value} {...data} />
-          ))}
-        </CheckboxGroup>
-        <Divider variant="secondary" />
-        <Button
-          style={{ float: "right", marginRight: 2 }}
-          onClick={handleExport}
-        >
-          Export
-        </Button>
-      </StackLayout>
-    </>
+      </Button>
+    </StackLayout>
   );
 };
 
@@ -126,6 +119,7 @@ export const WithActions = () => {
         }}
         aria-labelledby={id}
       >
+        <OverlayHeader id={id} header="Export" />
         <OverlayPanelContent>
           <WithActionsContent
             id={id}


### PR DESCRIPTION
* Adds new `OverlayHeader` component to replace deprecated `OverlayPanelCloseButton`
* Updates `DialogHeader` to match updated Figma spec and deprecate `DialogCloseButton`