### PR TITLE
Undeprecated --salt-accent-background-disabled

### DIFF
--- a/.changeset/nervous-maps-fix.md
+++ b/.changeset/nervous-maps-fix.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/theme": patch
+---
+
+Undeprecate `--salt-accent-background-disabled`

--- a/packages/theme/css/deprecated/characteristics.css
+++ b/packages/theme/css/deprecated/characteristics.css
@@ -137,7 +137,6 @@
   /* Accent */
   --salt-accent-fontWeight: var(--salt-typography-fontWeight-semiBold); /* Use --salt-text-notation-fontWeight */
   --salt-accent-foreground-disabled: var(--salt-palette-accent-foreground-disabled);
-  --salt-accent-background-disabled: var(--salt-palette-accent-background-disabled);
   --salt-accent-borderColor-disabled: var(--salt-palette-accent-border-disabled); /* Use --salt-container-primary-borderColor-disabled */
 
   /* Track */


### PR DESCRIPTION
In #4111 the token was added back to characteristics but it wasn't removed from the deprecated file.