### PR TITLE
`onDateChange` on consecutive invalid dates

### DIFF
--- a/.changeset/pretty-teachers-vanish.md
+++ b/.changeset/pretty-teachers-vanish.md
@@ -22,4 +22,4 @@ DatePicker and Calendar API improvements
 `CalendarGrid` - provides a grid of buttons representing the days from a calendar month.
 
 - Fixed issues with `Calendar`'s offset selection.
-- Calendar's `onSelectionDateChange` prop was renamed to `onSelectionChange` to make `DatePicker`'s API consistent with other components.
+- Calendar's `onSelectionDateChange` prop was renamed to `onSelectionChange` to make `DatePicker`'s API consistent with other components, and it will be invoked when triggered by different invalid date inputs.

--- a/packages/lab/src/__tests__/__e2e__/date-input/DateInputSingle.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-input/DateInputSingle.cy.tsx
@@ -23,6 +23,29 @@ describe("GIVEN a DateInputSingle", () => {
     cy.findByRole("textbox").should("have.value", "date value");
   });
 
+  it("SHOULD call onDateChange on consecutive invalid dates", () => {
+    const onDateChangeSpy = cy.stub().as("dateChangeSpy");
+    cy.mount(<Single locale={testLocale} onDateChange={onDateChangeSpy} />);
+    cy.findByRole("textbox").click().clear().type("bad date");
+    cy.realPress("Tab");
+    cy.get("@dateChangeSpy").should("have.been.calledOnce");
+    cy.get("@dateChangeSpy").should(
+      "have.been.calledWith",
+      Cypress.sinon.match.any,
+      null,
+      "not a valid date format",
+    );
+    cy.findByRole("textbox").click().clear().type("another bad date 2");
+    cy.realPress("Tab");
+    cy.get("@dateChangeSpy").should("have.been.calledTwice");
+    cy.get("@dateChangeSpy").should(
+      "have.been.calledWith",
+      Cypress.sinon.match.any,
+      null,
+      "not a valid date format",
+    );
+  });
+
   it("SHOULD support custom parser", () => {
     const parseSpy = cy.stub().as("parseSpy");
     const customParser = (

--- a/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.single.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.single.cy.tsx
@@ -67,9 +67,14 @@ describe("GIVEN a DatePicker where selectionVariant is single", () => {
     cy.realPress("Tab");
     cy.get("@selectionChangeSpy").should("have.been.calledTwice");
     cy.get("@selectionChangeSpy").should("have.been.calledWith", null);
+    // Different invalid date should call the event
+    cy.findByRole("textbox").click().clear().type("another bad date 2");
+    cy.realPress("Tab");
+    cy.get("@selectionChangeSpy").should("have.callCount", 3);
+    cy.get("@selectionChangeSpy").should("have.been.calledWith", null);
     cy.findByRole("textbox").click().clear().type(updatedFormattedDateValue);
     cy.realPress("Tab");
-    cy.get("@selectionChangeSpy").should("have.been.calledThrice");
+    cy.get("@selectionChangeSpy").should("have.callCount", 4);
     cy.get("@selectionChangeSpy").should("have.been.calledWith", updatedDate);
   });
 

--- a/packages/lab/src/date-input/DateInputSingle.tsx
+++ b/packages/lab/src/date-input/DateInputSingle.tsx
@@ -29,6 +29,8 @@ import {
   useEffect,
   useRef,
   useState,
+  type FocusEvent,
+  type KeyboardEvent,
 } from "react";
 import {
   type SingleDateSelection,
@@ -245,7 +247,7 @@ export const DateInputSingle = forwardRef<HTMLDivElement, DateInputSingleProps>(
         setDateValue(formattedDate);
         onDateValueChange?.(formattedDate, true);
       }
-    }, [date, format, locale, timeZone]);
+    }, [date, format]);
 
     const [focused, setFocused] = useState(false);
 
@@ -298,7 +300,8 @@ export const DateInputSingle = forwardRef<HTMLDivElement, DateInputSingleProps>(
           newDate = newDate.set(preservedTime.current);
         }
       }
-      if (hasDateChanged || lastError.current !== error) {
+      // As long as any `error`, invoke event so both "invalid" dates can be handled
+      if (hasDateChanged || error) {
         onDateChange?.(event, newDate, error);
       }
       lastError.current = error;

--- a/packages/lab/src/date-input/DateInputSingle.tsx
+++ b/packages/lab/src/date-input/DateInputSingle.tsx
@@ -29,8 +29,6 @@ import {
   useEffect,
   useRef,
   useState,
-  type FocusEvent,
-  type KeyboardEvent,
 } from "react";
 import {
   type SingleDateSelection,


### PR DESCRIPTION
From support email, this is a valid use case (it's "different" invalid dates) before asking user to listen to low level input change event themselves