### PR TITLE
Fix `.editable-cell` incorrectly set right text align

### DIFF
--- a/.changeset/ninety-bottles-deny.md
+++ b/.changeset/ninety-bottles-deny.md
@@ -2,4 +2,4 @@
 "@salt-ds/ag-grid-theme": patch
 ---
 
-Fixed `.editable-cell` incorrectly set text align. For numeric columns, use both `.edtiable-cell` and `.numeric-cell` for `cellClass`. Fixes #4141.
+Fixed `.editable-cell` incorrectly setting text-align. For numeric columns, use both `.edtiable-cell` and `.numeric-cell` for `cellClass`. Fixes #4141.

--- a/.changeset/ninety-bottles-deny.md
+++ b/.changeset/ninety-bottles-deny.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/ag-grid-theme": patch
+---
+
+Fixed `.editable-cell` incorrectly set text align. For numeric columns, use both `.edtiable-cell` and `.numeric-cell` for `cellClass`. Fixes #4141.

--- a/packages/ag-grid-theme/css/salt-ag-grid-theme.css
+++ b/packages/ag-grid-theme/css/salt-ag-grid-theme.css
@@ -280,10 +280,10 @@ div[class*="ag-theme-salt"] .editable-cell,
 div[class*="ag-theme-salt"] .editable-numeric-cell {
   outline: var(--salt-size-border) var(--salt-container-borderStyle) var(--salt-editable-borderColor);
   outline-offset: -1px;
-  text-align: right;
 }
 
-div[class*="ag-theme-salt"] .ag-cell.numeric-cell {
+div[class*="ag-theme-salt"] .ag-cell.numeric-cell,
+div[class*="ag-theme-salt"] .editable-numeric-cell {
   text-align: right;
 }
 

--- a/packages/ag-grid-theme/src/dependencies/dataGridExampleColumns.ts
+++ b/packages/ag-grid-theme/src/dependencies/dataGridExampleColumns.ts
@@ -44,7 +44,7 @@ const dataGridExampleColumns: ColDef[] = [
     field: "population",
     filter: "agNumberColumnFilter",
     editable: true,
-    // This is only here for backwards compatility. Use above 2 classes combination instead.
+    // This is only here for backwards compatibility. Use the combination of the above two classes instead.
     cellClass: ["editable-numeric-cell"],
   },
   {

--- a/packages/ag-grid-theme/src/dependencies/dataGridExampleColumns.ts
+++ b/packages/ag-grid-theme/src/dependencies/dataGridExampleColumns.ts
@@ -36,28 +36,23 @@ const dataGridExampleColumns: ColDef[] = [
     field: "population",
     filter: "agNumberColumnFilter",
     editable: true,
-    cellClass: ["editable-cell"],
+    cellClass: ["numeric-cell", "editable-cell"],
   },
   {
-    headerName: "Population",
+    headerName: "Population (editable numeric)",
     type: "numericColumn",
     field: "population",
     filter: "agNumberColumnFilter",
     editable: true,
-    cellClass: ["numeric-cell", "editable-cell"],
-  },
-  {
-    headerName: "Population",
-    type: "numericColumn",
-    field: "population",
-    filter: "agNumberColumnFilter",
-    editable: true,
-    cellClass: ["numeric-cell", "editable-cell"],
+    // This is only here for backwards compatility. Use above 2 classes combination instead.
+    cellClass: ["editable-numeric-cell"],
   },
   {
     headerName: "Date",
     field: "date",
     filter: "agDateColumnFilter",
+    editable: true,
+    cellClass: ["editable-cell"],
   },
 ];
 export default dataGridExampleColumns;

--- a/packages/ag-grid-theme/src/dependencies/dataGridExampleColumnsHdCompact.ts
+++ b/packages/ag-grid-theme/src/dependencies/dataGridExampleColumnsHdCompact.ts
@@ -38,7 +38,7 @@ const dataGridExampleColumnsHdCompact: ColDef[] = [
     field: "population",
     filter: "agNumberColumnFilter",
     editable: true,
-    cellClass: ["editable-cell"],
+    cellClass: ["numeric-cell", "editable-cell"],
   },
   {
     headerName: "Date",

--- a/site/src/examples/ag-grid-theme/data/defaultColumns.ts
+++ b/site/src/examples/ag-grid-theme/data/defaultColumns.ts
@@ -39,24 +39,10 @@ export const defaultColumns: ColDef[] = [
     cellClass: ["numeric-cell", "editable-cell"],
   },
   {
-    headerName: "Population",
-    type: "numericColumn",
-    field: "population",
-    filter: "agNumberColumnFilter",
-    editable: true,
-    cellClass: ["numeric-cell", "editable-cell"],
-  },
-  {
-    headerName: "Population",
-    type: "numericColumn",
-    field: "population",
-    filter: "agNumberColumnFilter",
-    editable: true,
-    cellClass: ["numeric-cell", "editable-cell"],
-  },
-  {
     headerName: "Date",
     field: "date",
     filter: "agDateColumnFilter",
+    editable: true,
+    cellClass: ["editable-cell"],
   },
 ];


### PR DESCRIPTION
`.edtiable-cell` should only be setting the border / corner flag styling. `.numeric-cell` is the one for right alignment (for both header and body cells)

#4141