### PR TITLE
enable missing next theme in qas

### DIFF
--- a/packages/ag-grid-theme/src/examples/Default.tsx
+++ b/packages/ag-grid-theme/src/examples/Default.tsx
@@ -10,6 +10,15 @@ const Default = ({
     containerClassName,
   });
 
+  const statusBar = {
+    statusPanels: [
+      {
+        statusPanel: "agTotalRowCountComponent",
+        align: "right",
+      },
+    ],
+  };
+
   return (
     <div {...containerProps}>
       <AgGridReact
@@ -37,6 +46,7 @@ const Default = ({
         ]}
         rowData={dataGridExampleData}
         rowSelection="single"
+        statusBar={statusBar}
         enableRangeSelection={true}
       />
     </div>

--- a/packages/core/src/dialog/Dialog.tsx
+++ b/packages/core/src/dialog/Dialog.tsx
@@ -104,7 +104,7 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>(
 
     const id = useId(idProp);
 
-    const currentbreakpoint = useCurrentBreakpoint();
+    const currentBreakpoint = useCurrentBreakpoint();
 
     const [showComponent, setShowComponent] = useState(false);
 
@@ -154,7 +154,7 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>(
             }}
             className={clsx(
               withBaseName(),
-              withBaseName(size, currentbreakpoint),
+              withBaseName(size, currentBreakpoint),
               {
                 [withBaseName("enterAnimation")]: open,
                 [withBaseName("exitAnimation")]: !open,

--- a/packages/core/stories/dialog/dialog.qa.stories.tsx
+++ b/packages/core/stories/dialog/dialog.qa.stories.tsx
@@ -4,16 +4,39 @@ import {
   DialogActions,
   DialogCloseButton,
   DialogContent,
+  DialogContext,
   DialogHeader,
   type DialogProps,
-  FlowLayout,
-  VALIDATION_NAMED_STATUS,
+  FormField,
+  FormFieldLabel,
+  Input,
+  StackLayout,
 } from "@salt-ds/core";
 import type { Meta, StoryFn } from "@storybook/react";
 import { QAContainer, type QAContainerProps } from "docs/components";
 
 import "./dialog.stories.css";
-import { Fragment } from "react";
+
+function FakeDialog({ children, status, id }: DialogProps) {
+  return (
+    <DialogContext.Provider value={{ status, id }}>
+      <div className="fakeDialogWindow">{children}</div>
+    </DialogContext.Provider>
+  );
+}
+
+function FakeLongDialog({ children, status, id }: DialogProps) {
+  return (
+    <DialogContext.Provider value={{ status, id }}>
+      <div
+        className="fakeDialogWindow longDialog"
+        style={{ display: "flex", flexDirection: "column" }}
+      >
+        {children}
+      </div>
+    </DialogContext.Provider>
+  );
+}
 
 export default {
   title: "Core/Dialog/QA",
@@ -26,194 +49,232 @@ const DialogTemplate: StoryFn<DialogProps & { header: string }> = ({
   header,
 }) => {
   return (
-    <Dialog status={status} open={openProp}>
-      <DialogHeader header={header} />
-      <DialogContent>This is dialog content...</DialogContent>
-      <DialogActions>
-        <Button style={{ marginRight: "auto" }} appearance="transparent">
-          Cancel
-        </Button>
-        <Button>Previous</Button>
-        <Button sentiment="accented" appearance="transparent">
-          Next
-        </Button>
-      </DialogActions>
-      <DialogCloseButton />
-    </Dialog>
+    <StackLayout>
+      <FakeDialog status={status}>
+        <DialogHeader header={header} />
+        <DialogContent>This is dialog content...</DialogContent>
+        <DialogActions>
+          <Button style={{ marginRight: "auto" }} variant="secondary">
+            Cancel
+          </Button>
+          <Button>Previous</Button>
+          <Button variant="cta">Next</Button>
+        </DialogActions>
+        <DialogCloseButton />
+      </FakeDialog>
+    </StackLayout>
   );
 };
 
-export const StatusVariants: StoryFn<QAContainerProps> = () => {
-  const DensityValues = ["high", "medium", "low", "touch"] as const;
+export const Default: StoryFn<QAContainerProps> = (props) => {
+  const { ...rest } = props;
   return (
-    <FlowLayout gap={0}>
-      {DensityValues.map((density) => (
-        <Fragment key={density}>
-          <iframe
-            title={`dialog ${density} example`}
-            src={`/iframe.html?globals=density:${density}&args=open:!true&id=core-dialog--default&viewMode=story`}
-            style={{ border: "none", width: 1200, height: 380 }}
-          />
-          <iframe
-            title={`dialog ${density} in dark mode example`}
-            src={`/iframe.html?globals=mode:dark;density:${density}&args=open:!true&id=core-dialog--default&viewMode=story`}
-            style={{ border: "none", width: 1200, height: 380 }}
-          />
-          {VALIDATION_NAMED_STATUS.map((status) => (
-            <Fragment key={status}>
-              <iframe
-                title={`dialog ${density} ${status} example`}
-                src={`/iframe.html?globals=density:${density}&args=open:!true;status:${status}&id=core-dialog--default&viewMode=story`}
-                style={{ border: "none", width: 1200, height: 380 }}
-              />
-              <iframe
-                title={`dialog ${density} ${status} in dark mode example`}
-                src={`/iframe.html?globals=mode:dark;density:${density}&args=open:!true;status:${status}&id=core-dialog--default&viewMode=story`}
-                style={{ border: "none", width: 1200, height: 380 }}
-              />
-            </Fragment>
-          ))}
-        </Fragment>
-      ))}
-    </FlowLayout>
+    <QAContainer cols={3} height={300} itemPadding={3} {...rest}>
+      <DialogTemplate header={"Dialog Title"} />
+    </QAContainer>
   );
 };
 
-StatusVariants.parameters = {
-  chromatic: {
-    disableSnapshot: false,
-    modes: {
-      theme: {
-        themeNext: "disable",
-      },
-      themeNext: {
-        themeNext: "enable",
-        corner: "rounded",
-        accent: "teal",
-        // Ignore headingFont given font is not loaded
-      },
-    },
-  },
+Default.parameters = {
+  chromatic: { disableSnapshot: false },
 };
 
-export const ContentVariants: StoryFn<QAContainerProps> = () => {
-  const DensityValues = ["high", "medium", "low", "touch"] as const;
+export const LongContent: StoryFn<QAContainerProps> = () => {
   return (
-    <FlowLayout gap={0}>
-      {DensityValues.map((density) => (
-        <Fragment key={density}>
-          <FlowLayout>
-            <iframe
-              title={`dialog ${density} small example`}
-              src={`/iframe.html?globals=density:${density}&args=open:!true;size:small&id=core-dialog--default&viewMode=story`}
-              style={{ border: "none", width: 400, height: 380 }}
-            />
-            <iframe
-              title={`dialog ${density} medium example`}
-              src={`/iframe.html?globals=density:${density}&args=open:!true;size:medium&id=core-dialog--default&viewMode=story`}
-              style={{ border: "none", width: 800, height: 380 }}
-            />
-            <iframe
-              title={`dialog ${density} large example`}
-              src={`/iframe.html?globals=density:${density}&args=open:!true;size:large&id=core-dialog--default&viewMode=story`}
-              style={{ border: "none", width: 1200, height: 380 }}
-            />
-          </FlowLayout>
-          <iframe
-            title={`dialog ${density} sticky footer example`}
-            src={`/iframe.html?globals=density:${density}&args=open:!true&id=core-dialog--sticky-footer&viewMode=story`}
-            style={{ border: "none", width: 1200, height: 380 }}
-          />
-          <iframe
-            title={`dialog ${density} sticky footer in dark mode example`}
-            src={`/iframe.html?globals=mode:dark;density:${density}&args=open:!true&id=core-dialog--sticky-footer&viewMode=story`}
-            style={{ border: "none", width: 1200, height: 380 }}
-          />
-          <iframe
-            title={`dialog ${density} long content example`}
-            src={`/iframe.html?globals=density:${density}&args=open:!true&id=core-dialog--long-content&viewMode=story`}
-            style={{ border: "none", width: 1200, height: 380 }}
-          />
-          <iframe
-            title={`dialog ${density} long content in dark mode example`}
-            src={`/iframe.html?globals=mode:dark;density:${density}&args=open:!true&id=core-dialog--long-content&viewMode=story`}
-            style={{ border: "none", width: 1200, height: 380 }}
-          />
-        </Fragment>
-      ))}
-    </FlowLayout>
+    <QAContainer width={1300} itemPadding={3}>
+      <FakeDialog>
+        <DialogHeader
+          header="Congratulations! You have created a Dialog."
+          style={{ width: "500px" }}
+        />
+
+        <DialogContent style={{ height: "500px" }}>
+          <StackLayout>
+            <div>
+              Lorem Ipsum is simply dummy text of the printing and typesetting
+              industry. Lorem Ipsum has been the industry's standard dummy text
+              ever since the 1500s, when an unknown printer took a galley of
+              type and scrambled it to make a type specimen book.
+            </div>
+            <div>
+              It has survived not only five centuries, but also the leap into
+              electronic typesetting, remaining essentially unchanged. It was
+              popularised in the 1960s with the release of Letraset sheets
+              containing Lorem Ipsum passages, and more recently with desktop
+              publishing software like Aldus PageMaker including versions of
+              Lorem Ipsum.
+            </div>
+            <div>
+              It is a long established fact that a reader will be distracted by
+              the readable content of a page when looking at its layout. The
+              point of using Lorem Ipsum is that it has a more-or-less normal
+              distribution of letters, as opposed to using 'Content here,
+              content here', making it look like readable English.
+            </div>
+            <div>
+              Many desktop publishing packages and web page editors now use
+              Lorem Ipsum as their default model text, and a search for 'lorem
+              ipsum' will uncover many web sites still in their infancy. Various
+              versions have evolved over the years, sometimes by accident,
+              sometimes on purpose (injected humour and the like).
+            </div>
+            <div>
+              Contrary to popular belief, Lorem Ipsum is not simply random text.
+              It has roots in a piece of classical Latin literature from 45 BC,
+              making it over 2000 years old. Richard McClintock, a Latin
+              professor at Hampden-Sydney College in Virginia, looked up one of
+              the more obscure Latin words, consectetur, from a Lorem Ipsum
+              passage, and going through the cites of the word in classical
+              literature, discovered the undoubtable source.
+            </div>
+            <div>
+              Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus
+              Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero,
+              written in 45 BC. This book is a treatise on the theory of ethics,
+              very popular during the Renaissance. The first line of Lorem
+              Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in
+              section 1.10.32.
+            </div>
+          </StackLayout>
+        </DialogContent>
+        <DialogActions>
+          <Button>Cancel</Button>
+          <Button variant="cta">Subscribe</Button>
+        </DialogActions>
+      </FakeDialog>
+    </QAContainer>
   );
 };
 
-ContentVariants.parameters = {
-  chromatic: {
-    disableSnapshot: false,
-    modes: {
-      theme: {
-        themeNext: "disable",
-      },
-      themeNext: {
-        themeNext: "enable",
-        corner: "rounded",
-        accent: "teal",
-        // Ignore headingFont given font is not loaded
-      },
-    },
-  },
+LongContent.parameters = {
+  chromatic: { disableSnapshot: false },
 };
 
-export const DialogHeaders: StoryFn<QAContainerProps> = () => (
-  <QAContainer
-    height={600}
-    cols={1}
-    itemPadding={5}
-    width={1200}
-    // vertical
-    // transposeDensity
-  >
-    <DialogHeader
-      header="Terms and conditions"
-      style={{
-        width: 600,
-      }}
-    />
-    <DialogHeader
-      style={{
-        width: 600,
-      }}
-      header="Terms and conditions"
-      preheader="Ensure you read and agree to these Terms"
-    />
-    <DialogHeader
-      status="info"
-      header="Terms and conditions"
-      style={{
-        width: 600,
-      }}
-    />
-    <DialogHeader
-      status="info"
-      style={{
-        width: 600,
-      }}
-      header="Terms and conditions"
-      preheader="Ensure you read and agree to these Terms"
-    />
-  </QAContainer>
-);
-DialogHeaders.parameters = {
-  chromatic: {
-    disableSnapshot: false,
-    modes: {
-      theme: {
-        themeNext: "disable",
-      },
-      themeNext: {
-        themeNext: "enable",
-        corner: "rounded",
-        accent: "teal",
-        // Ignore headingFont given font is not loaded
-      },
-    },
-  },
+export const Preheader: StoryFn<QAContainerProps> = () => {
+  return (
+    <QAContainer width={1300} itemPadding={3}>
+      <FakeDialog>
+        <DialogHeader
+          header="Subscribe"
+          preheader="Recieve emails about the latest updates"
+          style={{ width: "500px" }}
+        />
+        <DialogCloseButton />
+
+        <DialogContent>
+          <FormField necessity="asterisk">
+            <FormFieldLabel> Email </FormFieldLabel>
+            <Input defaultValue="Email Address" />
+          </FormField>
+        </DialogContent>
+        <DialogActions>
+          <Button>Cancel</Button>
+          <Button variant="cta">Subscribe</Button>
+        </DialogActions>
+      </FakeDialog>
+    </QAContainer>
+  );
+};
+
+Preheader.parameters = {
+  chromatic: { disableSnapshot: false },
+};
+
+type sizes = "small" | "medium" | "large";
+
+const sizes: sizes[] = ["small", "medium", "large"];
+
+export const SizeDialog: StoryFn<QAContainerProps> = (props) => {
+  const { ...rest } = props;
+  return (
+    <QAContainer cols={3} height={300} itemPadding={3} width={3000} {...rest}>
+      {sizes.map((size) => {
+        return <DialogTemplate key={size} header={"Info Dialog"} size={size} />;
+      })}
+    </QAContainer>
+  );
+};
+
+SizeDialog.parameters = {
+  chromatic: { disableSnapshot: false },
+};
+
+export const InfoDialog: StoryFn<QAContainerProps> = (props) => {
+  const { ...rest } = props;
+  return (
+    <QAContainer cols={3} height={300} itemPadding={3} width={1300} {...rest}>
+      <DialogTemplate status={"info"} header={"Info Dialog"} />
+    </QAContainer>
+  );
+};
+
+InfoDialog.parameters = {
+  chromatic: { disableSnapshot: false },
+};
+
+export const SuccessDialog: StoryFn<QAContainerProps> = (props) => {
+  const { ...rest } = props;
+  return (
+    <QAContainer cols={3} height={300} itemPadding={3} width={1300} {...rest}>
+      <DialogTemplate status={"success"} header={"Success Dialog"} />
+    </QAContainer>
+  );
+};
+
+SuccessDialog.parameters = {
+  chromatic: { disableSnapshot: false },
+};
+
+export const WarningDialog: StoryFn<QAContainerProps> = (props) => {
+  const { ...rest } = props;
+  return (
+    <QAContainer cols={3} height={300} itemPadding={3} width={1300} {...rest}>
+      <DialogTemplate status={"warning"} header={"Warning Dialog"} />
+    </QAContainer>
+  );
+};
+
+WarningDialog.parameters = {
+  chromatic: { disableSnapshot: false },
+};
+
+export const ErrorDialog: StoryFn<QAContainerProps> = (props) => {
+  const { ...rest } = props;
+  return (
+    <QAContainer cols={3} height={300} itemPadding={3} width={1300} {...rest}>
+      <DialogTemplate status={"error"} header={"Error Dialog"} />
+    </QAContainer>
+  );
+};
+
+ErrorDialog.parameters = {
+  chromatic: { disableSnapshot: false },
+};
+
+export const StickyFooter: StoryFn<QAContainerProps> = () => {
+  return (
+    <QAContainer width={1300} itemPadding={3}>
+      <FakeLongDialog>
+        <DialogHeader
+          header="Congratulations! You have created a Dialog."
+          style={{ width: "500px" }}
+        />
+        <DialogCloseButton />
+        <DialogContent>
+          Lorem Ipsum is simply dummy text of the printing and typesetting
+          industry. Lorem Ipsum has been the industry's standard dummy text ever
+          since the 1500s, when an unknown printer took a galley of type and
+          scrambled it to make a type specimen book.
+        </DialogContent>
+        <DialogActions>
+          <Button>Cancel</Button>
+          <Button variant="cta">Subscribe</Button>
+        </DialogActions>
+      </FakeLongDialog>
+    </QAContainer>
+  );
+};
+
+StickyFooter.parameters = {
+  chromatic: { disableSnapshot: false },
 };

--- a/packages/core/stories/dialog/dialog.qa.stories.tsx
+++ b/packages/core/stories/dialog/dialog.qa.stories.tsx
@@ -50,20 +50,24 @@ export const StatusVariants: StoryFn<QAContainerProps> = () => {
       {DensityValues.map((density) => (
         <Fragment key={density}>
           <iframe
+            title={`dialog ${density} example`}
             src={`/iframe.html?globals=density:${density}&args=open:!true&id=core-dialog--default&viewMode=story`}
             style={{ all: "unset", width: 1200, height: 320 }}
           />
           <iframe
+            title={`dialog ${density} in dark mode example`}
             src={`/iframe.html?globals=mode:dark;density:${density}&args=open:!true&id=core-dialog--default&viewMode=story`}
             style={{ all: "unset", width: 1200, height: 320 }}
           />
           {VALIDATION_NAMED_STATUS.map((status) => (
             <Fragment key={status}>
               <iframe
+                title={`dialog ${density} ${status} example`}
                 src={`/iframe.html?globals=density:${density}&args=open:!true;status:${status}&id=core-dialog--default&viewMode=story`}
                 style={{ all: "unset", width: 1200, height: 320 }}
               />
               <iframe
+                title={`dialog ${density} ${status} in dark mode example`}
                 src={`/iframe.html?globals=mode:dark;density:${density}&args=open:!true;status:${status}&id=core-dialog--default&viewMode=story`}
                 style={{ all: "unset", width: 1200, height: 320 }}
               />
@@ -94,40 +98,44 @@ StatusVariants.parameters = {
 
 export const ContentVariants: StoryFn<QAContainerProps> = () => {
   const DensityValues = ["high", "medium", "low", "touch"] as const;
-  const DialogSizes = ["small", "medium", "large"] as const;
   return (
     <FlowLayout gap={0}>
       {DensityValues.map((density) => (
         <Fragment key={density}>
-          {DialogSizes.map((size) => (
-            <FlowLayout key={size}>
-              <iframe
-                src={`/iframe.html?globals=density:${density}&args=open:!true&id=core-dialog--default&viewMode=story`}
-                style={{ all: "unset", width: 350, height: 320 }}
-              />
-              <iframe
-                src={`/iframe.html?globals=density:${density}&args=open:!true&id=core-dialog--default&viewMode=story`}
-                style={{ all: "unset", width: 700, height: 320 }}
-              />
-              <iframe
-                src={`/iframe.html?globals=density:${density}&args=open:!true&id=core-dialog--default&viewMode=story`}
-                style={{ all: "unset", width: 1200, height: 320 }}
-              />
-            </FlowLayout>
-          ))}
+          <FlowLayout>
+            <iframe
+              title={`dialog ${density} small example`}
+              src={`/iframe.html?globals=density:${density}&args=open:!true;size:small&id=core-dialog--default&viewMode=story`}
+              style={{ all: "unset", width: 350, height: 320 }}
+            />
+            <iframe
+              title={`dialog ${density} medium example`}
+              src={`/iframe.html?globals=density:${density}&args=open:!true;size:medium&id=core-dialog--default&viewMode=story`}
+              style={{ all: "unset", width: 700, height: 320 }}
+            />
+            <iframe
+              title={`dialog ${density} large example`}
+              src={`/iframe.html?globals=density:${density}&args=open:!true;size:large&id=core-dialog--default&viewMode=story`}
+              style={{ all: "unset", width: 1200, height: 320 }}
+            />
+          </FlowLayout>
           <iframe
+            title={`dialog ${density} sticky footer example`}
             src={`/iframe.html?globals=density:${density}&args=open:!true&id=core-dialog--sticky-footer&viewMode=story`}
             style={{ all: "unset", width: 1200, height: 320 }}
           />
           <iframe
+            title={`dialog ${density} sticky footer in dark mode example`}
             src={`/iframe.html?globals=mode:dark;density:${density}&args=open:!true&id=core-dialog--sticky-footer&viewMode=story`}
             style={{ all: "unset", width: 1200, height: 320 }}
           />
           <iframe
+            title={`dialog ${density} long content example`}
             src={`/iframe.html?globals=density:${density}&args=open:!true&id=core-dialog--long-content&viewMode=story`}
             style={{ all: "unset", width: 1200, height: 320 }}
           />
           <iframe
+            title={`dialog ${density} long content in dark mode example`}
             src={`/iframe.html?globals=mode:dark;density:${density}&args=open:!true&id=core-dialog--long-content&viewMode=story`}
             style={{ all: "unset", width: 1200, height: 320 }}
           />

--- a/packages/core/stories/dialog/dialog.qa.stories.tsx
+++ b/packages/core/stories/dialog/dialog.qa.stories.tsx
@@ -52,24 +52,24 @@ export const StatusVariants: StoryFn<QAContainerProps> = () => {
           <iframe
             title={`dialog ${density} example`}
             src={`/iframe.html?globals=density:${density}&args=open:!true&id=core-dialog--default&viewMode=story`}
-            style={{ all: "unset", width: 1200, height: 320 }}
+            style={{ border: "none", width: 1200, height: 380 }}
           />
           <iframe
             title={`dialog ${density} in dark mode example`}
             src={`/iframe.html?globals=mode:dark;density:${density}&args=open:!true&id=core-dialog--default&viewMode=story`}
-            style={{ all: "unset", width: 1200, height: 320 }}
+            style={{ border: "none", width: 1200, height: 380 }}
           />
           {VALIDATION_NAMED_STATUS.map((status) => (
             <Fragment key={status}>
               <iframe
                 title={`dialog ${density} ${status} example`}
                 src={`/iframe.html?globals=density:${density}&args=open:!true;status:${status}&id=core-dialog--default&viewMode=story`}
-                style={{ all: "unset", width: 1200, height: 320 }}
+                style={{ border: "none", width: 1200, height: 380 }}
               />
               <iframe
                 title={`dialog ${density} ${status} in dark mode example`}
                 src={`/iframe.html?globals=mode:dark;density:${density}&args=open:!true;status:${status}&id=core-dialog--default&viewMode=story`}
-                style={{ all: "unset", width: 1200, height: 320 }}
+                style={{ border: "none", width: 1200, height: 380 }}
               />
             </Fragment>
           ))}
@@ -106,38 +106,38 @@ export const ContentVariants: StoryFn<QAContainerProps> = () => {
             <iframe
               title={`dialog ${density} small example`}
               src={`/iframe.html?globals=density:${density}&args=open:!true;size:small&id=core-dialog--default&viewMode=story`}
-              style={{ all: "unset", width: 350, height: 320 }}
+              style={{ border: "none", width: 400, height: 380 }}
             />
             <iframe
               title={`dialog ${density} medium example`}
               src={`/iframe.html?globals=density:${density}&args=open:!true;size:medium&id=core-dialog--default&viewMode=story`}
-              style={{ all: "unset", width: 700, height: 320 }}
+              style={{ border: "none", width: 800, height: 380 }}
             />
             <iframe
               title={`dialog ${density} large example`}
               src={`/iframe.html?globals=density:${density}&args=open:!true;size:large&id=core-dialog--default&viewMode=story`}
-              style={{ all: "unset", width: 1200, height: 320 }}
+              style={{ border: "none", width: 1200, height: 380 }}
             />
           </FlowLayout>
           <iframe
             title={`dialog ${density} sticky footer example`}
             src={`/iframe.html?globals=density:${density}&args=open:!true&id=core-dialog--sticky-footer&viewMode=story`}
-            style={{ all: "unset", width: 1200, height: 320 }}
+            style={{ border: "none", width: 1200, height: 380 }}
           />
           <iframe
             title={`dialog ${density} sticky footer in dark mode example`}
             src={`/iframe.html?globals=mode:dark;density:${density}&args=open:!true&id=core-dialog--sticky-footer&viewMode=story`}
-            style={{ all: "unset", width: 1200, height: 320 }}
+            style={{ border: "none", width: 1200, height: 380 }}
           />
           <iframe
             title={`dialog ${density} long content example`}
             src={`/iframe.html?globals=density:${density}&args=open:!true&id=core-dialog--long-content&viewMode=story`}
-            style={{ all: "unset", width: 1200, height: 320 }}
+            style={{ border: "none", width: 1200, height: 380 }}
           />
           <iframe
             title={`dialog ${density} long content in dark mode example`}
             src={`/iframe.html?globals=mode:dark;density:${density}&args=open:!true&id=core-dialog--long-content&viewMode=story`}
-            style={{ all: "unset", width: 1200, height: 320 }}
+            style={{ border: "none", width: 1200, height: 380 }}
           />
         </Fragment>
       ))}

--- a/packages/core/stories/dialog/dialog.qa.stories.tsx
+++ b/packages/core/stories/dialog/dialog.qa.stories.tsx
@@ -76,9 +76,21 @@ export const Default: StoryFn<QAContainerProps> = (props) => {
 };
 
 Default.parameters = {
-  chromatic: { disableSnapshot: false },
+  chromatic: {
+    disableSnapshot: false,
+    modes: {
+      theme: {
+        themeNext: "disable",
+      },
+      themeNext: {
+        themeNext: "enable",
+        corner: "rounded",
+        accent: "teal",
+        // Ignore headingFont given font is not loaded
+      },
+    },
+  },
 };
-
 export const LongContent: StoryFn<QAContainerProps> = () => {
   return (
     <QAContainer width={1300} itemPadding={3}>
@@ -147,9 +159,21 @@ export const LongContent: StoryFn<QAContainerProps> = () => {
 };
 
 LongContent.parameters = {
-  chromatic: { disableSnapshot: false },
+  chromatic: {
+    disableSnapshot: false,
+    modes: {
+      theme: {
+        themeNext: "disable",
+      },
+      themeNext: {
+        themeNext: "enable",
+        corner: "rounded",
+        accent: "teal",
+        // Ignore headingFont given font is not loaded
+      },
+    },
+  },
 };
-
 export const Preheader: StoryFn<QAContainerProps> = () => {
   return (
     <QAContainer width={1300} itemPadding={3}>
@@ -177,9 +201,21 @@ export const Preheader: StoryFn<QAContainerProps> = () => {
 };
 
 Preheader.parameters = {
-  chromatic: { disableSnapshot: false },
+  chromatic: {
+    disableSnapshot: false,
+    modes: {
+      theme: {
+        themeNext: "disable",
+      },
+      themeNext: {
+        themeNext: "enable",
+        corner: "rounded",
+        accent: "teal",
+        // Ignore headingFont given font is not loaded
+      },
+    },
+  },
 };
-
 type sizes = "small" | "medium" | "large";
 
 const sizes: sizes[] = ["small", "medium", "large"];
@@ -196,9 +232,21 @@ export const SizeDialog: StoryFn<QAContainerProps> = (props) => {
 };
 
 SizeDialog.parameters = {
-  chromatic: { disableSnapshot: false },
+  chromatic: {
+    disableSnapshot: false,
+    modes: {
+      theme: {
+        themeNext: "disable",
+      },
+      themeNext: {
+        themeNext: "enable",
+        corner: "rounded",
+        accent: "teal",
+        // Ignore headingFont given font is not loaded
+      },
+    },
+  },
 };
-
 export const InfoDialog: StoryFn<QAContainerProps> = (props) => {
   const { ...rest } = props;
   return (
@@ -209,9 +257,21 @@ export const InfoDialog: StoryFn<QAContainerProps> = (props) => {
 };
 
 InfoDialog.parameters = {
-  chromatic: { disableSnapshot: false },
+  chromatic: {
+    disableSnapshot: false,
+    modes: {
+      theme: {
+        themeNext: "disable",
+      },
+      themeNext: {
+        themeNext: "enable",
+        corner: "rounded",
+        accent: "teal",
+        // Ignore headingFont given font is not loaded
+      },
+    },
+  },
 };
-
 export const SuccessDialog: StoryFn<QAContainerProps> = (props) => {
   const { ...rest } = props;
   return (
@@ -222,9 +282,21 @@ export const SuccessDialog: StoryFn<QAContainerProps> = (props) => {
 };
 
 SuccessDialog.parameters = {
-  chromatic: { disableSnapshot: false },
+  chromatic: {
+    disableSnapshot: false,
+    modes: {
+      theme: {
+        themeNext: "disable",
+      },
+      themeNext: {
+        themeNext: "enable",
+        corner: "rounded",
+        accent: "teal",
+        // Ignore headingFont given font is not loaded
+      },
+    },
+  },
 };
-
 export const WarningDialog: StoryFn<QAContainerProps> = (props) => {
   const { ...rest } = props;
   return (
@@ -235,9 +307,21 @@ export const WarningDialog: StoryFn<QAContainerProps> = (props) => {
 };
 
 WarningDialog.parameters = {
-  chromatic: { disableSnapshot: false },
+  chromatic: {
+    disableSnapshot: false,
+    modes: {
+      theme: {
+        themeNext: "disable",
+      },
+      themeNext: {
+        themeNext: "enable",
+        corner: "rounded",
+        accent: "teal",
+        // Ignore headingFont given font is not loaded
+      },
+    },
+  },
 };
-
 export const ErrorDialog: StoryFn<QAContainerProps> = (props) => {
   const { ...rest } = props;
   return (
@@ -248,9 +332,21 @@ export const ErrorDialog: StoryFn<QAContainerProps> = (props) => {
 };
 
 ErrorDialog.parameters = {
-  chromatic: { disableSnapshot: false },
+  chromatic: {
+    disableSnapshot: false,
+    modes: {
+      theme: {
+        themeNext: "disable",
+      },
+      themeNext: {
+        themeNext: "enable",
+        corner: "rounded",
+        accent: "teal",
+        // Ignore headingFont given font is not loaded
+      },
+    },
+  },
 };
-
 export const StickyFooter: StoryFn<QAContainerProps> = () => {
   return (
     <QAContainer width={1300} itemPadding={3}>
@@ -276,5 +372,18 @@ export const StickyFooter: StoryFn<QAContainerProps> = () => {
 };
 
 StickyFooter.parameters = {
-  chromatic: { disableSnapshot: false },
+  chromatic: {
+    disableSnapshot: false,
+    modes: {
+      theme: {
+        themeNext: "disable",
+      },
+      themeNext: {
+        themeNext: "enable",
+        corner: "rounded",
+        accent: "teal",
+        // Ignore headingFont given font is not loaded
+      },
+    },
+  },
 };

--- a/packages/core/stories/dialog/dialog.qa.stories.tsx
+++ b/packages/core/stories/dialog/dialog.qa.stories.tsx
@@ -4,39 +4,16 @@ import {
   DialogActions,
   DialogCloseButton,
   DialogContent,
-  DialogContext,
   DialogHeader,
   type DialogProps,
-  FormField,
-  FormFieldLabel,
-  Input,
-  StackLayout,
+  FlowLayout,
+  VALIDATION_NAMED_STATUS,
 } from "@salt-ds/core";
 import type { Meta, StoryFn } from "@storybook/react";
 import { QAContainer, type QAContainerProps } from "docs/components";
 
 import "./dialog.stories.css";
-
-function FakeDialog({ children, status, id }: DialogProps) {
-  return (
-    <DialogContext.Provider value={{ status, id }}>
-      <div className="fakeDialogWindow">{children}</div>
-    </DialogContext.Provider>
-  );
-}
-
-function FakeLongDialog({ children, status, id }: DialogProps) {
-  return (
-    <DialogContext.Provider value={{ status, id }}>
-      <div
-        className="fakeDialogWindow longDialog"
-        style={{ display: "flex", flexDirection: "column" }}
-      >
-        {children}
-      </div>
-    </DialogContext.Provider>
-  );
-}
+import { Fragment } from "react";
 
 export default {
   title: "Core/Dialog/QA",
@@ -49,33 +26,56 @@ const DialogTemplate: StoryFn<DialogProps & { header: string }> = ({
   header,
 }) => {
   return (
-    <StackLayout>
-      <FakeDialog status={status}>
-        <DialogHeader header={header} />
-        <DialogContent>This is dialog content...</DialogContent>
-        <DialogActions>
-          <Button style={{ marginRight: "auto" }} variant="secondary">
-            Cancel
-          </Button>
-          <Button>Previous</Button>
-          <Button variant="cta">Next</Button>
-        </DialogActions>
-        <DialogCloseButton />
-      </FakeDialog>
-    </StackLayout>
+    <Dialog status={status} open={openProp}>
+      <DialogHeader header={header} />
+      <DialogContent>This is dialog content...</DialogContent>
+      <DialogActions>
+        <Button style={{ marginRight: "auto" }} appearance="transparent">
+          Cancel
+        </Button>
+        <Button>Previous</Button>
+        <Button sentiment="accented" appearance="transparent">
+          Next
+        </Button>
+      </DialogActions>
+      <DialogCloseButton />
+    </Dialog>
   );
 };
 
-export const Default: StoryFn<QAContainerProps> = (props) => {
-  const { ...rest } = props;
+export const StatusVariants: StoryFn<QAContainerProps> = () => {
+  const DensityValues = ["high", "medium", "low", "touch"] as const;
   return (
-    <QAContainer cols={3} height={300} itemPadding={3} {...rest}>
-      <DialogTemplate header={"Dialog Title"} />
-    </QAContainer>
+    <FlowLayout gap={0}>
+      {DensityValues.map((density) => (
+        <Fragment key={density}>
+          <iframe
+            src={`/iframe.html?globals=density:${density}&args=open:!true&id=core-dialog--default&viewMode=story`}
+            style={{ all: "unset", width: 1200, height: 320 }}
+          />
+          <iframe
+            src={`/iframe.html?globals=mode:dark;density:${density}&args=open:!true&id=core-dialog--default&viewMode=story`}
+            style={{ all: "unset", width: 1200, height: 320 }}
+          />
+          {VALIDATION_NAMED_STATUS.map((status) => (
+            <Fragment key={status}>
+              <iframe
+                src={`/iframe.html?globals=density:${density}&args=open:!true;status:${status}&id=core-dialog--default&viewMode=story`}
+                style={{ all: "unset", width: 1200, height: 320 }}
+              />
+              <iframe
+                src={`/iframe.html?globals=mode:dark;density:${density}&args=open:!true;status:${status}&id=core-dialog--default&viewMode=story`}
+                style={{ all: "unset", width: 1200, height: 320 }}
+              />
+            </Fragment>
+          ))}
+        </Fragment>
+      ))}
+    </FlowLayout>
   );
 };
 
-Default.parameters = {
+StatusVariants.parameters = {
   chromatic: {
     disableSnapshot: false,
     modes: {
@@ -91,74 +91,53 @@ Default.parameters = {
     },
   },
 };
-export const LongContent: StoryFn<QAContainerProps> = () => {
-  return (
-    <QAContainer width={1300} itemPadding={3}>
-      <FakeDialog>
-        <DialogHeader
-          header="Congratulations! You have created a Dialog."
-          style={{ width: "500px" }}
-        />
 
-        <DialogContent style={{ height: "500px" }}>
-          <StackLayout>
-            <div>
-              Lorem Ipsum is simply dummy text of the printing and typesetting
-              industry. Lorem Ipsum has been the industry's standard dummy text
-              ever since the 1500s, when an unknown printer took a galley of
-              type and scrambled it to make a type specimen book.
-            </div>
-            <div>
-              It has survived not only five centuries, but also the leap into
-              electronic typesetting, remaining essentially unchanged. It was
-              popularised in the 1960s with the release of Letraset sheets
-              containing Lorem Ipsum passages, and more recently with desktop
-              publishing software like Aldus PageMaker including versions of
-              Lorem Ipsum.
-            </div>
-            <div>
-              It is a long established fact that a reader will be distracted by
-              the readable content of a page when looking at its layout. The
-              point of using Lorem Ipsum is that it has a more-or-less normal
-              distribution of letters, as opposed to using 'Content here,
-              content here', making it look like readable English.
-            </div>
-            <div>
-              Many desktop publishing packages and web page editors now use
-              Lorem Ipsum as their default model text, and a search for 'lorem
-              ipsum' will uncover many web sites still in their infancy. Various
-              versions have evolved over the years, sometimes by accident,
-              sometimes on purpose (injected humour and the like).
-            </div>
-            <div>
-              Contrary to popular belief, Lorem Ipsum is not simply random text.
-              It has roots in a piece of classical Latin literature from 45 BC,
-              making it over 2000 years old. Richard McClintock, a Latin
-              professor at Hampden-Sydney College in Virginia, looked up one of
-              the more obscure Latin words, consectetur, from a Lorem Ipsum
-              passage, and going through the cites of the word in classical
-              literature, discovered the undoubtable source.
-            </div>
-            <div>
-              Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus
-              Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero,
-              written in 45 BC. This book is a treatise on the theory of ethics,
-              very popular during the Renaissance. The first line of Lorem
-              Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in
-              section 1.10.32.
-            </div>
-          </StackLayout>
-        </DialogContent>
-        <DialogActions>
-          <Button>Cancel</Button>
-          <Button variant="cta">Subscribe</Button>
-        </DialogActions>
-      </FakeDialog>
-    </QAContainer>
+export const ContentVariants: StoryFn<QAContainerProps> = () => {
+  const DensityValues = ["high", "medium", "low", "touch"] as const;
+  const DialogSizes = ["small", "medium", "large"] as const;
+  return (
+    <FlowLayout gap={0}>
+      {DensityValues.map((density) => (
+        <Fragment key={density}>
+          {DialogSizes.map((size) => (
+            <FlowLayout key={size}>
+              <iframe
+                src={`/iframe.html?globals=density:${density}&args=open:!true&id=core-dialog--default&viewMode=story`}
+                style={{ all: "unset", width: 350, height: 320 }}
+              />
+              <iframe
+                src={`/iframe.html?globals=density:${density}&args=open:!true&id=core-dialog--default&viewMode=story`}
+                style={{ all: "unset", width: 700, height: 320 }}
+              />
+              <iframe
+                src={`/iframe.html?globals=density:${density}&args=open:!true&id=core-dialog--default&viewMode=story`}
+                style={{ all: "unset", width: 1200, height: 320 }}
+              />
+            </FlowLayout>
+          ))}
+          <iframe
+            src={`/iframe.html?globals=density:${density}&args=open:!true&id=core-dialog--sticky-footer&viewMode=story`}
+            style={{ all: "unset", width: 1200, height: 320 }}
+          />
+          <iframe
+            src={`/iframe.html?globals=mode:dark;density:${density}&args=open:!true&id=core-dialog--sticky-footer&viewMode=story`}
+            style={{ all: "unset", width: 1200, height: 320 }}
+          />
+          <iframe
+            src={`/iframe.html?globals=density:${density}&args=open:!true&id=core-dialog--long-content&viewMode=story`}
+            style={{ all: "unset", width: 1200, height: 320 }}
+          />
+          <iframe
+            src={`/iframe.html?globals=mode:dark;density:${density}&args=open:!true&id=core-dialog--long-content&viewMode=story`}
+            style={{ all: "unset", width: 1200, height: 320 }}
+          />
+        </Fragment>
+      ))}
+    </FlowLayout>
   );
 };
 
-LongContent.parameters = {
+ContentVariants.parameters = {
   chromatic: {
     disableSnapshot: false,
     modes: {
@@ -174,204 +153,47 @@ LongContent.parameters = {
     },
   },
 };
-export const Preheader: StoryFn<QAContainerProps> = () => {
-  return (
-    <QAContainer width={1300} itemPadding={3}>
-      <FakeDialog>
-        <DialogHeader
-          header="Subscribe"
-          preheader="Recieve emails about the latest updates"
-          style={{ width: "500px" }}
-        />
-        <DialogCloseButton />
 
-        <DialogContent>
-          <FormField necessity="asterisk">
-            <FormFieldLabel> Email </FormFieldLabel>
-            <Input defaultValue="Email Address" />
-          </FormField>
-        </DialogContent>
-        <DialogActions>
-          <Button>Cancel</Button>
-          <Button variant="cta">Subscribe</Button>
-        </DialogActions>
-      </FakeDialog>
-    </QAContainer>
-  );
-};
-
-Preheader.parameters = {
-  chromatic: {
-    disableSnapshot: false,
-    modes: {
-      theme: {
-        themeNext: "disable",
-      },
-      themeNext: {
-        themeNext: "enable",
-        corner: "rounded",
-        accent: "teal",
-        // Ignore headingFont given font is not loaded
-      },
-    },
-  },
-};
-type sizes = "small" | "medium" | "large";
-
-const sizes: sizes[] = ["small", "medium", "large"];
-
-export const SizeDialog: StoryFn<QAContainerProps> = (props) => {
-  const { ...rest } = props;
-  return (
-    <QAContainer cols={3} height={300} itemPadding={3} width={3000} {...rest}>
-      {sizes.map((size) => {
-        return <DialogTemplate key={size} header={"Info Dialog"} size={size} />;
-      })}
-    </QAContainer>
-  );
-};
-
-SizeDialog.parameters = {
-  chromatic: {
-    disableSnapshot: false,
-    modes: {
-      theme: {
-        themeNext: "disable",
-      },
-      themeNext: {
-        themeNext: "enable",
-        corner: "rounded",
-        accent: "teal",
-        // Ignore headingFont given font is not loaded
-      },
-    },
-  },
-};
-export const InfoDialog: StoryFn<QAContainerProps> = (props) => {
-  const { ...rest } = props;
-  return (
-    <QAContainer cols={3} height={300} itemPadding={3} width={1300} {...rest}>
-      <DialogTemplate status={"info"} header={"Info Dialog"} />
-    </QAContainer>
-  );
-};
-
-InfoDialog.parameters = {
-  chromatic: {
-    disableSnapshot: false,
-    modes: {
-      theme: {
-        themeNext: "disable",
-      },
-      themeNext: {
-        themeNext: "enable",
-        corner: "rounded",
-        accent: "teal",
-        // Ignore headingFont given font is not loaded
-      },
-    },
-  },
-};
-export const SuccessDialog: StoryFn<QAContainerProps> = (props) => {
-  const { ...rest } = props;
-  return (
-    <QAContainer cols={3} height={300} itemPadding={3} width={1300} {...rest}>
-      <DialogTemplate status={"success"} header={"Success Dialog"} />
-    </QAContainer>
-  );
-};
-
-SuccessDialog.parameters = {
-  chromatic: {
-    disableSnapshot: false,
-    modes: {
-      theme: {
-        themeNext: "disable",
-      },
-      themeNext: {
-        themeNext: "enable",
-        corner: "rounded",
-        accent: "teal",
-        // Ignore headingFont given font is not loaded
-      },
-    },
-  },
-};
-export const WarningDialog: StoryFn<QAContainerProps> = (props) => {
-  const { ...rest } = props;
-  return (
-    <QAContainer cols={3} height={300} itemPadding={3} width={1300} {...rest}>
-      <DialogTemplate status={"warning"} header={"Warning Dialog"} />
-    </QAContainer>
-  );
-};
-
-WarningDialog.parameters = {
-  chromatic: {
-    disableSnapshot: false,
-    modes: {
-      theme: {
-        themeNext: "disable",
-      },
-      themeNext: {
-        themeNext: "enable",
-        corner: "rounded",
-        accent: "teal",
-        // Ignore headingFont given font is not loaded
-      },
-    },
-  },
-};
-export const ErrorDialog: StoryFn<QAContainerProps> = (props) => {
-  const { ...rest } = props;
-  return (
-    <QAContainer cols={3} height={300} itemPadding={3} width={1300} {...rest}>
-      <DialogTemplate status={"error"} header={"Error Dialog"} />
-    </QAContainer>
-  );
-};
-
-ErrorDialog.parameters = {
-  chromatic: {
-    disableSnapshot: false,
-    modes: {
-      theme: {
-        themeNext: "disable",
-      },
-      themeNext: {
-        themeNext: "enable",
-        corner: "rounded",
-        accent: "teal",
-        // Ignore headingFont given font is not loaded
-      },
-    },
-  },
-};
-export const StickyFooter: StoryFn<QAContainerProps> = () => {
-  return (
-    <QAContainer width={1300} itemPadding={3}>
-      <FakeLongDialog>
-        <DialogHeader
-          header="Congratulations! You have created a Dialog."
-          style={{ width: "500px" }}
-        />
-        <DialogCloseButton />
-        <DialogContent>
-          Lorem Ipsum is simply dummy text of the printing and typesetting
-          industry. Lorem Ipsum has been the industry's standard dummy text ever
-          since the 1500s, when an unknown printer took a galley of type and
-          scrambled it to make a type specimen book.
-        </DialogContent>
-        <DialogActions>
-          <Button>Cancel</Button>
-          <Button variant="cta">Subscribe</Button>
-        </DialogActions>
-      </FakeLongDialog>
-    </QAContainer>
-  );
-};
-
-StickyFooter.parameters = {
+export const DialogHeaders: StoryFn<QAContainerProps> = () => (
+  <QAContainer
+    height={600}
+    cols={1}
+    itemPadding={5}
+    width={1200}
+    // vertical
+    // transposeDensity
+  >
+    <DialogHeader
+      header="Terms and conditions"
+      style={{
+        width: 600,
+      }}
+    />
+    <DialogHeader
+      style={{
+        width: 600,
+      }}
+      header="Terms and conditions"
+      preheader="Ensure you read and agree to these Terms"
+    />
+    <DialogHeader
+      status="info"
+      header="Terms and conditions"
+      style={{
+        width: 600,
+      }}
+    />
+    <DialogHeader
+      status="info"
+      style={{
+        width: 600,
+      }}
+      header="Terms and conditions"
+      preheader="Ensure you read and agree to these Terms"
+    />
+  </QAContainer>
+);
+DialogHeaders.parameters = {
   chromatic: {
     disableSnapshot: false,
     modes: {

--- a/packages/core/stories/form-field/form-field.qa.stories.tsx
+++ b/packages/core/stories/form-field/form-field.qa.stories.tsx
@@ -39,7 +39,20 @@ export const AllVariantsGrid: StoryFn<QAContainerProps> = (props) => (
 );
 
 AllVariantsGrid.parameters = {
-  chromatic: { disableSnapshot: false },
+  chromatic: {
+    disableSnapshot: false,
+    modes: {
+      theme: {
+        themeNext: "disable",
+      },
+      themeNext: {
+        themeNext: "enable",
+        corner: "rounded",
+        accent: "teal",
+        // Ignore headingFont given font is not loaded
+      },
+    },
+  },
 };
 
 export const NoStyleInjectionGrid: StoryFn<QAContainerNoStyleInjectionProps> = (

--- a/packages/core/stories/link/link.qa.stories.tsx
+++ b/packages/core/stories/link/link.qa.stories.tsx
@@ -44,7 +44,20 @@ export const AllVariantsGrid: StoryFn<QAContainerProps> = (props) => (
 );
 
 AllVariantsGrid.parameters = {
-  chromatic: { disableSnapshot: false },
+  chromatic: {
+    disableSnapshot: false,
+    modes: {
+      theme: {
+        themeNext: "disable",
+      },
+      themeNext: {
+        themeNext: "enable",
+        corner: "rounded",
+        accent: "teal",
+        // Ignore headingFont given font is not loaded
+      },
+    },
+  },
 };
 
 export const NoStyleInjectionGrid: StoryFn<QAContainerNoStyleInjectionProps> = (

--- a/packages/core/stories/list-box/list-box.qa.stories.tsx
+++ b/packages/core/stories/list-box/list-box.qa.stories.tsx
@@ -1,4 +1,4 @@
-import { ListBox, Option } from "@salt-ds/core";
+import { ListBox, Option, OptionGroup } from "@salt-ds/core";
 import type { Meta, StoryFn } from "@storybook/react";
 import { QAContainer, type QAContainerProps } from "docs/components";
 import { shortColorData } from "../assets/exampleData";
@@ -27,6 +27,13 @@ export const AllExamples: StoryFn<QAContainerProps> = () => (
       {shortColorData.map((color) => (
         <Option key={color} value={color} />
       ))}
+    </ListBox>
+    <ListBox>
+      <OptionGroup label="B">
+        {shortColorData.slice(0, 4).map((color) => (
+          <Option key={color} value={color} />
+        ))}
+      </OptionGroup>
     </ListBox>
   </QAContainer>
 );

--- a/packages/core/stories/pagination/pagination.qa.stories.tsx
+++ b/packages/core/stories/pagination/pagination.qa.stories.tsx
@@ -10,6 +10,7 @@ import {
 } from "@salt-ds/core";
 import type { Meta, StoryFn } from "@storybook/react";
 import { QAContainer, type QAContainerProps } from "docs/components";
+import { AllVariantsGrid } from "@stories/button/button.qa.stories";
 
 export default {
   title: "Core/Pagination/Pagination QA",
@@ -75,6 +76,19 @@ export const AllExamplesGrid: StoryFn<QAContainerProps> = (props) => {
   );
 };
 
-AllExamplesGrid.parameters = {
-  chromatic: { disableSnapshot: false },
+AllVariantsGrid.parameters = {
+  chromatic: {
+    disableSnapshot: false,
+    modes: {
+      theme: {
+        themeNext: "disable",
+      },
+      themeNext: {
+        themeNext: "enable",
+        corner: "rounded",
+        accent: "teal",
+        // Ignore headingFont given font is not loaded
+      },
+    },
+  },
 };

--- a/packages/core/stories/pagination/pagination.qa.stories.tsx
+++ b/packages/core/stories/pagination/pagination.qa.stories.tsx
@@ -10,7 +10,6 @@ import {
 } from "@salt-ds/core";
 import type { Meta, StoryFn } from "@storybook/react";
 import { QAContainer, type QAContainerProps } from "docs/components";
-import { AllVariantsGrid } from "@stories/button/button.qa.stories";
 
 export default {
   title: "Core/Pagination/Pagination QA",
@@ -76,7 +75,7 @@ export const AllExamplesGrid: StoryFn<QAContainerProps> = (props) => {
   );
 };
 
-AllVariantsGrid.parameters = {
+AllExamplesGrid.parameters = {
   chromatic: {
     disableSnapshot: false,
     modes: {


### PR DESCRIPTION
addresses theme next in qas from https://github.com/jpmorganchase/salt-ds/issues/4134; adds status bar to ag grid example.

dialog refactor not in this PR