### PR TITLE
Fix ag grid menu icon hover color in theme next

### DIFF
--- a/packages/ag-grid-theme/css/parts/ag-header.css
+++ b/packages/ag-grid-theme/css/parts/ag-header.css
@@ -119,7 +119,9 @@ div[class*="ag-theme-salt"] .ag-chart-menu-icon:hover {
   /* Button is the same size of icon, we're copying what ag quartz theme is doing */
   box-shadow: 0 0 0 var(--salt-spacing-50) var(--salt-actionable-subtle-background-hover);
   background-color: var(--salt-actionable-subtle-background-hover);
+  --ag-icon-font-color: var(--salt-actionable-subtle-foreground-hover);
   --ag-icon-font-color-filter: var(--salt-actionable-subtle-foreground-hover);
+  --ag-icon-font-color-menu-alt: var(--salt-actionable-subtle-foreground-hover);
 }
 
 /* Make filter and menu icon apart, to accomodate hover effects above */


### PR DESCRIPTION
Changset not needed, will go with #4418

The column menu icon, hover over icon, in **theme next**
https://storybook.saltdesignsystem.com/?path=/story/ag-grid-ag-grid-theme--context-menu&globals=themeNext:enable;accent:teal