### PR TITLE
Fix HD Toast icon alignment

### DIFF
--- a/.changeset/wet-swans-wave.md
+++ b/.changeset/wet-swans-wave.md
@@ -2,4 +2,4 @@
 "@salt-ds/core": patch
 ---
 
-Fixed HD Toast icon alignment
+Fixed Toast icon alignment not matching Figma.

--- a/.changeset/wet-swans-wave.md
+++ b/.changeset/wet-swans-wave.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Fixed HD Toast icon alignment

--- a/.changeset/wet-swans-wave.md
+++ b/.changeset/wet-swans-wave.md
@@ -2,4 +2,4 @@
 "@salt-ds/core": patch
 ---
 
-Fixed Toast icon alignment not matching Figma.
+Fixed Toast icon alignment.

--- a/packages/core/src/toast/Toast.css
+++ b/packages/core/src/toast/Toast.css
@@ -30,7 +30,7 @@
 
 /* Styles applied to icon */
 .saltToast-iconContainer > .saltIcon {
-  margin: calc(var(--salt-spacing-75) + 2px) 0 var(--salt-spacing-75) 0;
+  margin: calc(var(--salt-spacing-75) + min(var(--salt-spacing-25), 2px)) 0 var(--salt-spacing-75) 0;
   color: var(--toast-iconColor);
 }
 

--- a/packages/core/src/toast/Toast.css
+++ b/packages/core/src/toast/Toast.css
@@ -30,7 +30,7 @@
 
 /* Styles applied to icon */
 .saltToast-iconContainer > .saltIcon {
-  margin-top: var(--salt-spacing-100);
+  margin-top: calc(var(--salt-spacing-75) + calc((var(--salt-text-lineHeight) - max(var(--salt-size-icon), 12px)) / 2));
   color: var(--toast-iconColor);
 }
 

--- a/packages/core/src/toast/Toast.css
+++ b/packages/core/src/toast/Toast.css
@@ -30,7 +30,7 @@
 
 /* Styles applied to icon */
 .saltToast-iconContainer > .saltIcon {
-  margin: calc(var(--salt-spacing-75) + min(var(--salt-spacing-25), 2px)) 0 var(--salt-spacing-75) 0;
+  margin-top: var(--salt-spacing-100);
   color: var(--toast-iconColor);
 }
 


### PR DESCRIPTION
Closes #3524

In the Figma spec, the high density icon has a `padding-top` value of `1px`. The other densities have a value of `2px`.

In the code, the `padding-top` value is combined with the `margin-top` value, however all densities have a value of `2px`.

I've updated the CSS to use `1px` instead of `2px` when high density is selected.