### PR TITLE
Try split entries of date-adapters

### DIFF
--- a/.changeset/good-jokes-punch.md
+++ b/.changeset/good-jokes-punch.md
@@ -1,0 +1,16 @@
+---
+"@salt-ds/date-adapters": minor
+---
+
+Split date adapters into sub packages to help with peerDependencies resolution
+
+```diff
+- import { AdapterDateFns } from "@salt-ds/date-adapters";
+- import { AdapterDayjs } from "@salt-ds/date-adapters";
+- import { AdapterLuxon } from "@salt-ds/date-adapters";
+- import { AdapterMoment } from "@salt-ds/date-adapters";
++ import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
++ import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
++ import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
++ import { AdapterMoment } from "@salt-ds/date-adapters/moment";
+```

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "types": ["cypress"]
+    "types": ["cypress"],
+    "paths": {
+      "@salt-ds/date-adapters/*": ["../packages/date-adapters/src/*"]
+    }
   },
   "include": ["**/*.ts", "**/*.tsx"]
 }

--- a/docs/decorators/withLocalization.tsx
+++ b/docs/decorators/withLocalization.tsx
@@ -1,9 +1,9 @@
 import type { Decorator } from "@storybook/react";
 import "dayjs/locale/en";
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import { LocalizationProvider } from "@salt-ds/lab";
 import { enUS as dateFnsEnUs } from "date-fns/locale";
 

--- a/packages/date-adapters/package.json
+++ b/packages/date-adapters/package.json
@@ -38,6 +38,13 @@
     "provenance": true
   },
   "scripts": {
-    "build": "yarn node ../../scripts/build.mjs"
-  }
+    "build": "yarn node ../../scripts/build.mjs && yarn build:entries",
+    "build:entries": "yarn node ./scripts/build.mjs"
+  },
+  "files": [
+    "/date-fns",
+    "/dayjs",
+    "/luxon",
+    "/moment"
+  ]
 }

