### PR TITLE
Default locale to en-US

### DIFF
--- a/.changeset/pretty-teachers-vanish.md
+++ b/.changeset/pretty-teachers-vanish.md
@@ -21,5 +21,7 @@ DatePicker and Calendar API improvements
 `CalendarWeekHeader` - provides a header for `CalendarGrid` indicating the day of the week.
 `CalendarGrid` - provides a grid of buttons representing the days from a calendar month.
 
+- Default locale changed from "local" to "en-US", to be matched with default `parser`'s "DD MMM YYYY" format.
+- Removed `DateInput`'s default `placeholder`. You can set yourself with `inputProps.placeholder` if needed.
 - Fixed issues with `Calendar`'s offset selection.
 - Calendar's `onSelectionDateChange` prop was renamed to `onSelectionChange` to make `DatePicker`'s API consistent with other components.

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.single.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.single.cy.tsx
@@ -6,7 +6,7 @@ import {
   startOfMonth,
   today,
 } from "@internationalized/date";
-import { type CalendarProps, formatDate, getCurrentLocale } from "@salt-ds/lab";
+import { type CalendarProps, formatDate } from "@salt-ds/lab";
 import * as calendarStories from "@stories/calendar/calendar.stories";
 import { composeStories } from "@storybook/react";
 

--- a/packages/lab/src/calendar/CalendarWeekHeader.tsx
+++ b/packages/lab/src/calendar/CalendarWeekHeader.tsx
@@ -6,7 +6,6 @@ import { daysForLocale } from "./internal/utils";
 import { useComponentCssInjection } from "@salt-ds/styles";
 import { useWindow } from "@salt-ds/window";
 import calendarWeekHeaderCss from "./CalendarWeekHeader.css";
-import { getCurrentLocale } from "./formatDate";
 import { useCalendarContext } from "./internal/CalendarContext";
 
 export type CalendarWeekHeaderProps = ComponentPropsWithRef<"div"> & {};

--- a/packages/lab/src/calendar/formatDate.ts
+++ b/packages/lab/src/calendar/formatDate.ts
@@ -4,14 +4,9 @@ import {
   getLocalTimeZone,
 } from "@internationalized/date";
 
