### PR TITLE
Use workspace protocol for theme peer dependency

### DIFF
--- a/packages/ag-grid-theme/package.json
+++ b/packages/ag-grid-theme/package.json
@@ -25,6 +25,6 @@
     "del": "^7.0.0"
   },
   "peerDependencies": {
-    "@salt-ds/theme": "^1.23.0"
+    "@salt-ds/theme": "workspace:^"
   }
 }

--- a/packages/ag-grid-theme/scripts/build.mjs
+++ b/packages/ag-grid-theme/scripts/build.mjs
@@ -3,8 +3,9 @@ import { argv } from "node:process";
 import { deleteSync } from "del";
 import esbuild from "esbuild";
 import fs from "fs-extra";
+import { transformWorkspaceDeps } from "../../../scripts/transformWorkspaceDeps.mjs";
 
-const FILES_TO_COPY = ["README.md", "LICENSE", "CHANGELOG.md", "package.json"];
+const FILES_TO_COPY = ["README.md", "LICENSE", "CHANGELOG.md"];
 
 const cwd = process.cwd();
 const packageJson = (
@@ -38,6 +39,17 @@ if (argv.includes("--watch")) {
   await context.rebuild();
   await context.dispose();
 }
+
+await fs.writeJSON(
+  path.join(buildFolder, "package.json"),
+  {
+    ...packageJson,
+    peerDependencies: await transformWorkspaceDeps(
+      packageJson.peerDependencies,
+    ),
+  },
+  { spaces: 2 },
+);
 
 for (const file of FILES_TO_COPY) {
   const from = path.join(cwd, file);

--- a/scripts/transformWorkspaceDeps.mjs
+++ b/scripts/transformWorkspaceDeps.mjs
@@ -1,0 +1,35 @@
+export async function transformWorkspaceDeps(dependencies = {}) {
+  const workspacePackages = Object.entries(dependencies).filter(([, version]) =>
+    version.match(/^workspace:/),
+  );
+
+  const workspaceDependencies = {};
+
+  for (const [name, version] of workspacePackages) {
+    // strip workspace:
+    const strippedVersion = version.slice(10);
+
+    if (
+      strippedVersion !== "~" &&
+      strippedVersion !== "*" &&
+      strippedVersion !== "^"
+    ) {
+      workspaceDependencies[name] = strippedVersion;
+      continue;
+    }
+
+    const packageJson = (
+      await import(`${name}/package.json`, {
+        with: { type: "json" },
+      })
+    ).default;
+
+    workspaceDependencies[name] =
+      `${strippedVersion !== "*" ? strippedVersion : ""}${packageJson.version}`;
+  }
+
+  return {
+    ...dependencies,
+    ...workspaceDependencies,
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3332,7 +3332,7 @@ __metadata:
   dependencies:
     del: "npm:^7.0.0"
   peerDependencies:
-    "@salt-ds/theme": ^1.23.0
+    "@salt-ds/theme": "workspace:^"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Using a workspace protocol is better since it will get transformed during build and means that the version will be up-to-date and not out of sync to the next released version.

Also since it is transformed during the build it's ignored by changesets and doesn't break the Version Packages PR. It also aligns peer dependencies with how we handle workspace dependencies already.