--- a/packages/date-adapters/scripts/build.mjs
+++ b/packages/date-adapters/scripts/build.mjs
@@ -1,0 +1,130 @@
+import path from "node:path";
+import commonjs from "@rollup/plugin-commonjs";
+import json from "@rollup/plugin-json";
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import browserslistToEsbuild from "browserslist-to-esbuild";
+import fs from "fs-extra";
+import { rollup } from "rollup";
+import esbuild from "rollup-plugin-esbuild";
+import postcss from "rollup-plugin-postcss";
+import { makeTypings } from "./makeTypings.mjs";
+// import { transformWorkspaceDeps } from "./transformWorkspaceDeps.mjs";
+// import { distinct } from "./utils.mjs";
+
+const cwd = process.cwd();
+
+const packageJson = (
+  await import(path.join("file://", cwd, "package.json"), {
+    with: { type: "json" },
+  })
+).default;
+
+const FILES_TO_COPY = [];
+// ["README.md", "LICENSE", "CHANGELOG.md"].concat(
+//   packageJson.files ?? [],
+// );
+
+const ENTRY_FOLDERS = ["date-fns", "dayjs", "luxon", "moment"];
+
+for (const entry of ENTRY_FOLDERS) {
+  const packageName = `${packageJson.name}/${entry}`;
+
+  const outputDir = path.join(packageJson.publishConfig.directory, entry);
+
+  console.log(`Building ${packageName}`);
+
+  await fs.mkdirp(outputDir);
+  await fs.emptyDir(outputDir);
+
+  await makeTypings(outputDir, entry);
+
+  const bundle = await rollup({
+    input: path.join(cwd, "src", entry, "index.ts"),
+    external: (id) => {
+      // via tsdx
+      // TODO: this should probably be included into deps instead
+      if (id === "babel-plugin-transform-async-to-promises/helpers") {
+        // we want to inline these helpers
+        return false;
+      }
+      // exclude any dependency that's not a realtive import
+      return !id.startsWith(".") && !path.isAbsolute(id);
+    },
+    treeshake: {
+      propertyReadSideEffects: false,
+    },
+    plugins: [
+      nodeResolve({
+        extensions: [".ts", ".tsx", ".js", ".jsx"],
+        browser: true,
+        mainFields: ["module", "main", "browser"],
+      }),
+      commonjs({ include: /\/node_modules\// }),
+      esbuild({
+        target: browserslistToEsbuild(),
+        minify: false,
+        sourceMap: true,
+      }),
+      postcss({ extract: false, inject: false }),
+      json(),
+    ],
+  });
+
+  const transformSourceMap = (relativeSourcePath, sourceMapPath) => {
+    // make source map input files relative to the `${packagePath}/dist-${format}` within
+    // the package directory
+
+    const absoluteSourcepath = path.resolve(
+      path.dirname(sourceMapPath),
+      relativeSourcePath,
+    );
+    const packageRelativeSourcePath = path.relative(cwd, absoluteSourcepath);
+
+    return `../${packageRelativeSourcePath}`;
+  };
+
+  await bundle.write({
+    freeze: false,
+    sourcemap: true,
+    preserveModules: true,
+    dir: path.join(outputDir, "dist-cjs"),
+    format: "cjs",
+    exports: "auto",
+    sourcemapPathTransform: transformSourceMap,
+  });
+
+  await bundle.write({
+    freeze: false,
+    sourcemap: true,
+    preserveModules: true,
+    dir: path.join(outputDir, "dist-es"),
+    format: "es",
+    exports: "auto",
+    sourcemapPathTransform: transformSourceMap,
+  });
+
+  await bundle.close();
+
+  await fs.writeJSON(
+    path.join(outputDir, "package.json"),
+    {
+      main: `dist-cjs/${entry}/index.js`,
+      module: `dist-es/${entry}/ndex.js`,
+      typings: `dist-types/${entry}/index.d.ts`,
+    },
+    { spaces: 2 },
+  );
+
+  for (const file of FILES_TO_COPY) {
+    const filePath = path.join(cwd, file);
+    try {
+      await fs.copy(filePath, path.join(outputDir, file));
+    } catch (error) {
+      if (error.code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+
+  console.log(`Built ${packageName} into ${outputDir}`);
+}

--- a/packages/date-adapters/scripts/build.mjs
+++ b/packages/date-adapters/scripts/build.mjs
@@ -108,8 +108,9 @@ for (const entry of ENTRY_FOLDERS) {
   await fs.writeJSON(
     path.join(outputDir, "package.json"),
     {
+      sideEffects: false,
       main: `dist-cjs/${entry}/index.js`,
-      module: `dist-es/${entry}/ndex.js`,
+      module: `dist-es/${entry}/index.js`,
       typings: `dist-types/${entry}/index.d.ts`,
     },
     { spaces: 2 },

--- a/packages/date-adapters/scripts/makeTypings.mjs
+++ b/packages/date-adapters/scripts/makeTypings.mjs
@@ -1,0 +1,128 @@
+import path from "node:path";
+import { isCI } from "ci-info";
+import fse from "fs-extra";
+import { getTsconfig } from "get-tsconfig";
+import ts from "typescript";
+
+const typescriptConfigFilename = "tsconfig.json";
+const cwd = process.cwd();
+
+export function reportTSDiagnostics(diagnostics) {
+  for (const diagnostic of diagnostics) {
+    let message = "Error";
+    if (diagnostic.file) {
+      const where = diagnostic.file.getLineAndCharacterOfPosition(
+        diagnostic.start,
+      );
+      message += ` ${diagnostic.file.fileName} ${where.line}, ${
+        where.character + 1
+      }`;
+    }
+    message += `: ${ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n")}`;
+    console.error(message);
+  }
+}
+
+export async function makeTypings(outDir, entryFolder) {
+  const typescriptConfig = await getTypescriptConfig(cwd, entryFolder);
+
+  console.log("generating .d.ts files");
+
+  // make a shallow copy of the configuration
+  const tsconfig = {
+    ...typescriptConfig,
+    compilerOptions: {
+      ...typescriptConfig.compilerOptions,
+    },
+  };
+
+  // then add our custom stuff
+  // Only include src files from the package to prevent already built
+  // files from interferring with the compile
+  tsconfig.include = [path.join(cwd, "src", entryFolder)];
+  tsconfig.compilerOptions = {
+    ...tsconfig.compilerOptions,
+    noEmit: false,
+    declaration: true,
+    emitDeclarationOnly: true,
+    declarationDir: path.join(outDir, "dist-types"),
+    rootDir: path.join(cwd, "src"),
+    diagnostics: !isCI,
+  };
+
+  // Extract config information
+  const configParseResult = ts.parseJsonConfigFileContent(
+    tsconfig,
+    ts.sys,
+    path.dirname(typescriptConfigFilename),
+  );
+
+  if (configParseResult.errors.length > 0) {
+    reportTSDiagnostics(configParseResult.errors);
+    throw new Error("Could not parse Typescript configuration");
+  }
+
+  const host = ts.createCompilerHost(configParseResult.options);
+  host.writeFile = (fileName, contents) => {
+    fse.mkdirpSync(path.dirname(fileName));
+    fse.writeFileSync(fileName, contents);
+  };
+
+  // Compile
+  const program = ts.createProgram(
+    configParseResult.fileNames,
+    configParseResult.options,
+    host,
+  );
+
+  const emitResult = program.emit();
+
+  // Skip diagnostic reporting in CI
+  if (isCI) {
+    return;
+  }
+  const diagnostics = ts
+    .getPreEmitDiagnostics(program)
+    .concat(emitResult.diagnostics);
+  if (diagnostics.length > 0) {
+    reportTSDiagnostics(diagnostics);
+    throw new Error("Could not generate .d.ts files");
+  }
+}
+
+export function distinct(arr) {
+  return [...new Set(arr)];
+}
+
+export async function getTypescriptConfig(cwd, entryFolder) {
+  const typescriptConfig = {};
+
+  const result = getTsconfig(cwd);
+
+  Object.assign(typescriptConfig, result.config, {
+    include: [path.join(cwd, "src", entryFolder)],
+    exclude: distinct(
+      [
+        // all TS test files, regardless whether co-located or in test/ etc
+        "**/*.stories.ts",
+        "**/*.stories.tsx",
+        "**/*.spec.ts",
+        "**/*.test.ts",
+        "**/*.e2e.ts",
+        "**/*.spec.tsx",
+        "**/*.test.tsx",
+        "**/__tests__",
+        "**/dist-cjs",
+        "**/dist-es",
+        "**/dist-types",
+        // TS defaults below
+        "node_modules",
+        "bower_components",
+        "jspm_packages",
+        "tmp",
+      ].concat(result.exclude ?? []),
+    ),
+  });
+
+  return typescriptConfig;
+}

--- a/packages/date-adapters/src/__tests__/date-fns.spec.ts
+++ b/packages/date-adapters/src/__tests__/date-fns.spec.ts
@@ -1,7 +1,8 @@
 import { isValid } from "date-fns";
 import { enUS } from "date-fns/locale";
 import { describe, expect, it } from "vitest";
-import { AdapterDateFns, DateDetailErrorEnum } from "../index";
+import { AdapterDateFns } from "../date-fns";
+import { DateDetailErrorEnum } from "../index";
 
 describe("GIVEN a AdapterDateFns", () => {
   const adapter = new AdapterDateFns({ locale: enUS });

--- a/packages/date-adapters/src/__tests__/dayjs.spec.ts
+++ b/packages/date-adapters/src/__tests__/dayjs.spec.ts
@@ -3,7 +3,8 @@ import customParseFormat from "dayjs/plugin/customParseFormat";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
 import { describe, expect, it } from "vitest";
-import { AdapterDayjs, DateDetailErrorEnum } from "../index";
+import { AdapterDayjs } from "../dayjs";
+import { DateDetailErrorEnum } from "../index";
 
 // Extend dayjs with necessary plugins
 dayjs.extend(utc);

--- a/packages/date-adapters/src/__tests__/luxon.spec.ts
+++ b/packages/date-adapters/src/__tests__/luxon.spec.ts
@@ -1,6 +1,7 @@
 import { DateTime } from "luxon";
 import { describe, expect, it } from "vitest";
-import { AdapterLuxon, DateDetailErrorEnum } from "../index";
+import { DateDetailErrorEnum } from "../index";
+import { AdapterLuxon } from "../luxon";
 
 describe("GIVEN a AdapterLuxon", () => {
   const adapter = new AdapterLuxon({ locale: "en-US" });

--- a/packages/date-adapters/src/__tests__/moment.spec.ts
+++ b/packages/date-adapters/src/__tests__/moment.spec.ts
@@ -1,7 +1,8 @@
 import moment from "moment";
 import { describe, expect, it } from "vitest";
 import "moment-timezone";
-import { AdapterMoment, DateDetailErrorEnum } from "../index";
+import { DateDetailErrorEnum } from "../index";
+import { AdapterMoment } from "../moment";
 
 describe("GIVEN a AdapterMoment", () => {
   const adapter = new AdapterMoment({ locale: "en" });

--- a/packages/date-adapters/src/index.ts
+++ b/packages/date-adapters/src/index.ts
@@ -10,9 +10,4 @@
 // biome-ignore lint/complexity/noBannedTypes: type augmented by configured adapters
 export type DateFrameworkTypeMap = {};
 
-export * from "./date-fns";
-export * from "./dayjs";
-export * from "./luxon";
-export * from "./moment";
-
 export * from "./types";

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.a11y.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.a11y.cy.tsx
@@ -1,7 +1,7 @@
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 
 import * as calendarStories from "@stories/calendar/calendar.stories";
 import { composeStories } from "@storybook/react";

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.cy.tsx
@@ -2,10 +2,10 @@ import type {
   DateFrameworkType,
   SaltDateAdapter,
 } from "@salt-ds/date-adapters";
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import {
   Calendar,
   CalendarGrid,

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.multiselect.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.multiselect.cy.tsx
@@ -2,10 +2,10 @@ import type {
   DateFrameworkType,
   SaltDateAdapter,
 } from "@salt-ds/date-adapters";
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import {
   Calendar,
   CalendarGrid,

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.offset.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.offset.cy.tsx
@@ -2,10 +2,10 @@ import type {
   DateFrameworkType,
   SaltDateAdapter,
 } from "@salt-ds/date-adapters";
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import {
   Calendar,
   CalendarGrid,

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.range.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.range.cy.tsx
@@ -1,11 +1,11 @@
-import {
-  AdapterDateFns,
-  AdapterDayjs,
-  AdapterLuxon,
-  AdapterMoment,
-  type DateFrameworkType,
-  type SaltDateAdapter,
+import type {
+  DateFrameworkType,
+  SaltDateAdapter,
 } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import {
   Calendar,
   CalendarGrid,

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.single.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.single.cy.tsx
@@ -2,10 +2,10 @@ import type {
   DateFrameworkType,
   SaltDateAdapter,
 } from "@salt-ds/date-adapters";
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import {
   Calendar,
   CalendarGrid,

--- a/packages/lab/src/__tests__/__e2e__/date-input/DateInput.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-input/DateInput.cy.tsx
@@ -1,7 +1,7 @@
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import * as dateInputStories from "@stories/date-input/date-input.stories";
 import { composeStories } from "@storybook/react";
 import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";

--- a/packages/lab/src/__tests__/__e2e__/date-input/DateInputRange.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-input/DateInputRange.cy.tsx
@@ -1,13 +1,13 @@
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
 import {
   DateDetailErrorEnum,
   type DateFrameworkType,
   type ParserResult,
   type SaltDateAdapter,
 } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import {
   DateInputRange,
   type DateParserField,

--- a/packages/lab/src/__tests__/__e2e__/date-input/DateInputSingle.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-input/DateInputSingle.cy.tsx
@@ -4,10 +4,10 @@ import {
   type ParserResult,
   type SaltDateAdapter,
 } from "@salt-ds/date-adapters";
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import { DateInputSingle } from "@salt-ds/lab";
 
 import { es as dateFnsEs } from "date-fns/locale";

--- a/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.cy.tsx
@@ -1,7 +1,7 @@
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import * as datePickerStories from "@stories/date-picker/date-picker.stories";
 import { composeStories } from "@storybook/react";
 import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";

--- a/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.range.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.range.cy.tsx
@@ -3,10 +3,10 @@ import {
   type DateFrameworkType,
   type SaltDateAdapter,
 } from "@salt-ds/date-adapters";
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import {
   DatePicker,
   DatePickerOverlay,

--- a/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.single.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.single.cy.tsx
@@ -3,10 +3,10 @@ import {
   type DateFrameworkType,
   type SaltDateAdapter,
 } from "@salt-ds/date-adapters";
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import {
   DatePicker,
   DatePickerOverlay,

--- a/site/docs/components/localization-provider/usage.mdx
+++ b/site/docs/components/localization-provider/usage.mdx
@@ -37,25 +37,25 @@ To import your chosen adapter adapter use one of the following :
 ### date-fns
 
 ```
-import { AdapterDateFns } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
 ```
 
 ### dayjs
 
 ```
-import { AdapterDayJs } from "@salt-ds/date-adapters";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
 ```
 
 ### luxon
 
 ```
-import { AdapterLuxon } from "@salt-ds/date-adapters";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
 ```
 
 ### moment (legacy)
 
 ```
-import { AdapterMoment } from "@salt-ds/date-adapters";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 ```
 
 ## Usage

--- a/site/src/components/components/LivePreview.tsx
+++ b/site/src/components/components/LivePreview.tsx
@@ -14,7 +14,7 @@ import useIsMobileView from "../../utils/useIsMobileView";
 import { Pre } from "../mdx/pre";
 import { useLivePreviewControls } from "./useLivePreviewControls";
 
-import { AdapterDateFns } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
 import { LocalizationProvider } from "@salt-ds/lab";
 import styles from "./LivePreview.module.css";
 

--- a/site/src/examples/calendar/WithLocale.tsx
+++ b/site/src/examples/calendar/WithLocale.tsx
@@ -1,4 +1,4 @@
-import { AdapterDateFns } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
 import {
   Calendar,
   CalendarGrid,

--- a/site/src/examples/localization-provider/Locale.tsx
+++ b/site/src/examples/localization-provider/Locale.tsx
@@ -13,10 +13,10 @@ import {
 } from "@salt-ds/lab";
 import { type ChangeEventHandler, type ReactElement, useState } from "react";
 import "dayjs/locale/en";
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import moment from "moment";
 import "moment/locale/zh-cn"; // Import the Chinese locale
 import { enUS as dateFnsEnUs } from "date-fns/locale";

--- a/site/src/examples/localization-provider/MinMax.tsx
+++ b/site/src/examples/localization-provider/MinMax.tsx
@@ -1,5 +1,6 @@
 import { FormField, FormFieldHelperText, FormFieldLabel } from "@salt-ds/core";
-import { AdapterDateFns, type DateFrameworkType } from "@salt-ds/date-adapters";
+import type { DateFrameworkType } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
 import {
   Calendar,
   CalendarGrid,

--- a/site/src/pages/_app.tsx
+++ b/site/src/pages/_app.tsx
@@ -25,7 +25,7 @@ import {
   SaltProviderNext,
   useCurrentBreakpoint,
 } from "@salt-ds/core";
-import { AdapterDateFns } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
 import { LocalizationProvider } from "@salt-ds/lab";
 import clsx from "clsx";
 import { SessionProvider } from "next-auth/react";

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "baseUrl": ".",
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "paths": {
+      "@salt-ds/date-adapters/*": ["../packages/date-adapters/src/*"]
+    }
   },
   "include": ["src/**/*", "globals.d.ts"],
   "exclude": ["node_modules"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
         "packages/icons/stories/*",
         "packages/lab/stories/*",
         "packages/theme/stories/*"
-      ]
+      ],
+      "@salt-ds/date-adapters/*": ["packages/date-adapters/src/*"]
     },
     "types": ["cypress", "@testing-library/cypress", "node"]
   },


### PR DESCRIPTION
Try to fix #4468

`0.0.0-snapshot-20241202180035` does work with a simple vite set up when running `npm run dev`...

Would be better for the output doesn't have sub directory under each dist (second LIB) in `dist/{LIB}/dist-[cjs|es|types]/{LIB}`

Test with [codesandbox](https://codesandbox.io/p/sandbox/datepicker-with-open-on-focus-4hrzf7)

--
Doesn't work with subfolder from `0.0.0-snapshot-20241202175046` snapshot ...
> [plugin:vite:import-analysis] Failed to resolve import "@salt-ds/date-adapters/date-fns" from "src/App.tsx". Does the file exist?
/Users/F692193/projects/temp/vite-salt 2/src/App.tsx:11:31
21 |  } from "react";
22 |  import { SaltProvider } from "@salt-ds/core";
23 |  import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";