-/**
- * Gets the current locale from the browser.
- * @returns The current locale as a string.
- */
-export function getCurrentLocale() {
-  return navigator.languages[0];
+export function getUsLocale() {
+  return "en-US";
 }
-
 /**
  * Default options for date formatting.
  */
@@ -36,7 +31,7 @@ export function formatDate(
   if (!date) {
     return "";
   }
-  const timeLocale = locale || getCurrentLocale();
+  const timeLocale = locale || getUsLocale();
   const timeZone = options?.timeZone || getLocalTimeZone();
 
   const formatter = new DateFormatter(timeLocale, {

--- a/packages/lab/src/calendar/formatDate.ts
+++ b/packages/lab/src/calendar/formatDate.ts
@@ -4,9 +4,9 @@ import {
   getLocalTimeZone,
 } from "@internationalized/date";
 
-export function getUsLocale() {
-  return "en-US";
-}
+/** Default locale is `en-US` */
+export const defaultLocale = "en-US";
+
 /**
  * Default options for date formatting.
  */
@@ -31,7 +31,7 @@ export function formatDate(
   if (!date) {
     return "";
   }
-  const timeLocale = locale || getUsLocale();
+  const timeLocale = locale || defaultLocale;
   const timeZone = options?.timeZone || getLocalTimeZone();
 
   const formatter = new DateFormatter(timeLocale, {

--- a/packages/lab/src/calendar/internal/useFocusManagement.ts
+++ b/packages/lab/src/calendar/internal/useFocusManagement.ts
@@ -8,12 +8,12 @@ import type {
   KeyboardEventHandler,
   MouseEventHandler,
 } from "react";
-import { getUsLocale } from "../formatDate";
+import { defaultLocale } from "../formatDate";
 import { useCalendarContext } from "./CalendarContext";
 
 export function useFocusManagement({
   date,
-  locale = getUsLocale(),
+  locale = defaultLocale,
 }: {
   date: DateValue;
   locale: string;

--- a/packages/lab/src/calendar/internal/useFocusManagement.ts
+++ b/packages/lab/src/calendar/internal/useFocusManagement.ts
@@ -8,12 +8,12 @@ import type {
   KeyboardEventHandler,
   MouseEventHandler,
 } from "react";
-import { getCurrentLocale } from "../formatDate";
+import { getUsLocale } from "../formatDate";
 import { useCalendarContext } from "./CalendarContext";
 
 export function useFocusManagement({
   date,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
 }: {
   date: DateValue;
   locale: string;

--- a/packages/lab/src/calendar/internal/utils.ts
+++ b/packages/lab/src/calendar/internal/utils.ts
@@ -12,14 +12,14 @@ import {
   toCalendarDate,
   today,
 } from "@internationalized/date";
-import { getCurrentLocale } from "../formatDate";
+import { getUsLocale } from "../formatDate";
 
 export function formatDate(
   date: DateValue,
   locale: string,
   options?: Intl.DateTimeFormatOptions,
 ) {
-  const timeLocale = locale || getCurrentLocale();
+  const timeLocale = locale || getUsLocale();
   const timeZone = options?.timeZone || getLocalTimeZone();
   const formatter = new DateFormatter(timeLocale, options);
   return formatter.format(date.toDate(timeZone));

--- a/packages/lab/src/calendar/internal/utils.ts
+++ b/packages/lab/src/calendar/internal/utils.ts
@@ -12,14 +12,14 @@ import {
   toCalendarDate,
   today,
 } from "@internationalized/date";
-import { getUsLocale } from "../formatDate";
+import { defaultLocale } from "../formatDate";
 
 export function formatDate(
   date: DateValue,
   locale: string,
   options?: Intl.DateTimeFormatOptions,
 ) {
-  const timeLocale = locale || getUsLocale();
+  const timeLocale = locale || defaultLocale;
   const timeZone = options?.timeZone || getLocalTimeZone();
   const formatter = new DateFormatter(timeLocale, options);
   return formatter.format(date.toDate(timeZone));

--- a/packages/lab/src/calendar/useCalendar.ts
+++ b/packages/lab/src/calendar/useCalendar.ts
@@ -17,7 +17,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import { getUsLocale } from "./formatDate";
+import { defaultLocale } from "./formatDate";
 import { generateDatesForMonth } from "./internal/utils";
 import {
   type UseCalendarSelectionMultiSelectProps,
@@ -172,7 +172,7 @@ export function useCalendar(props: UseCalendarProps) {
     visibleMonth: visibleMonthProp,
     hideOutOfRangeDates,
     timeZone = getLocalTimeZone(),
-    locale = getUsLocale(),
+    locale = defaultLocale,
     defaultVisibleMonth = today(timeZone),
     onSelectionChange,
     onVisibleMonthChange,

--- a/packages/lab/src/calendar/useCalendar.ts
+++ b/packages/lab/src/calendar/useCalendar.ts
@@ -17,7 +17,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import { getCurrentLocale } from "./formatDate";
+import { getUsLocale } from "./formatDate";
 import { generateDatesForMonth } from "./internal/utils";
 import {
   type UseCalendarSelectionMultiSelectProps,
@@ -172,7 +172,7 @@ export function useCalendar(props: UseCalendarProps) {
     visibleMonth: visibleMonthProp,
     hideOutOfRangeDates,
     timeZone = getLocalTimeZone(),
-    locale = getCurrentLocale(),
+    locale = getUsLocale(),
     defaultVisibleMonth = today(timeZone),
     onSelectionChange,
     onVisibleMonthChange,

--- a/packages/lab/src/date-input/DateInputRange.tsx
+++ b/packages/lab/src/date-input/DateInputRange.tsx
@@ -31,7 +31,7 @@ import {
 import {
   type DateRangeSelection,
   formatDate as defaultFormatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "../calendar";
 import dateInputCss from "./DateInput.css";
 import type { DateInputSingleParserError } from "./DateInputSingle";
@@ -232,7 +232,7 @@ export const DateInputRange = forwardRef<HTMLDivElement, DateInputRangeProps>(
       readOnly: readOnlyProp,
       validationStatus: validationStatusProp,
       variant = "primary",
-      locale = getCurrentLocale(),
+      locale = getUsLocale(),
       timeZone = getLocalTimeZone(),
       ...rest
     } = props;

--- a/packages/lab/src/date-input/DateInputRange.tsx
+++ b/packages/lab/src/date-input/DateInputRange.tsx
@@ -31,7 +31,7 @@ import {
 import {
   type DateRangeSelection,
   formatDate as defaultFormatDate,
-  getUsLocale,
+  defaultLocale,
 } from "../calendar";
 import dateInputCss from "./DateInput.css";
 import type { DateInputSingleParserError } from "./DateInputSingle";
@@ -232,7 +232,7 @@ export const DateInputRange = forwardRef<HTMLDivElement, DateInputRangeProps>(
       readOnly: readOnlyProp,
       validationStatus: validationStatusProp,
       variant = "primary",
-      locale = getUsLocale(),
+      locale = defaultLocale,
       timeZone = getLocalTimeZone(),
       ...rest
     } = props;

--- a/packages/lab/src/date-input/DateInputSingle.tsx
+++ b/packages/lab/src/date-input/DateInputSingle.tsx
@@ -33,7 +33,7 @@ import {
 import {
   type SingleDateSelection,
   formatDate as defaultFormatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "../calendar";
 import dateInputCss from "./DateInput.css";
 import { extractTimeFieldsFromDate, parseCalendarDate } from "./utils";
@@ -186,12 +186,11 @@ export const DateInputSingle = forwardRef<HTMLDivElement, DateInputSingleProps>(
       inputProps = {},
       inputRef: inputRefProp = null,
       parse = parseCalendarDate,
-      placeholder = "dd mmm yyyy",
       readOnly: readOnlyProp,
       validationStatus: validationStatusProp,
       variant = "primary",
       onDateValueChange,
-      locale = getCurrentLocale(),
+      locale = getUsLocale(),
       timeZone = getLocalTimeZone(),
       ...rest
     } = props;
@@ -369,8 +368,6 @@ export const DateInputSingle = forwardRef<HTMLDivElement, DateInputSingleProps>(
           readOnly={isReadOnly}
           ref={handleInputRef}
           tabIndex={isDisabled ? -1 : 0}
-          placeholder={placeholder}
-          size={placeholder.length}
           value={isReadOnly && !dateValue ? emptyReadOnlyMarker : dateValue}
           {...restDateInputProps}
           onBlur={handleBlur}

--- a/packages/lab/src/date-input/DateInputSingle.tsx
+++ b/packages/lab/src/date-input/DateInputSingle.tsx
@@ -33,7 +33,7 @@ import {
 import {
   type SingleDateSelection,
   formatDate as defaultFormatDate,
-  getUsLocale,
+  defaultLocale,
 } from "../calendar";
 import dateInputCss from "./DateInput.css";
 import { extractTimeFieldsFromDate, parseCalendarDate } from "./utils";
@@ -190,7 +190,7 @@ export const DateInputSingle = forwardRef<HTMLDivElement, DateInputSingleProps>(
       validationStatus: validationStatusProp,
       variant = "primary",
       onDateValueChange,
-      locale = getUsLocale(),
+      locale = defaultLocale,
       timeZone = getLocalTimeZone(),
       ...rest
     } = props;

--- a/packages/lab/src/date-input/utils.ts
+++ b/packages/lab/src/date-input/utils.ts
@@ -10,7 +10,7 @@ import {
 import {
   type DateRangeSelection,
   type SingleDateSelection,
-  getUsLocale,
+  defaultLocale,
 } from "../calendar";
 
 export type RangeTimeFields = {
@@ -38,7 +38,7 @@ export function getMonthNames(locale: string): { [key: string]: number } {
  */
 export function parseCalendarDate(
   inputDate: string,
-  locale: string = getUsLocale(),
+  locale: string = defaultLocale,
 ): {
   date: DateValue | null;
   error: string | false;
@@ -112,7 +112,7 @@ export function parseCalendarDate(
  */
 export function parseZonedDateTime(
   inputDate: string,
-  locale: string = getUsLocale(),
+  locale: string = defaultLocale,
   timeZone: string = getLocalTimeZone(),
 ): {
   date: DateValue | null;

--- a/packages/lab/src/date-input/utils.ts
+++ b/packages/lab/src/date-input/utils.ts
@@ -10,7 +10,7 @@ import {
 import {
   type DateRangeSelection,
   type SingleDateSelection,
-  getCurrentLocale,
+  getUsLocale,
 } from "../calendar";
 
 export type RangeTimeFields = {
@@ -38,7 +38,7 @@ export function getMonthNames(locale: string): { [key: string]: number } {
  */
 export function parseCalendarDate(
   inputDate: string,
-  locale: string = getCurrentLocale(),
+  locale: string = getUsLocale(),
 ): {
   date: DateValue | null;
   error: string | false;
@@ -112,7 +112,7 @@ export function parseCalendarDate(
  */
 export function parseZonedDateTime(
   inputDate: string,
-  locale: string = getCurrentLocale(),
+  locale: string = getUsLocale(),
   timeZone: string = getLocalTimeZone(),
 ): {
   date: DateValue | null;

--- a/packages/lab/src/date-picker/DatePickerRangePanel.tsx
+++ b/packages/lab/src/date-picker/DatePickerRangePanel.tsx
@@ -39,7 +39,7 @@ import {
   type CalendarWeekHeaderProps,
   type DateRangeSelection,
   type UseCalendarSelectionRangeProps,
-  getCurrentLocale,
+  getUsLocale,
 } from "../calendar";
 import { useDatePickerContext } from "./DatePickerContext";
 import datePickerPanelCss from "./DatePickerPanel.css";
@@ -218,7 +218,7 @@ export const DatePickerRangePanel = forwardRef<
       timeZone = getLocalTimeZone(),
       minDate = startOfMonth(today(timeZone)),
       maxDate = minDate.add({ months: 1 }),
-      locale = getCurrentLocale(),
+      locale = getUsLocale(),
     },
     helpers: { setSelectedDate },
   } = useDatePickerContext({ selectionVariant: "range" });

--- a/packages/lab/src/date-picker/DatePickerRangePanel.tsx
+++ b/packages/lab/src/date-picker/DatePickerRangePanel.tsx
@@ -39,7 +39,7 @@ import {
   type CalendarWeekHeaderProps,
   type DateRangeSelection,
   type UseCalendarSelectionRangeProps,
-  getUsLocale,
+  defaultLocale,
 } from "../calendar";
 import { useDatePickerContext } from "./DatePickerContext";
 import datePickerPanelCss from "./DatePickerPanel.css";
@@ -218,7 +218,7 @@ export const DatePickerRangePanel = forwardRef<
       timeZone = getLocalTimeZone(),
       minDate = startOfMonth(today(timeZone)),
       maxDate = minDate.add({ months: 1 }),
-      locale = getUsLocale(),
+      locale = defaultLocale,
     },
     helpers: { setSelectedDate },
   } = useDatePickerContext({ selectionVariant: "range" });

--- a/packages/lab/src/date-picker/DatePickerSinglePanel.tsx
+++ b/packages/lab/src/date-picker/DatePickerSinglePanel.tsx
@@ -32,7 +32,7 @@ import {
   type CalendarSingleProps,
   CalendarWeekHeader,
   type CalendarWeekHeaderProps,
-  getCurrentLocale,
+  getUsLocale,
 } from "../calendar";
 import { Calendar, type SingleDateSelection } from "../calendar";
 import datePickerPanelCss from "./DatePickerPanel.css";
@@ -136,7 +136,7 @@ export const DatePickerSinglePanel = forwardRef<
       timeZone = getLocalTimeZone(),
       minDate = startOfMonth(today(timeZone)),
       maxDate = minDate.add({ months: 1 }),
-      locale = getCurrentLocale(),
+      locale = getUsLocale(),
     },
     helpers: { setSelectedDate },
   } = useDatePickerContext({ selectionVariant: "single" });

--- a/packages/lab/src/date-picker/DatePickerSinglePanel.tsx
+++ b/packages/lab/src/date-picker/DatePickerSinglePanel.tsx
@@ -32,7 +32,7 @@ import {
   type CalendarSingleProps,
   CalendarWeekHeader,
   type CalendarWeekHeaderProps,
-  getUsLocale,
+  defaultLocale,
 } from "../calendar";
 import { Calendar, type SingleDateSelection } from "../calendar";
 import datePickerPanelCss from "./DatePickerPanel.css";
@@ -136,7 +136,7 @@ export const DatePickerSinglePanel = forwardRef<
       timeZone = getLocalTimeZone(),
       minDate = startOfMonth(today(timeZone)),
       maxDate = minDate.add({ months: 1 }),
-      locale = getUsLocale(),
+      locale = defaultLocale,
     },
     helpers: { setSelectedDate },
   } = useDatePickerContext({ selectionVariant: "single" });

--- a/packages/lab/src/date-picker/useDatePicker.ts
+++ b/packages/lab/src/date-picker/useDatePicker.ts
@@ -12,7 +12,7 @@ import {
   CALENDAR_MIN_YEAR,
   type DateRangeSelection,
   type SingleDateSelection,
-  getUsLocale,
+  defaultLocale,
 } from "../calendar";
 import type {
   RangeDatePickerError,
@@ -161,7 +161,7 @@ export function useDatePicker<SelectionVariant extends "single" | "range">(
     minDate: minDateProp,
     maxDate: maxDateProp,
     timeZone = getLocalTimeZone(),
-    locale = getUsLocale(),
+    locale = defaultLocale,
     onCancel,
   } = props;
 

--- a/packages/lab/src/date-picker/useDatePicker.ts
+++ b/packages/lab/src/date-picker/useDatePicker.ts
@@ -12,7 +12,7 @@ import {
   CALENDAR_MIN_YEAR,
   type DateRangeSelection,
   type SingleDateSelection,
-  getCurrentLocale,
+  getUsLocale,
 } from "../calendar";
 import type {
   RangeDatePickerError,
@@ -161,7 +161,7 @@ export function useDatePicker<SelectionVariant extends "single" | "range">(
     minDate: minDateProp,
     maxDate: maxDateProp,
     timeZone = getLocalTimeZone(),
-    locale = getCurrentLocale(),
+    locale = getUsLocale(),
     onCancel,
   } = props;
 

--- a/packages/lab/stories/calendar/calendar.stories.tsx
+++ b/packages/lab/stories/calendar/calendar.stories.tsx
@@ -22,7 +22,7 @@ import {
   CalendarWeekHeader,
   type UseCalendarSelectionRangeProps,
   type UseCalendarSelectionSingleProps,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import type { Meta, StoryFn } from "@storybook/react";
 import type React from "react";
@@ -139,7 +139,7 @@ export const UnselectableDates = Template.bind({});
 UnselectableDates.args = {
   // Saturday & Sunday
   isDayUnselectable: (date) =>
-    getDayOfWeek(date, getCurrentLocale()) >= 5
+    getDayOfWeek(date, getUsLocale()) >= 5
       ? "Weekends are un-selectable"
       : false,
 };
@@ -148,9 +148,7 @@ export const DisabledDates = Template.bind({});
 DisabledDates.args = {
   // Saturday & Sunday
   isDayDisabled: (date) =>
-    getDayOfWeek(date, getCurrentLocale()) >= 5
-      ? "Weekends are disabled"
-      : false,
+    getDayOfWeek(date, getUsLocale()) >= 5 ? "Weekends are disabled" : false,
 };
 
 export const HighlightedDates = Template.bind({});
@@ -219,7 +217,7 @@ export const TodayButton: StoryFn<
 };
 
 function renderDayContents(day: DateValue) {
-  const formatter = new DateFormatter(getCurrentLocale(), { day: "2-digit" });
+  const formatter = new DateFormatter(getUsLocale(), { day: "2-digit" });
   return <>{formatter.format(day.toDate(getLocalTimeZone()))}</>;
 }
 

--- a/packages/lab/stories/calendar/calendar.stories.tsx
+++ b/packages/lab/stories/calendar/calendar.stories.tsx
@@ -22,7 +22,7 @@ import {
   CalendarWeekHeader,
   type UseCalendarSelectionRangeProps,
   type UseCalendarSelectionSingleProps,
-  getUsLocale,
+  defaultLocale,
 } from "@salt-ds/lab";
 import type { Meta, StoryFn } from "@storybook/react";
 import type React from "react";
@@ -139,7 +139,7 @@ export const UnselectableDates = Template.bind({});
 UnselectableDates.args = {
   // Saturday & Sunday
   isDayUnselectable: (date) =>
-    getDayOfWeek(date, getUsLocale()) >= 5
+    getDayOfWeek(date, defaultLocale) >= 5
       ? "Weekends are un-selectable"
       : false,
 };
@@ -148,7 +148,7 @@ export const DisabledDates = Template.bind({});
 DisabledDates.args = {
   // Saturday & Sunday
   isDayDisabled: (date) =>
-    getDayOfWeek(date, getUsLocale()) >= 5 ? "Weekends are disabled" : false,
+    getDayOfWeek(date, defaultLocale) >= 5 ? "Weekends are disabled" : false,
 };
 
 export const HighlightedDates = Template.bind({});
@@ -217,7 +217,7 @@ export const TodayButton: StoryFn<
 };
 
 function renderDayContents(day: DateValue) {
-  const formatter = new DateFormatter(getUsLocale(), { day: "2-digit" });
+  const formatter = new DateFormatter(defaultLocale, { day: "2-digit" });
   return <>{formatter.format(day.toDate(getLocalTimeZone()))}</>;
 }
 

--- a/packages/lab/stories/date-input/date-input.stories.tsx
+++ b/packages/lab/stories/date-input/date-input.stories.tsx
@@ -12,7 +12,7 @@ import {
   type DateInputSingleProps,
   type DateRangeSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import type { Meta, StoryFn } from "@storybook/react";
 import { fn } from "@storybook/test";
@@ -25,7 +25,7 @@ export default {
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
 ): string {
   const { startDate, endDate } = dateRange || {};
   const formattedStartDate = startDate

--- a/packages/lab/stories/date-input/date-input.stories.tsx
+++ b/packages/lab/stories/date-input/date-input.stories.tsx
@@ -11,8 +11,8 @@ import {
   type DateInputSingleError,
   type DateInputSingleProps,
   type DateRangeSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
 } from "@salt-ds/lab";
 import type { Meta, StoryFn } from "@storybook/react";
 import { fn } from "@storybook/test";
@@ -25,7 +25,7 @@ export default {
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
 ): string {
   const { startDate, endDate } = dateRange || {};
   const formattedStartDate = startDate

--- a/packages/lab/stories/date-picker/date-picker.qa.stories.tsx
+++ b/packages/lab/stories/date-picker/date-picker.qa.stories.tsx
@@ -6,7 +6,6 @@ import {
   DatePickerRangePanel,
   DatePickerSingleInput,
   DatePickerSinglePanel,
-  getCurrentLocale,
 } from "@salt-ds/lab";
 import type { StoryFn } from "@storybook/react";
 import { QAContainer, type QAContainerProps } from "docs/components";

--- a/packages/lab/stories/date-picker/date-picker.stories.tsx
+++ b/packages/lab/stories/date-picker/date-picker.stories.tsx
@@ -33,8 +33,8 @@ import {
   type RangeDatePickerState,
   type SingleDatePickerState,
   type SingleDateSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
   parseCalendarDate,
   useDatePickerContext,
 } from "@salt-ds/lab";
@@ -61,7 +61,7 @@ function isValidDateRange(date: DateRangeSelection | null) {
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
   options?: Intl.DateTimeFormatOptions,
 ): string {
   const { startDate, endDate } = dateRange || {};
@@ -75,7 +75,7 @@ function formatDateRange(
 }
 function formatSingleDate(
   date: DateValue | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
   options?: Intl.DateTimeFormatOptions,
 ) {
   if (date) {
@@ -925,7 +925,7 @@ export const SingleWithCustomParser: StoryFn<DatePickerSingleProps> = ({
   const customParser = useCallback(
     (
       inputDate: string,
-      locale: string = getUsLocale(),
+      locale: string = defaultLocale,
     ): DateInputSingleParserResult => {
       if (!inputDate?.length) {
         return { date: null, error: false };

--- a/packages/lab/stories/date-picker/date-picker.stories.tsx
+++ b/packages/lab/stories/date-picker/date-picker.stories.tsx
@@ -5,8 +5,8 @@ import {
   type ZonedDateTime,
   getLocalTimeZone,
   now,
-  today,
   parseDate,
+  today,
 } from "@internationalized/date";
 import {
   Button,

--- a/site/src/examples/calendar/CustomDayRender.tsx
+++ b/site/src/examples/calendar/CustomDayRender.tsx
@@ -8,12 +8,12 @@ import {
   CalendarGrid,
   CalendarNavigation,
   CalendarWeekHeader,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import type { ReactElement } from "react";
 
 function renderDayContents(day: DateValue) {
-  const formatter = new DateFormatter(getCurrentLocale(), { day: "2-digit" });
+  const formatter = new DateFormatter(getUsLocale(), { day: "2-digit" });
   return <>{formatter.format(day.toDate(getLocalTimeZone()))}</>;
 }
 

--- a/site/src/examples/calendar/CustomDayRender.tsx
+++ b/site/src/examples/calendar/CustomDayRender.tsx
@@ -8,12 +8,12 @@ import {
   CalendarGrid,
   CalendarNavigation,
   CalendarWeekHeader,
-  getUsLocale,
+  defaultLocale,
 } from "@salt-ds/lab";
 import type { ReactElement } from "react";
 
 function renderDayContents(day: DateValue) {
-  const formatter = new DateFormatter(getUsLocale(), { day: "2-digit" });
+  const formatter = new DateFormatter(defaultLocale, { day: "2-digit" });
   return <>{formatter.format(day.toDate(getLocalTimeZone()))}</>;
 }
 

--- a/site/src/examples/calendar/DisabledDates.tsx
+++ b/site/src/examples/calendar/DisabledDates.tsx
@@ -4,13 +4,13 @@ import {
   CalendarGrid,
   CalendarNavigation,
   CalendarWeekHeader,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import type { ReactElement } from "react";
 
 // Saturday & Sunday
 const isDayDisabled = (date: DateValue) =>
-  getDayOfWeek(date, getCurrentLocale()) >= 5 ? "Weekends are disabled" : false;
+  getDayOfWeek(date, getUsLocale()) >= 5 ? "Weekends are disabled" : false;
 
 export const DisabledDates = (): ReactElement => (
   <Calendar selectionVariant="single" isDayDisabled={isDayDisabled}>

--- a/site/src/examples/calendar/DisabledDates.tsx
+++ b/site/src/examples/calendar/DisabledDates.tsx
@@ -4,13 +4,13 @@ import {
   CalendarGrid,
   CalendarNavigation,
   CalendarWeekHeader,
-  getUsLocale,
+  defaultLocale,
 } from "@salt-ds/lab";
 import type { ReactElement } from "react";
 
 // Saturday & Sunday
 const isDayDisabled = (date: DateValue) =>
-  getDayOfWeek(date, getUsLocale()) >= 5 ? "Weekends are disabled" : false;
+  getDayOfWeek(date, defaultLocale) >= 5 ? "Weekends are disabled" : false;
 
 export const DisabledDates = (): ReactElement => (
   <Calendar selectionVariant="single" isDayDisabled={isDayDisabled}>

--- a/site/src/examples/calendar/UnselectableDates.tsx
+++ b/site/src/examples/calendar/UnselectableDates.tsx
@@ -4,15 +4,13 @@ import {
   CalendarGrid,
   CalendarNavigation,
   CalendarWeekHeader,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import type { ReactElement } from "react";
 
 // Saturday & Sunday
 const isDayUnselectable = (date: DateValue) =>
-  getDayOfWeek(date, getCurrentLocale()) >= 5
-    ? "Weekends are un-selectable"
-    : false;
+  getDayOfWeek(date, getUsLocale()) >= 5 ? "Weekends are un-selectable" : false;
 
 export const UnselectableDates = (): ReactElement => (
   <Calendar selectionVariant="single" isDayUnselectable={isDayUnselectable}>

--- a/site/src/examples/calendar/UnselectableDates.tsx
+++ b/site/src/examples/calendar/UnselectableDates.tsx
@@ -4,13 +4,13 @@ import {
   CalendarGrid,
   CalendarNavigation,
   CalendarWeekHeader,
-  getUsLocale,
+  defaultLocale,
 } from "@salt-ds/lab";
 import type { ReactElement } from "react";
 
 // Saturday & Sunday
 const isDayUnselectable = (date: DateValue) =>
-  getDayOfWeek(date, getUsLocale()) >= 5 ? "Weekends are un-selectable" : false;
+  getDayOfWeek(date, defaultLocale) >= 5 ? "Weekends are un-selectable" : false;
 
 export const UnselectableDates = (): ReactElement => (
   <Calendar selectionVariant="single" isDayUnselectable={isDayUnselectable}>

--- a/site/src/examples/date-input/Range.tsx
+++ b/site/src/examples/date-input/Range.tsx
@@ -4,13 +4,13 @@ import {
   type DateInputRangeError,
   type DateRangeSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import type { ReactElement, SyntheticEvent } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
 ): string {
   const { startDate, endDate } = dateRange || {};
   const formattedStartDate = startDate

--- a/site/src/examples/date-input/Range.tsx
+++ b/site/src/examples/date-input/Range.tsx
@@ -3,14 +3,14 @@ import {
   DateInputRange,
   type DateInputRangeError,
   type DateRangeSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
 } from "@salt-ds/lab";
 import type { ReactElement, SyntheticEvent } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
 ): string {
   const { startDate, endDate } = dateRange || {};
   const formattedStartDate = startDate

--- a/site/src/examples/date-input/RangeBordered.tsx
+++ b/site/src/examples/date-input/RangeBordered.tsx
@@ -4,13 +4,13 @@ import {
   type DateInputRangeError,
   type DateRangeSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import type { ReactElement, SyntheticEvent } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
 ): string {
   const { startDate, endDate } = dateRange || {};
   const formattedStartDate = startDate

--- a/site/src/examples/date-input/RangeBordered.tsx
+++ b/site/src/examples/date-input/RangeBordered.tsx
@@ -3,14 +3,14 @@ import {
   DateInputRange,
   type DateInputRangeError,
   type DateRangeSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
 } from "@salt-ds/lab";
 import type { ReactElement, SyntheticEvent } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
 ): string {
   const { startDate, endDate } = dateRange || {};
   const formattedStartDate = startDate

--- a/site/src/examples/date-input/RangeControlled.tsx
+++ b/site/src/examples/date-input/RangeControlled.tsx
@@ -4,13 +4,13 @@ import {
   type DateInputRangeError,
   type DateRangeSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, type SyntheticEvent, useState } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
 ): string {
   const { startDate, endDate } = dateRange || {};
   const formattedStartDate = startDate

--- a/site/src/examples/date-input/RangeControlled.tsx
+++ b/site/src/examples/date-input/RangeControlled.tsx
@@ -3,14 +3,14 @@ import {
   DateInputRange,
   type DateInputRangeError,
   type DateRangeSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, type SyntheticEvent, useState } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
 ): string {
   const { startDate, endDate } = dateRange || {};
   const formattedStartDate = startDate

--- a/site/src/examples/date-picker/Range.tsx
+++ b/site/src/examples/date-picker/Range.tsx
@@ -4,14 +4,14 @@ import {
   DatePickerRangeInput,
   DatePickerRangePanel,
   type DateRangeSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
   options?: Intl.DateTimeFormatOptions,
 ): string {
   const { startDate, endDate } = dateRange || {};

--- a/site/src/examples/date-picker/Range.tsx
+++ b/site/src/examples/date-picker/Range.tsx
@@ -5,13 +5,13 @@ import {
   DatePickerRangePanel,
   type DateRangeSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
   options?: Intl.DateTimeFormatOptions,
 ): string {
   const { startDate, endDate } = dateRange || {};

--- a/site/src/examples/date-picker/RangeBordered.tsx
+++ b/site/src/examples/date-picker/RangeBordered.tsx
@@ -9,14 +9,14 @@ import {
   DatePickerRangeInput,
   DatePickerRangePanel,
   type DateRangeSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
 } from "@salt-ds/lab";
 import React, { type ReactElement, useCallback, useState } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
   options?: Intl.DateTimeFormatOptions,
 ): string {
   const { startDate, endDate } = dateRange || {};

--- a/site/src/examples/date-picker/RangeBordered.tsx
+++ b/site/src/examples/date-picker/RangeBordered.tsx
@@ -10,13 +10,13 @@ import {
   DatePickerRangePanel,
   type DateRangeSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import React, { type ReactElement, useCallback, useState } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
   options?: Intl.DateTimeFormatOptions,
 ): string {
   const { startDate, endDate } = dateRange || {};

--- a/site/src/examples/date-picker/RangeControlled.tsx
+++ b/site/src/examples/date-picker/RangeControlled.tsx
@@ -5,13 +5,13 @@ import {
   DatePickerRangePanel,
   type DateRangeSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback, useState } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
   options?: Intl.DateTimeFormatOptions,
 ): string {
   const { startDate, endDate } = dateRange || {};

--- a/site/src/examples/date-picker/RangeControlled.tsx
+++ b/site/src/examples/date-picker/RangeControlled.tsx
@@ -4,14 +4,14 @@ import {
   DatePickerRangeInput,
   DatePickerRangePanel,
   type DateRangeSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback, useState } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
   options?: Intl.DateTimeFormatOptions,
 ): string {
   const { startDate, endDate } = dateRange || {};

--- a/site/src/examples/date-picker/RangeWithConfirmation.tsx
+++ b/site/src/examples/date-picker/RangeWithConfirmation.tsx
@@ -15,13 +15,13 @@ import {
   DatePickerRangePanel,
   type DateRangeSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import React, { type ReactElement, useCallback, useRef, useState } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
   options?: Intl.DateTimeFormatOptions,
 ): string {
   const { startDate, endDate } = dateRange || {};

--- a/site/src/examples/date-picker/RangeWithConfirmation.tsx
+++ b/site/src/examples/date-picker/RangeWithConfirmation.tsx
@@ -14,14 +14,14 @@ import {
   DatePickerRangeInput,
   DatePickerRangePanel,
   type DateRangeSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
 } from "@salt-ds/lab";
 import React, { type ReactElement, useCallback, useRef, useState } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
   options?: Intl.DateTimeFormatOptions,
 ): string {
   const { startDate, endDate } = dateRange || {};

--- a/site/src/examples/date-picker/RangeWithCustomPanel.tsx
+++ b/site/src/examples/date-picker/RangeWithCustomPanel.tsx
@@ -9,15 +9,15 @@ import {
   DatePickerOverlay,
   DatePickerRangeInput,
   type DateRangeSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
 } from "@salt-ds/lab";
 import { CustomDatePickerPanel } from "@salt-ds/lab/stories/date-picker/CustomDatePickerPanel";
 import React, { type ReactElement, useCallback, useState } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
   options?: Intl.DateTimeFormatOptions,
 ): string {
   const { startDate, endDate } = dateRange || {};

--- a/site/src/examples/date-picker/RangeWithCustomPanel.tsx
+++ b/site/src/examples/date-picker/RangeWithCustomPanel.tsx
@@ -10,14 +10,14 @@ import {
   DatePickerRangeInput,
   type DateRangeSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import { CustomDatePickerPanel } from "@salt-ds/lab/stories/date-picker/CustomDatePickerPanel";
 import React, { type ReactElement, useCallback, useState } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
   options?: Intl.DateTimeFormatOptions,
 ): string {
   const { startDate, endDate } = dateRange || {};

--- a/site/src/examples/date-picker/RangeWithFormField.tsx
+++ b/site/src/examples/date-picker/RangeWithFormField.tsx
@@ -10,13 +10,13 @@ import {
   DatePickerRangePanel,
   type DateRangeSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback, useState } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
   options?: Intl.DateTimeFormatOptions,
 ): string {
   const { startDate, endDate } = dateRange || {};

--- a/site/src/examples/date-picker/RangeWithFormField.tsx
+++ b/site/src/examples/date-picker/RangeWithFormField.tsx
@@ -9,14 +9,14 @@ import {
   DatePickerRangeInput,
   DatePickerRangePanel,
   type DateRangeSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback, useState } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
   options?: Intl.DateTimeFormatOptions,
 ): string {
   const { startDate, endDate } = dateRange || {};

--- a/site/src/examples/date-picker/RangeWithInitialError.tsx
+++ b/site/src/examples/date-picker/RangeWithInitialError.tsx
@@ -10,14 +10,14 @@ import {
   DatePickerRangeInput,
   DatePickerRangePanel,
   type DateRangeSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback, useState } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
   options?: Intl.DateTimeFormatOptions,
 ): string {
   const { startDate, endDate } = dateRange || {};

--- a/site/src/examples/date-picker/RangeWithInitialError.tsx
+++ b/site/src/examples/date-picker/RangeWithInitialError.tsx
@@ -11,13 +11,13 @@ import {
   DatePickerRangePanel,
   type DateRangeSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback, useState } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
   options?: Intl.DateTimeFormatOptions,
 ): string {
   const { startDate, endDate } = dateRange || {};

--- a/site/src/examples/date-picker/RangeWithLocaleEsES.tsx
+++ b/site/src/examples/date-picker/RangeWithLocaleEsES.tsx
@@ -9,14 +9,14 @@ import {
   DatePickerRangeInput,
   DatePickerRangePanel,
   type DateRangeSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
 } from "@salt-ds/lab";
 import React, { type ReactElement, useCallback, useState } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
   options?: Intl.DateTimeFormatOptions,
 ): string {
   const { startDate, endDate } = dateRange || {};

--- a/site/src/examples/date-picker/RangeWithLocaleEsES.tsx
+++ b/site/src/examples/date-picker/RangeWithLocaleEsES.tsx
@@ -10,13 +10,13 @@ import {
   DatePickerRangePanel,
   type DateRangeSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import React, { type ReactElement, useCallback, useState } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
   options?: Intl.DateTimeFormatOptions,
 ): string {
   const { startDate, endDate } = dateRange || {};

--- a/site/src/examples/date-picker/RangeWithMinMaxDate.tsx
+++ b/site/src/examples/date-picker/RangeWithMinMaxDate.tsx
@@ -10,14 +10,14 @@ import {
   DatePickerRangeInput,
   DatePickerRangePanel,
   type DateRangeSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback, useState } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
   options?: Intl.DateTimeFormatOptions,
 ): string {
   const { startDate, endDate } = dateRange || {};

--- a/site/src/examples/date-picker/RangeWithMinMaxDate.tsx
+++ b/site/src/examples/date-picker/RangeWithMinMaxDate.tsx
@@ -11,13 +11,13 @@ import {
   DatePickerRangePanel,
   type DateRangeSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback, useState } from "react";
 
 function formatDateRange(
   dateRange: DateRangeSelection | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
   options?: Intl.DateTimeFormatOptions,
 ): string {
   const { startDate, endDate } = dateRange || {};

--- a/site/src/examples/date-picker/Single.tsx
+++ b/site/src/examples/date-picker/Single.tsx
@@ -6,13 +6,13 @@ import {
   DatePickerSinglePanel,
   type SingleDateSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback } from "react";
 
 function formatSingleDate(
   date: DateValue | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
   options?: Intl.DateTimeFormatOptions,
 ) {
   if (date) {

--- a/site/src/examples/date-picker/Single.tsx
+++ b/site/src/examples/date-picker/Single.tsx
@@ -5,14 +5,14 @@ import {
   DatePickerSingleInput,
   DatePickerSinglePanel,
   type SingleDateSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback } from "react";
 
 function formatSingleDate(
   date: DateValue | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
   options?: Intl.DateTimeFormatOptions,
 ) {
   if (date) {

--- a/site/src/examples/date-picker/SingleBordered.tsx
+++ b/site/src/examples/date-picker/SingleBordered.tsx
@@ -11,13 +11,13 @@ import {
   DatePickerSinglePanel,
   type SingleDateSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import React, { type ReactElement, useCallback, useState } from "react";
 
 function formatSingleDate(
   date: DateValue | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
   options?: Intl.DateTimeFormatOptions,
 ) {
   if (date) {

--- a/site/src/examples/date-picker/SingleBordered.tsx
+++ b/site/src/examples/date-picker/SingleBordered.tsx
@@ -10,14 +10,14 @@ import {
   DatePickerSingleInput,
   DatePickerSinglePanel,
   type SingleDateSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
 } from "@salt-ds/lab";
 import React, { type ReactElement, useCallback, useState } from "react";
 
 function formatSingleDate(
   date: DateValue | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
   options?: Intl.DateTimeFormatOptions,
 ) {
   if (date) {

--- a/site/src/examples/date-picker/SingleControlled.tsx
+++ b/site/src/examples/date-picker/SingleControlled.tsx
@@ -5,14 +5,14 @@ import {
   DatePickerSingleInput,
   DatePickerSinglePanel,
   type SingleDateSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback, useState } from "react";
 
 function formatSingleDate(
   date: DateValue | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
   options?: Intl.DateTimeFormatOptions,
 ) {
   if (date) {

--- a/site/src/examples/date-picker/SingleControlled.tsx
+++ b/site/src/examples/date-picker/SingleControlled.tsx
@@ -6,13 +6,13 @@ import {
   DatePickerSinglePanel,
   type SingleDateSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback, useState } from "react";
 
 function formatSingleDate(
   date: DateValue | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
   options?: Intl.DateTimeFormatOptions,
 ) {
   if (date) {

--- a/site/src/examples/date-picker/SingleWithConfirmation.tsx
+++ b/site/src/examples/date-picker/SingleWithConfirmation.tsx
@@ -14,14 +14,14 @@ import {
   DatePickerSingleInput,
   DatePickerSinglePanel,
   type SingleDateSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
 } from "@salt-ds/lab";
 import React, { type ReactElement, useCallback, useRef, useState } from "react";
 
 function formatSingleDate(
   date: DateValue | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
   options?: Intl.DateTimeFormatOptions,
 ) {
   if (date) {

--- a/site/src/examples/date-picker/SingleWithConfirmation.tsx
+++ b/site/src/examples/date-picker/SingleWithConfirmation.tsx
@@ -15,13 +15,13 @@ import {
   DatePickerSinglePanel,
   type SingleDateSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import React, { type ReactElement, useCallback, useRef, useState } from "react";
 
 function formatSingleDate(
   date: DateValue | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
   options?: Intl.DateTimeFormatOptions,
 ) {
   if (date) {

--- a/site/src/examples/date-picker/SingleWithCustomPanel.tsx
+++ b/site/src/examples/date-picker/SingleWithCustomPanel.tsx
@@ -13,15 +13,15 @@ import {
   DatePickerOverlay,
   DatePickerSingleInput,
   type SingleDateSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
 } from "@salt-ds/lab";
 import { CustomDatePickerPanel } from "@salt-ds/lab/stories/date-picker/CustomDatePickerPanel";
 import React, { type ReactElement, useCallback, useState } from "react";
 
 function formatSingleDate(
   date: DateValue | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
   options?: Intl.DateTimeFormatOptions,
 ) {
   if (date) {

--- a/site/src/examples/date-picker/SingleWithCustomPanel.tsx
+++ b/site/src/examples/date-picker/SingleWithCustomPanel.tsx
@@ -14,14 +14,14 @@ import {
   DatePickerSingleInput,
   type SingleDateSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import { CustomDatePickerPanel } from "@salt-ds/lab/stories/date-picker/CustomDatePickerPanel";
 import React, { type ReactElement, useCallback, useState } from "react";
 
 function formatSingleDate(
   date: DateValue | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
   options?: Intl.DateTimeFormatOptions,
 ) {
   if (date) {

--- a/site/src/examples/date-picker/SingleWithCustomParser.tsx
+++ b/site/src/examples/date-picker/SingleWithCustomParser.tsx
@@ -16,15 +16,15 @@ import {
   DatePickerSingleInput,
   DatePickerSinglePanel,
   type SingleDateSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
   parseCalendarDate,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback, useState } from "react";
 
 function formatSingleDate(
   date: DateValue | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
   options?: Intl.DateTimeFormatOptions,
 ) {
   if (date) {

--- a/site/src/examples/date-picker/SingleWithCustomParser.tsx
+++ b/site/src/examples/date-picker/SingleWithCustomParser.tsx
@@ -17,14 +17,14 @@ import {
   DatePickerSinglePanel,
   type SingleDateSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
   parseCalendarDate,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback, useState } from "react";
 
 function formatSingleDate(
   date: DateValue | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
   options?: Intl.DateTimeFormatOptions,
 ) {
   if (date) {

--- a/site/src/examples/date-picker/SingleWithFormField.tsx
+++ b/site/src/examples/date-picker/SingleWithFormField.tsx
@@ -11,13 +11,13 @@ import {
   DatePickerSinglePanel,
   type SingleDateSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback, useState } from "react";
 
 function formatSingleDate(
   date: DateValue | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
   options?: Intl.DateTimeFormatOptions,
 ) {
   if (date) {

--- a/site/src/examples/date-picker/SingleWithFormField.tsx
+++ b/site/src/examples/date-picker/SingleWithFormField.tsx
@@ -10,14 +10,14 @@ import {
   DatePickerSingleInput,
   DatePickerSinglePanel,
   type SingleDateSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback, useState } from "react";
 
 function formatSingleDate(
   date: DateValue | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
   options?: Intl.DateTimeFormatOptions,
 ) {
   if (date) {

--- a/site/src/examples/date-picker/SingleWithInitialError.tsx
+++ b/site/src/examples/date-picker/SingleWithInitialError.tsx
@@ -11,13 +11,13 @@ import {
   DatePickerSinglePanel,
   type SingleDateSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback, useState } from "react";
 
 function formatSingleDate(
   date: DateValue | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
   options?: Intl.DateTimeFormatOptions,
 ) {
   if (date) {

--- a/site/src/examples/date-picker/SingleWithInitialError.tsx
+++ b/site/src/examples/date-picker/SingleWithInitialError.tsx
@@ -10,14 +10,14 @@ import {
   DatePickerSingleInput,
   DatePickerSinglePanel,
   type SingleDateSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback, useState } from "react";
 
 function formatSingleDate(
   date: DateValue | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
   options?: Intl.DateTimeFormatOptions,
 ) {
   if (date) {

--- a/site/src/examples/date-picker/SingleWithMinMaxDate.tsx
+++ b/site/src/examples/date-picker/SingleWithMinMaxDate.tsx
@@ -11,13 +11,13 @@ import {
   DatePickerSinglePanel,
   type SingleDateSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback, useState } from "react";
 
 function formatSingleDate(
   date: DateValue | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
   options?: Intl.DateTimeFormatOptions,
 ) {
   if (date) {

--- a/site/src/examples/date-picker/SingleWithMinMaxDate.tsx
+++ b/site/src/examples/date-picker/SingleWithMinMaxDate.tsx
@@ -10,14 +10,14 @@ import {
   DatePickerSingleInput,
   DatePickerSinglePanel,
   type SingleDateSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
 } from "@salt-ds/lab";
 import { type ReactElement, useCallback, useState } from "react";
 
 function formatSingleDate(
   date: DateValue | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
   options?: Intl.DateTimeFormatOptions,
 ) {
   if (date) {

--- a/site/src/examples/date-picker/SingleWithTodayButton.tsx
+++ b/site/src/examples/date-picker/SingleWithTodayButton.tsx
@@ -20,7 +20,7 @@ import {
   type SingleDatePickerState,
   type SingleDateSelection,
   formatDate,
-  getCurrentLocale,
+  getUsLocale,
   useDatePickerContext,
 } from "@salt-ds/lab";
 import React, { type ReactElement, useCallback, useState } from "react";
@@ -47,7 +47,7 @@ const TodayButton = () => {
 
 function formatSingleDate(
   date: DateValue | null,
-  locale = getCurrentLocale(),
+  locale = getUsLocale(),
   options?: Intl.DateTimeFormatOptions,
 ) {
   if (date) {

--- a/site/src/examples/date-picker/SingleWithTodayButton.tsx
+++ b/site/src/examples/date-picker/SingleWithTodayButton.tsx
@@ -19,8 +19,8 @@ import {
   DatePickerSinglePanel,
   type SingleDatePickerState,
   type SingleDateSelection,
+  defaultLocale,
   formatDate,
-  getUsLocale,
   useDatePickerContext,
 } from "@salt-ds/lab";
 import React, { type ReactElement, useCallback, useState } from "react";
@@ -47,7 +47,7 @@ const TodayButton = () => {
 
 function formatSingleDate(
   date: DateValue | null,
-  locale = getUsLocale(),
+  locale = defaultLocale,
   options?: Intl.DateTimeFormatOptions,
 ) {
   if (date) {


### PR DESCRIPTION
ref - https://github.com/jpmorganchase/salt-ds/pull/4238#issuecomment-2395470502

There will be a natural conflict between local locale vs default parser logic (and a little bit of formatter)

Without it, most "default" out-of-box behaviour will be universally the same across regions, which is better for cross regional banking system. 

For some localized usage, it can still be tuned to be be using local locale, which means all parser / placeholder / formatter needs to be adjusted accordingly as well. This would be a rather "advanced" use case to make sure it works well for each region.