### PR TITLE
Add site heading link scroll top

### DIFF
--- a/site/src/components/mdx/h2/Heading2.module.css
+++ b/site/src/components/mdx/h2/Heading2.module.css
@@ -1,6 +1,7 @@
 .heading2 {
   margin-bottom: var(--salt-spacing-200);
   margin-top: var(--salt-spacing-300);
+  scroll-margin-top: var(--site-navigation-scroll-margin-top, 0);
 }
 
 .heading2 + h3 {

--- a/site/src/components/mdx/h3/Heading3.module.css
+++ b/site/src/components/mdx/h3/Heading3.module.css
@@ -8,6 +8,7 @@
   font-size: var(--salt-text-h3-fontSize);
   font-weight: var(--salt-text-h3-fontWeight-strong);
   line-height: var(--salt-text-h3-lineHeight);
+  scroll-margin-top: var(--site-navigation-scroll-margin-top, 0);
 }
 
 .heading3 + h4 {

--- a/site/src/components/mdx/h4/Heading4.module.css
+++ b/site/src/components/mdx/h4/Heading4.module.css
@@ -1,4 +1,5 @@
 .heading4 {
   margin-top: calc(var(--salt-size-unit) * 2);
   margin-bottom: var(--salt-size-unit);
+  scroll-margin-top: var(--site-navigation-scroll-margin-top, 0);
 }

--- a/site/src/css/global/text.css
+++ b/site/src/css/global/text.css
@@ -21,6 +21,9 @@ h2 {
 main {
   font-size: var(--salt-text-fontSize);
   line-height: var(--salt-text-lineHeight);
+  /* This needs to be here so scroll-margin can be defined for headers */
+  --site-navigation-height: calc(var(--salt-spacing-200) + var(--salt-size-base));
+  --site-navigation-scroll-margin-top: calc(var(--salt-spacing-100) + var(--site-navigation-height));
 }
 
 p {
@@ -33,5 +36,11 @@ p {
     --heading-font-size: var(--salt-text-h3-fontSize);
     --heading-font-weight: var(--salt-text-h3-fontWeight);
     --heading-line-height: var(--salt-text-h3-lineHeight);
+  }
+}
+
+@media screen and (max-width: 959px) {
+  main {
+    --site-navigation-height: calc(var(--salt-size-unit) * 5);
   }
 }

--- a/site/src/layouts/index.module.css
+++ b/site/src/layouts/index.module.css
@@ -1,7 +1,6 @@
 .base > header {
   --site-navigation-padding-vertical: 0;
   --site-navigation-padding-horizontal: var(--salt-spacing-300);
-  --site-navigation-height: calc(var(--salt-spacing-200) + var(--salt-size-base));
   --mosaic-border-width-thin: 0;
   --mosaic-shadow-dark-elevation2: var(--salt-shadow-100-color);
   --mosaic-color-dark-neutral-background-regular: var(--salt-color-gray-900);
@@ -65,7 +64,6 @@
   .base > header {
     --site-navigation-padding-horizontal: var(--salt-size-unit);
     --site-navigation-padding-vertical: var(--salt-size-unit);
-    --site-navigation-height: calc(var(--salt-size-unit) * 5);
   }
 
   .base > header {


### PR DESCRIPTION
This should fix the confusion that user clicking the header link, got lost... i.e. when landing on a page with hash id, headings shouldn't be covered up by the app header

Part of #4447