### PR TITLE
Fix Site Doc Info status color description

### DIFF
--- a/site/docs/foundations/color.mdx
+++ b/site/docs/foundations/color.mdx
@@ -15,12 +15,12 @@ Status colors are visual indicators that reflect changes in the state or conditi
 
 The Salt design system includes 4 statuses with corresponding colors:
 
-| Status  | Color                              |
-| ------- | ---------------------------------- |
-| Info    | Accent - Blue (Teal in Next theme) |
-| Error   | Red                                |
-| Warning | Orange                             |
-| Success | Green                              |
+| Status  | Color  |
+| ------- | ------ |
+| Info    | Blue   |
+| Error   | Red    |
+| Warning | Orange |
+| Success | Green  |
 
 ## Sentiment
 


### PR DESCRIPTION
Info status do not point to accent, it's a planned future change

https://github.com/jpmorganchase/salt-ds/blob/5c8d47b934db5aee0c46c03b5461e60307e32150/packages/theme/css/characteristics/status-next.css#L6