### PR TITLE
Split date adapters into sub packages to help with peerDependencies r…

### DIFF
--- a/.changeset/giant-cycles-clap.md
+++ b/.changeset/giant-cycles-clap.md
@@ -1,0 +1,57 @@
+---
+"@salt-ds/date-adapters": patch
+"@salt-ds/lab": patch
+---
+
+Refine peer dependency management for DatePicker adapters by splitting them into sub-packages. You now import only the specific date framework adapter you need, simplifying dependency handling.
+
+- **For `date-fns`:**
+
+  ```diff
+  - import { AdapterDateFns } from "@salt-ds/date-adapters";
+  + import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+  ```
+
+- **For `dayjs`:**
+
+  ```diff
+  - import { AdapterDayjs } from "@salt-ds/date-adapters";
+  + import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+  ```
+
+- **For `luxon`:**
+
+  ```diff
+  - import { AdapterLuxon } from "@salt-ds/date-adapters";
+  + import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+  ```
+
+- **For `moment`:**
+
+  ```diff
+  - import { AdapterMoment } from "@salt-ds/date-adapters";
+  + import { AdapterMoment } from "@salt-ds/date-adapters/moment";
+  ```
+
+Additionally, `DateDetailErrorEnum` is now a simpler `DateDetailError` of type `DateDetailErrorType`.
+
+```diff
+- import { DateDetailErrorEnum } from "@salt-ds/date-adapters";
++ import { DateDetailError } from "@salt-ds/date-adapters/moment";
+```
+
+### Instructions
+
+1. Modify your import statements to use the specific sub-package for the date adapter you require.
+
+2. Ensure your `package.json` includes the necessary date framework as a dependency. For example, if using `date-fns`:
+
+   ```json
+   {
+     "dependencies": {
+       "date-fns": "^x.x.x"
+     }
+   }
+   ```
+
+This change helps streamline the integration of date frameworks with the DatePicker component by ensuring only the necessary adapters and dependencies are included.

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -56,10 +56,6 @@ async function getViteConfig(config: UserConfig) {
             __dirname,
             "./dist/salt-ds-countries",
           ),
-          "@salt-ds/date-adapters": path.resolve(
-            __dirname,
-            "./dist/salt-ds-date-adapters",
-          ),
           "@salt-ds/data-grid": path.resolve(
             __dirname,
             "./dist/salt-ds-data-grid",
@@ -73,7 +69,6 @@ async function getViteConfig(config: UserConfig) {
       optimizeDeps: {
         include: [
           "@salt-ds/core",
-          "@salt-ds/data-adapters",
           "@salt-ds/data-grid",
           "@salt-ds/lab",
           "@salt-ds/icons",

--- a/docs/decorators/withLocalization.tsx
+++ b/docs/decorators/withLocalization.tsx
@@ -1,9 +1,9 @@
 import type { Decorator } from "@storybook/react";
 import "dayjs/locale/en";
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import { LocalizationProvider } from "@salt-ds/lab";
 import { enUS as dateFnsEnUs } from "date-fns/locale";
 

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "get-tsconfig": "^4.7.5",
     "rollup": "^4.24.2",
     "rollup-plugin-esbuild": "^6.1.1",
-    "rollup-plugin-postcss": "^4.0.2"
+    "rollup-plugin-postcss": "^4.0.2",
+    "vite-tsconfig-paths": "^4.2.0"
   }
 }

--- a/packages/date-adapters/package.json
+++ b/packages/date-adapters/package.json
@@ -38,6 +38,6 @@
     "provenance": true
   },
   "scripts": {
-    "build": "yarn node ../../scripts/build.mjs"
+    "build": "yarn node ./scripts/build.mjs"
   }
 }

--- a/packages/date-adapters/scripts/build.mjs
+++ b/packages/date-adapters/scripts/build.mjs
@@ -1,0 +1,164 @@
+import path from "node:path";
+import commonjs from "@rollup/plugin-commonjs";
+import json from "@rollup/plugin-json";
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import browserslistToEsbuild from "browserslist-to-esbuild";
+import fs from "fs-extra";
+import { rollup } from "rollup";
+import esbuild from "rollup-plugin-esbuild";
+import { makeTypings } from "./../../../scripts/makeTypings.mjs";
+import { transformWorkspaceDeps } from "./../../../scripts/transformWorkspaceDeps.mjs";
+import { distinct } from "./../../../scripts/utils.mjs";
+
+const cwd = process.cwd();
+
+const packageJson = (
+  await import(path.join("file://", cwd, "package.json"), {
+    with: { type: "json" },
+  })
+).default;
+
+const FILES_TO_COPY = ["README.md", "LICENSE", "CHANGELOG.md"].concat(
+  packageJson.files ?? [],
+);
+
+const packageName = packageJson.name;
+const outputDir = path.join(packageJson.publishConfig.directory);
+
+console.log(`Building ${packageName}`);
+
+await fs.mkdirp(outputDir);
+await fs.emptyDir(outputDir);
+
+// Define entry points for each adapter
+const entryPoints = {
+  types: path.join(cwd, "src/types/index.ts"),
+  moment: path.join(cwd, "src/moment-adapter/index.ts"),
+  luxon: path.join(cwd, "src/luxon-adapter/index.ts"),
+  dayjs: path.join(cwd, "src/dayjs-adapter/index.ts"),
+  "date-fns": path.join(cwd, "src/date-fns-adapter/index.ts"),
+};
+
+for (const [adapterName, inputPath] of Object.entries(entryPoints)) {
+  const entryFolder = path.basename(path.dirname(inputPath));
+
+  await makeTypings(outputDir, path.dirname(inputPath));
+
+  const bundle = await rollup({
+    input: inputPath,
+    external: (id) => {
+      if (id === "babel-plugin-transform-async-to-promises/helpers") {
+        return false;
+      }
+      return !id.startsWith(".") && !path.isAbsolute(id);
+    },
+    treeshake: {
+      propertyReadSideEffects: false,
+    },
+    plugins: [
+      nodeResolve({
+        extensions: [".ts", ".tsx", ".js", ".jsx"],
+        browser: true,
+        mainFields: ["module", "main", "browser"],
+      }),
+      commonjs({ include: /\/node_modules\// }),
+      esbuild({
+        target: browserslistToEsbuild(),
+        minify: false,
+        sourceMap: true,
+      }),
+      json(),
+    ],
+  });
+
+  const transformSourceMap = (relativeSourcePath, sourceMapPath) => {
+    const absoluteSourcepath = path.resolve(
+      path.dirname(sourceMapPath),
+      relativeSourcePath,
+    );
+    const packageRelativeSourcePath = path.relative(cwd, absoluteSourcepath);
+
+    return `../${packageRelativeSourcePath}`;
+  };
+
+  await bundle.write({
+    freeze: false,
+    sourcemap: true,
+    preserveModules: false,
+    dir: path.join(outputDir, `dist-cjs/${adapterName}`),
+    format: "cjs",
+    exports: "named",
+    sourcemapPathTransform: transformSourceMap,
+  });
+
+  await bundle.write({
+    freeze: false,
+    sourcemap: true,
+    preserveModules: false,
+    dir: path.join(outputDir, `dist-es/${adapterName}`),
+    format: "es",
+    exports: "named",
+    sourcemapPathTransform: transformSourceMap,
+  });
+
+  await bundle.close();
+}
+
+await fs.writeJSON(
+  path.join(outputDir, "package.json"),
+  {
+    ...packageJson,
+    dependencies: await transformWorkspaceDeps(packageJson.dependencies),
+    main: "dist-cjs/index.js",
+    module: "dist-es/index.js",
+    typings: "dist-types/types/index.d.ts",
+    exports: {
+      ".": {
+        import: "./dist-es/types/index.js",
+        require: "./dist-cjs/types/index.js",
+        types: "./dist-types/types/index.d.ts",
+      },
+      "./date-fns": {
+        import: "./dist-es/date-fns/index.js",
+        require: "./dist-cjs/date-fns/index.js",
+        types: "./dist-types/date-fns-adapter/index.d.ts",
+      },
+      "./dayjs": {
+        import: "./dist-es/dayjs/index.js",
+        require: "./dist-cjs/dayjs/index.js",
+        types: "./dist-types/dayjs-adapter/index.d.ts",
+      },
+      "./luxon": {
+        import: "./dist-es/luxon/index.js",
+        require: "./dist-cjs/luxon/index.js",
+        types: "./dist-types/luxon-adapter/index.d.ts",
+      },
+      "./moment": {
+        import: "./dist-es/moment/index.js",
+        require: "./dist-cjs/moment/index.js",
+        types: "./dist-types/moment-adapter/index.d.ts",
+      },
+    },
+    files: distinct([
+      ...(packageJson.files ?? []),
+      "dist-cjs",
+      "dist-es",
+      "dist-types",
+      "CHANGELOG.md",
+    ]),
+  },
+  { spaces: 2 },
+);
+
+for (const file of FILES_TO_COPY) {
+  const filePath = path.join(cwd, file);
+  try {
+    await fs.copy(filePath, path.join(outputDir, file));
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+console.log(`Built ${packageName} into ${outputDir}`);

--- a/packages/date-adapters/scripts/build.mjs
+++ b/packages/date-adapters/scripts/build.mjs
@@ -40,8 +40,6 @@ const entryPoints = {
 };
 
 for (const [adapterName, inputPath] of Object.entries(entryPoints)) {
-  const entryFolder = path.basename(path.dirname(inputPath));
-
   await makeTypings(outputDir, path.dirname(inputPath));
 
   const bundle = await rollup({
@@ -114,29 +112,29 @@ await fs.writeJSON(
     typings: "dist-types/types/index.d.ts",
     exports: {
       ".": {
+        types: "./dist-types/types/index.d.ts",
         import: "./dist-es/types/index.js",
         require: "./dist-cjs/types/index.js",
-        types: "./dist-types/types/index.d.ts",
       },
       "./date-fns": {
+        types: "./dist-types/date-fns-adapter/index.d.ts",
         import: "./dist-es/date-fns/index.js",
         require: "./dist-cjs/date-fns/index.js",
-        types: "./dist-types/date-fns-adapter/index.d.ts",
       },
       "./dayjs": {
+        types: "./dist-types/dayjs-adapter/index.d.ts",
         import: "./dist-es/dayjs/index.js",
         require: "./dist-cjs/dayjs/index.js",
-        types: "./dist-types/dayjs-adapter/index.d.ts",
       },
       "./luxon": {
+        types: "./dist-types/luxon-adapter/index.d.ts",
         import: "./dist-es/luxon/index.js",
         require: "./dist-cjs/luxon/index.js",
-        types: "./dist-types/luxon-adapter/index.d.ts",
       },
       "./moment": {
+        types: "./dist-types/moment-adapter/index.d.ts",
         import: "./dist-es/moment/index.js",
         require: "./dist-cjs/moment/index.js",
-        types: "./dist-types/moment-adapter/index.d.ts",
       },
     },
     files: distinct([

--- a/packages/date-adapters/src/__tests__/date-fns.spec.ts
+++ b/packages/date-adapters/src/__tests__/date-fns.spec.ts
@@ -1,7 +1,7 @@
 import { isValid } from "date-fns";
 import { enUS } from "date-fns/locale";
 import { describe, expect, it } from "vitest";
-import { AdapterDateFns, DateDetailErrorEnum } from "../index";
+import { AdapterDateFns, DateDetailError } from "../index";
 
 describe("GIVEN a AdapterDateFns", () => {
   const adapter = new AdapterDateFns({ locale: enUS });
@@ -34,7 +34,7 @@ describe("GIVEN a AdapterDateFns", () => {
     expect(result.errors).toEqual([
       {
         message: "not a valid date",
-        type: DateDetailErrorEnum.INVALID_DATE,
+        type: DateDetailError.INVALID_DATE,
       },
     ]);
   });

--- a/packages/date-adapters/src/__tests__/date-fns.spec.ts
+++ b/packages/date-adapters/src/__tests__/date-fns.spec.ts
@@ -1,7 +1,8 @@
 import { isValid } from "date-fns";
 import { enUS } from "date-fns/locale";
 import { describe, expect, it } from "vitest";
-import { AdapterDateFns, DateDetailError } from "../index";
+import { AdapterDateFns } from "../date-fns-adapter";
+import { DateDetailError } from "../index";
 
 describe("GIVEN a AdapterDateFns", () => {
   const adapter = new AdapterDateFns({ locale: enUS });

--- a/packages/date-adapters/src/__tests__/dayjs.spec.ts
+++ b/packages/date-adapters/src/__tests__/dayjs.spec.ts
@@ -3,7 +3,8 @@ import customParseFormat from "dayjs/plugin/customParseFormat";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
 import { describe, expect, it } from "vitest";
-import { AdapterDayjs, DateDetailError } from "../index";
+import { AdapterDayjs } from "../dayjs-adapter";
+import { DateDetailError } from "../index";
 
 // Extend dayjs with necessary plugins
 dayjs.extend(utc);

--- a/packages/date-adapters/src/__tests__/dayjs.spec.ts
+++ b/packages/date-adapters/src/__tests__/dayjs.spec.ts
@@ -3,7 +3,7 @@ import customParseFormat from "dayjs/plugin/customParseFormat";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
 import { describe, expect, it } from "vitest";
-import { AdapterDayjs, DateDetailErrorEnum } from "../index";
+import { AdapterDayjs, DateDetailError } from "../index";
 
 // Extend dayjs with necessary plugins
 dayjs.extend(utc);
@@ -70,7 +70,7 @@ describe("GIVEN a AdapterDayjs", () => {
     expect(result.errors).toEqual([
       {
         message: "not a valid date",
-        type: DateDetailErrorEnum.INVALID_DATE,
+        type: DateDetailError.INVALID_DATE,
       },
     ]);
   });

--- a/packages/date-adapters/src/__tests__/luxon.spec.ts
+++ b/packages/date-adapters/src/__tests__/luxon.spec.ts
@@ -1,6 +1,7 @@
 import { DateTime } from "luxon";
 import { describe, expect, it } from "vitest";
-import { AdapterLuxon, DateDetailError } from "../index";
+import { DateDetailError } from "../index";
+import { AdapterLuxon } from "../luxon-adapter";
 
 describe("GIVEN a AdapterLuxon", () => {
   const adapter = new AdapterLuxon({ locale: "en-US" });

--- a/packages/date-adapters/src/__tests__/luxon.spec.ts
+++ b/packages/date-adapters/src/__tests__/luxon.spec.ts
@@ -1,6 +1,6 @@
 import { DateTime } from "luxon";
 import { describe, expect, it } from "vitest";
-import { AdapterLuxon, DateDetailErrorEnum } from "../index";
+import { AdapterLuxon, DateDetailError } from "../index";
 
 describe("GIVEN a AdapterLuxon", () => {
   const adapter = new AdapterLuxon({ locale: "en-US" });
@@ -62,7 +62,7 @@ describe("GIVEN a AdapterLuxon", () => {
     expect(result.errors).toEqual([
       {
         message: "not a valid date",
-        type: DateDetailErrorEnum.INVALID_DATE,
+        type: DateDetailError.INVALID_DATE,
       },
     ]);
   });

--- a/packages/date-adapters/src/__tests__/moment.spec.ts
+++ b/packages/date-adapters/src/__tests__/moment.spec.ts
@@ -1,7 +1,8 @@
 import moment from "moment";
 import { describe, expect, it } from "vitest";
 import "moment-timezone";
-import { AdapterMoment, DateDetailError } from "../index";
+import { DateDetailError } from "../index";
+import { AdapterMoment } from "../moment-adapter";
 
 describe("GIVEN a AdapterMoment", () => {
   const adapter = new AdapterMoment({ locale: "en" });

--- a/packages/date-adapters/src/__tests__/moment.spec.ts
+++ b/packages/date-adapters/src/__tests__/moment.spec.ts
@@ -1,7 +1,7 @@
 import moment from "moment";
 import { describe, expect, it } from "vitest";
 import "moment-timezone";
-import { AdapterMoment, DateDetailErrorEnum } from "../index";
+import { AdapterMoment, DateDetailError } from "../index";
 
 describe("GIVEN a AdapterMoment", () => {
   const adapter = new AdapterMoment({ locale: "en" });
@@ -63,7 +63,7 @@ describe("GIVEN a AdapterMoment", () => {
     expect(result.errors).toEqual([
       {
         message: "not a valid date",
-        type: DateDetailErrorEnum.INVALID_DATE,
+        type: DateDetailError.INVALID_DATE,
       },
     ]);
   });

--- a/packages/date-adapters/src/date-fns-adapter/index.ts
+++ b/packages/date-adapters/src/date-fns-adapter/index.ts
@@ -33,7 +33,7 @@ import {
 import { enUS } from "date-fns/locale";
 import {
   type AdapterOptions,
-  DateDetailErrorEnum,
+  DateDetailError,
   type ParserResult,
   type RecommendedFormats,
   type SaltDateAdapter,
@@ -41,7 +41,7 @@ import {
   type Timezone,
 } from "../types";
 
-declare module "../types" {
+declare module "@salt-ds/date-adapters" {
   interface DateFrameworkTypeMap {
     "date-fns": Date;
   }
@@ -213,8 +213,8 @@ export class AdapterDateFns implements SaltDateAdapter<Date, Locale> {
         {
           message: isDateDefined ? "not a valid date" : "no date defined",
           type: isDateDefined
-            ? DateDetailErrorEnum.INVALID_DATE
-            : DateDetailErrorEnum.UNSET,
+            ? DateDetailError.INVALID_DATE
+            : DateDetailError.UNSET,
         },
       ],
     };

--- a/packages/date-adapters/src/dayjs-adapter/index.ts
+++ b/packages/date-adapters/src/dayjs-adapter/index.ts
@@ -1,7 +1,12 @@
-import defaultMoment, { type Moment } from "moment";
+import defaultDayjs, { type Dayjs } from "dayjs";
+import customParseFormat from "dayjs/plugin/customParseFormat";
+import localeData from "dayjs/plugin/localeData";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+import weekday from "dayjs/plugin/weekday";
 import {
   type AdapterOptions,
-  DateDetailErrorEnum,
+  DateDetailError,
   type ParserResult,
   type RecommendedFormats,
   type SaltDateAdapter,
@@ -9,24 +14,32 @@ import {
   type Timezone,
 } from "../types";
 
-declare module "../types" {
-  export interface DateFrameworkTypeMap {
-    moment: Moment;
+type Constructor = {
+  (...args: Parameters<typeof defaultDayjs>): Dayjs;
+  tz?: (value: Parameters<typeof defaultDayjs>[0], timezone: string) => Dayjs;
+  utc?: (value?: Parameters<typeof defaultDayjs>[0]) => Dayjs;
+};
+
+declare module "@salt-ds/date-adapters" {
+  interface DateFrameworkTypeMap {
+    dayjs: Dayjs;
   }
 }
 
+defaultDayjs.extend(utc);
+defaultDayjs.extend(timezone);
+defaultDayjs.extend(weekday);
+defaultDayjs.extend(localeData);
+
 /**
- * Adapter for Moment.js library, implementing the SaltDateAdapter interface.
- * Provides methods for date manipulation and formatting using Moment.js.
- * Salt provides a Moment adapter to aid migration to a maintained library.
- *
- * @deprecated Moment date library has been deprecated by its maintainers since September 2020, consider migration to a maintained OSS library.
+ * Adapter for Day.js library, implementing the SaltDateAdapter interface.
+ * Provides methods for date manipulation and formatting using Day.js.
  */
-export class AdapterMoment implements SaltDateAdapter<Moment, string> {
+export class AdapterDayjs implements SaltDateAdapter<Dayjs, string> {
   /**
-   * The Moment.js instance used for date operations.
+   * The Day.js instance used for date operations.
    */
-  public moment: typeof defaultMoment;
+  public dayjs: Constructor;
 
   /**
    * The locale used for date formatting.
@@ -36,146 +49,139 @@ export class AdapterMoment implements SaltDateAdapter<Moment, string> {
   /**
    * The name of the date library.
    */
-  public lib = "moment";
+  public lib = "dayjs";
 
   /**
-   * Creates an instance of AdapterMoment.
-   * @param options - Adapter options including locale and instance.
+   * Creates an instance of AdapterDayjs.
+   * @param options - Adapter options including locale.
+   * @param instance - The Day.js instance to use.
    */
-  constructor({
-    locale,
-    instance,
-  }: AdapterOptions<string, typeof defaultMoment> = {}) {
-    this.moment = instance || defaultMoment;
+  constructor(
+    { locale }: AdapterOptions<string, typeof defaultDayjs> = {},
+    instance?: Constructor,
+  ) {
     this.locale = locale || "en";
+    this.dayjs = instance || defaultDayjs;
+
+    // Allow user customization
+    if (!instance) {
+      defaultDayjs.extend(customParseFormat);
+    }
   }
 
   /**
-   * Checks if the timezone plugin is available.
-   * @returns True if the timezone plugin is available, false otherwise.
+   * Type guard for Dayjs object
+   * @param date
+   * @private
    */
-  private hasTimezonePlugin = () =>
-    typeof (this.moment as any).tz !== "undefined";
+  private isDayjs(date: any): date is Dayjs {
+    return date instanceof this.dayjs().constructor;
+  }
 
   /**
-   * Creates a Moment.js date object in the system timezone.
+   * Creates a Day.js date object in the system timezone.
    * @param value - The date string to parse.
    * @param locale - The locale to use for parsing.
-   * @returns The parsed Moment.js date object.
+   * @returns The parsed Day.js date object.
    */
   private createSystemDate = (
     value: string | undefined,
     locale?: string,
-  ): Moment => {
-    const parsedValue = this.moment(value).local();
-    if (this.locale === undefined && locale === undefined) {
-      return parsedValue;
-    }
-
-    return parsedValue.locale(locale ?? this.locale);
+  ): Dayjs => {
+    return this.dayjs(value).locale(locale ?? this.locale);
   };
 
   /**
-   * Creates a Moment.js date object in UTC.
+   * Creates a Day.js date object in UTC.
    * @param value - The date string to parse.
    * @param locale - The locale to use for parsing.
-   * @returns The parsed Moment.js date object.
+   * @returns The parsed Day.js date object.
+   * @throws Error if the UTC plugin is missing.
    */
-  private createUTCDate = (value: string, locale?: string): Moment => {
-    const parsedValue = this.moment.utc(value);
-    if (this.locale === undefined && locale === undefined) {
-      return parsedValue;
+  private createUTCDate = (
+    value: string | undefined,
+    locale?: string,
+  ): Dayjs => {
+    if (!this.dayjs.utc) {
+      throw new Error("Salt Day.js adapter: missing UTC plugin");
     }
-
-    return parsedValue.locale(locale ?? this.locale);
+    return this.dayjs.utc(value).locale(locale ?? this.locale);
   };
 
   /**
-   * Creates a Moment.js date object in a specified timezone.
+   * Creates a Day.js date object in a specified timezone.
    * @param value - The date string to parse.
    * @param timezone - The timezone to use.
    * @param locale - The locale to use for parsing.
-   * @returns The parsed Moment.js date object.
+   * @returns The parsed Day.js date object.
    * @throws Error if the timezone plugin is missing.
    */
   private createTZDate = (
-    value: string,
+    value: string | undefined,
     timezone: Timezone,
     locale?: string,
-  ): Moment => {
-    if (!this.hasTimezonePlugin()) {
-      throw new Error("Salt moment adapter: missing timezone plugin");
+  ): Dayjs => {
+    if (!this.dayjs.tz) {
+      throw new Error("Salt Day.js adapter: missing timezone plugin");
     }
-    const parsedValue =
-      timezone === "default"
-        ? this.moment(value)
-        : (this.moment as any).tz(value, timezone);
-
-    if (this.locale === undefined && locale === undefined) {
-      return parsedValue;
-    }
-    return parsedValue.locale(locale ?? this.locale);
+    return timezone === "default"
+      ? this.dayjs(value).locale(locale ?? this.locale)
+      : this.dayjs.tz(value, timezone).locale(locale ?? this.locale);
   };
 
   /**
-   * Creates a Moment.js date object from a string or returns an invalid date.
+   * Creates a Day.js date object from a string or returns an invalid date.
    * @param value - The date string to parse.
    * @param timezone - The timezone to use (default is "default").
    * @param locale - The locale to use for parsing.
-   * @returns The parsed Moment.js date object or an invalid date object.
+   * @returns The parsed Day.js date object or an invalid date object.
    */
   public date = <T extends string | undefined>(
     value?: T,
     timezone: Timezone = "default",
     locale?: string,
-  ): Moment => {
+  ): Dayjs => {
     if (!value || !this.isValidDateString(value)) {
-      return this.moment.invalid();
+      return this.dayjs("Invalid Date");
     }
-
+    let date: Dayjs;
     if (timezone === "UTC") {
-      return this.createUTCDate(value, locale);
+      date = this.createUTCDate(value, locale);
+    } else if (timezone === "system" || timezone === "default") {
+      date = this.createSystemDate(value, locale);
+    } else {
+      date = this.createTZDate(value, timezone, locale);
     }
 
-    if (
-      timezone === "system" ||
-      (timezone === "default" && !this.hasTimezonePlugin())
-    ) {
-      return this.createSystemDate(value, locale);
-    }
-
-    return this.createTZDate(value, timezone, locale);
+    return date;
   };
 
   /**
-   * Formats a Moment.js date object using the specified format string.
+   * Formats a Day.js date object using the specified format string.
    * Returns an empty string when null or undefined date is given.
-   * @param date - The Moment.js date object to format.
+   * @param date - The Day.js date object to format.
    * @param format - The format string to use.
    * @param locale - The locale to use for formatting.
    * @returns The formatted date string.
    */
   public format(
-    date: Moment | null | undefined,
+    date: Dayjs | null | undefined,
     format: RecommendedFormats = "DD MMM YYYY",
     locale?: string,
   ): string {
     if (this.isValid(date)) {
-      return date
-        .clone()
-        .locale(locale ?? this.locale)
-        .format(format);
+      return date.locale(locale ?? this.locale).format(format);
     }
     return "";
   }
 
   /**
-   * Compares two Moment.js date objects.
-   * @param dateA - The first Moment.js date object.
-   * @param dateB - The second Moment.js date object.
+   * Compares two Day.js date objects.
+   * @param dateA - The first Day.js date object.
+   * @param dateB - The second Day.js date object.
    * @returns 0 if equal, 1 if dateA is after dateB, -1 if dateA is before dateB.
    */
-  public compare(dateA: Moment, dateB: Moment): number {
+  public compare(dateA: Dayjs, dateB: Dayjs): number {
     if (dateA.isSame(dateB)) {
       return 0;
     }
@@ -196,11 +202,13 @@ export class AdapterMoment implements SaltDateAdapter<Moment, string> {
     value: string,
     format: string,
     locale?: string,
-  ): ParserResult<Moment> {
-    const parsedDate =
-      this.locale || locale
-        ? this.moment(value, format, locale ?? this.locale, true)
-        : this.moment(value, format, true);
+  ): ParserResult<Dayjs> {
+    const parsedDate = this.dayjs(
+      value?.trim(),
+      format,
+      locale ?? this.locale,
+      false,
+    );
     if (parsedDate.isValid()) {
       return {
         date: parsedDate,
@@ -209,36 +217,36 @@ export class AdapterMoment implements SaltDateAdapter<Moment, string> {
     }
     const isDateDefined = !!value?.trim().length;
     return {
-      date: parsedDate,
+      date: this.dayjs("Invalid Date"),
       value,
       errors: [
         {
           message: isDateDefined ? "not a valid date" : "no date defined",
           type: isDateDefined
-            ? DateDetailErrorEnum.INVALID_DATE
-            : DateDetailErrorEnum.UNSET,
+            ? DateDetailError.INVALID_DATE
+            : DateDetailError.UNSET,
         },
       ],
     };
   }
 
   /**
-   * Checks if a Moment.js date object is valid.
-   * @param date - The Moment.js date object to check.
+   * Checks if a Day.js date object is valid.
+   * @param date - The Day.js date object to check.
    * @returns True if the date is valid date object, false otherwise.
    */
-  public isValid(date: any): date is Moment {
-    return this.moment.isMoment(date) ? date.isValid() : false;
+  public isValid(date: any): date is Dayjs {
+    return this.isDayjs(date) ? date.isValid() : false;
   }
 
   /**
-   * Subtracts time from a Moment.js date object.
-   * @param date - The Moment.js date object to subtract from.
+   * Subtracts time from a Day.js date object.
+   * @param date - The Day.js date object to subtract from.
    * @param duration - The duration to subtract.
-   * @returns The resulting Moment.js date object.
+   * @returns The resulting Day.js date object.
    */
   public subtract(
-    date: Moment,
+    date: Dayjs,
     {
       days,
       weeks,
@@ -258,19 +266,19 @@ export class AdapterMoment implements SaltDateAdapter<Moment, string> {
       seconds?: number;
       milliseconds?: number;
     },
-  ): Moment {
-    let newDate = date.clone();
+  ): Dayjs {
+    let newDate = date;
     if (days) {
-      newDate = newDate.subtract(days, "days");
+      newDate = newDate.subtract(days, "day");
     }
     if (weeks) {
-      newDate = newDate.subtract(weeks, "weeks");
+      newDate = newDate.subtract(weeks, "week");
     }
     if (months) {
-      newDate = newDate.subtract(months, "months");
+      newDate = newDate.subtract(months, "month");
     }
     if (years) {
-      newDate = newDate.subtract(years, "years");
+      newDate = newDate.subtract(years, "year");
     }
     if (hours) {
       newDate = newDate.subtract(hours, "hours");
@@ -288,13 +296,13 @@ export class AdapterMoment implements SaltDateAdapter<Moment, string> {
   }
 
   /**
-   * Adds time to a Moment.js date object.
-   * @param date - The Moment.js date object to add to.
+   * Adds time to a Day.js date object.
+   * @param date - The Day.js date object to add to.
    * @param duration - The duration to add.
-   * @returns The resulting Moment.js date object.
+   * @returns The resulting Day.js date object.
    */
   public add(
-    date: Moment,
+    date: Dayjs,
     {
       days,
       weeks,
@@ -314,19 +322,19 @@ export class AdapterMoment implements SaltDateAdapter<Moment, string> {
       seconds?: number;
       milliseconds?: number;
     },
-  ): Moment {
-    let newDate = date.clone();
+  ): Dayjs {
+    let newDate = date;
     if (days) {
-      newDate = newDate.add(days, "days");
+      newDate = newDate.add(days, "day");
     }
     if (weeks) {
-      newDate = newDate.add(weeks, "weeks");
+      newDate = newDate.add(weeks, "week");
     }
     if (months) {
-      newDate = newDate.add(months, "months");
+      newDate = newDate.add(months, "month");
     }
     if (years) {
-      newDate = newDate.add(years, "years");
+      newDate = newDate.add(years, "year");
     }
     if (hours) {
       newDate = newDate.add(hours, "hour");
@@ -344,13 +352,13 @@ export class AdapterMoment implements SaltDateAdapter<Moment, string> {
   }
 
   /**
-   * Sets specific components of a Moment.js date object.
-   * @param date - The Moment.js date object to modify.
+   * Sets specific components of a Day.js date object.
+   * @param date - The Day.js date object to modify.
    * @param components - The components to set, the month is a number (1-12).
-   * @returns The resulting Moment.js date object.
+   * @returns The resulting Day.js date object.
    */
   public set(
-    date: Moment,
+    date: Dayjs,
     {
       day,
       month,
@@ -368,7 +376,7 @@ export class AdapterMoment implements SaltDateAdapter<Moment, string> {
       second?: number;
       millisecond?: number;
     },
-  ): Moment {
+  ): Dayjs {
     let newDate = date.clone();
     if (day) {
       newDate = newDate.date(day);
@@ -395,50 +403,48 @@ export class AdapterMoment implements SaltDateAdapter<Moment, string> {
   }
 
   /**
-   * Checks if two Moment.js date objects are the same based on the specified granularity.
-   * @param dateA - The first Moment.js date object.
-   * @param dateB - The second Moment.js date object.
+   * Checks if two Day.js date objects are the same based on the specified granularity.
+   * @param dateA - The first Day.js date object.
+   * @param dateB - The second Day.js date object.
    * @param granularity - The granularity to compare by ("day", "month", "year").
    * @returns True if the dates are the same, false otherwise.
    */
   public isSame(
-    dateA: Moment,
-    dateB: Moment,
+    dateA: Dayjs,
+    dateB: Dayjs,
     granularity: "day" | "month" | "year" = "day",
   ): boolean {
     return dateA.isSame(dateB, granularity);
   }
 
   /**
-   * Gets the start of a specified time period for a Moment.js date object.
-   * @param date - The Moment.js date object.
+   * Gets the start of a specified time period for a Day.js date object.
+   * @param date - The Day.js date object.
    * @param offset - The time period ("day", "week", "month", "year").
    * @param locale - The locale to use.
-   * @returns The Moment.js date object representing the start of the period.
+   * @returns The Day.js date object representing the start of the period.
    */
   public startOf(
-    date: Moment,
+    date: Dayjs,
     offset: "day" | "week" | "month" | "year",
     locale?: string,
-  ): Moment {
-    const newDate = date.clone().locale(locale ?? this.locale);
-    return newDate.startOf(offset);
+  ): Dayjs {
+    return date.locale(locale ?? this.locale).startOf(offset);
   }
 
   /**
-   * Gets the end of a specified time period for a Moment.js date object.
-   * @param date - The Moment.js date object.
+   * Gets the end of a specified time period for a Day.js date object.
+   * @param date - The Day.js date object.
    * @param offset - The time period ("day", "week", "month", "year").
    * @param locale - The locale to use.
-   * @returns The Moment.js date object representing the end of the period.
+   * @returns The Day.js date object representing the end of the period.
    */
   public endOf(
-    date: Moment,
+    date: Dayjs,
     offset: "day" | "week" | "month" | "year",
     locale?: string,
-  ): Moment {
-    const newDate = date.clone().locale(locale ?? this.locale);
-    return newDate.endOf(offset);
+  ): Dayjs {
+    return date.locale(locale ?? this.locale).endOf(offset);
   }
 
   /**
@@ -446,8 +452,8 @@ export class AdapterMoment implements SaltDateAdapter<Moment, string> {
    * @param locale - The locale to use.
    * @returns The current date at the start of the day.
    */
-  public today(locale?: string): Moment {
-    return this.moment()
+  public today(locale?: string): Dayjs {
+    return this.dayjs()
       .locale(locale ?? this.locale)
       .startOf("day");
   }
@@ -457,15 +463,25 @@ export class AdapterMoment implements SaltDateAdapter<Moment, string> {
    * @param locale - The locale to use.
    * @returns The current date and time.
    */
-  public now(locale?: string): Moment {
-    return this.moment().locale(locale ?? this.locale);
+  public now(locale?: string): Dayjs {
+    return this.dayjs().locale(locale ?? this.locale);
+  }
+
+  /**
+   * Gets the day of the week for a Day.js date object.
+   * @param date - The Day.js date object.
+   * @param locale - The locale to use.
+   * @returns The day of the week as a number (0-6).
+   */
+  public getDayOfWeek(date: Dayjs, locale?: string): number {
+    return date.locale(locale ?? this.locale).day();
   }
 
   /**
    * Gets the name of the day of the week.
    * @param dow - The day of the week as a number (0-6).
    * @param format - The format for the day name ("long", "short", "narrow").
-   * @param locale - The locale to use.
+   * @param locale - The locale to use
    * @returns The name of the day of the week.
    */
   public getDayOfWeekName(
@@ -473,59 +489,52 @@ export class AdapterMoment implements SaltDateAdapter<Moment, string> {
     format: "long" | "short" | "narrow",
     locale?: string,
   ): string {
-    const day = this.moment()
+    const date = this.dayjs()
       .locale(locale ?? this.locale)
       .weekday(dow);
-    return format === "narrow" ? day.format("dd")[0] : day.format("dddd");
+    const formatString =
+      format === "long" ? "dddd" : format === "short" ? "ddd" : "dd";
+    return date.format(formatString);
   }
 
   /**
-   * Gets the day of the week for a Moment.js date object.
-   * @param date - The Moment.js date object.
-   * @returns The day of the week as a number (0-6).
-   */
-  public getDayOfWeek(date: Moment): number {
-    return date.day();
-  }
-
-  /**
-   * Gets the day of the month for a Moment.js date object.
-   * @param date - The Moment.js date object.
+   * Gets the day of the month for a Day.js date object.
+   * @param date - The Day.js date object.
    * @returns The day of the month as a number (1-31).
    */
-  public getDay(date: Moment): number {
+  public getDay(date: Dayjs): number {
     return date.date();
   }
 
   /**
-   * Gets the month for a Moment.js date object.
-   * @param date - The Moment.js date object.
-   * @returns The month as a number (1-12).
+   * Gets the month for a Day.js date object.
+   * @param date - The Day.js date object.
+   * @returns The month as a number (0-11).
    */
-  public getMonth(date: Moment): number {
+  public getMonth(date: Dayjs): number {
     return date.month() + 1;
   }
 
   /**
-   * Gets the year for a Moment.js date object.
-   * @param date - The Moment.js date object.
+   * Gets the year for a Day.js date object.
+   * @param date - The Day.js date object.
    * @returns The year as a number.
    */
-  public getYear(date: Moment): number {
+  public getYear(date: Dayjs): number {
     return date.year();
   }
 
   /**
-   * Gets the time components for a Moment.js date object.
-   * @param date - The Moment.js date object.
+   * Gets the time components for a Day.js date object.
+   * @param date - The Day.js date object.
    * @returns An object containing the hour, minute, second, and millisecond.
    */
-  public getTime(date: Moment): TimeFields {
+  public getTime(date: Dayjs): TimeFields {
     return {
-      hour: date.hour(),
-      minute: date.minute(),
-      second: date.second(),
-      millisecond: date.millisecond(),
+      hour: date.get("hour"),
+      minute: date.get("minute"),
+      second: date.get("second"),
+      millisecond: date.get("millisecond"),
     };
   }
 
@@ -534,15 +543,16 @@ export class AdapterMoment implements SaltDateAdapter<Moment, string> {
    * @param value
    */
   public isValidDateString(value: string): boolean {
-    /** Ensure ISO 8601 format of date string is passed to Moment to avoid warning **/
-    return this.moment(value, this.moment.ISO_8601, true).isValid();
+    // Attempt to parse the string as an ISO 8601 date
+    const date = this.dayjs(value, { format: "YYYY-MM-DDTHH:mm:ssZ" });
+    return date.isValid();
   }
 
   /**
    * Clone the date object
    * @param date
    */
-  public clone(date: Moment): Moment {
+  public clone(date: Dayjs): Dayjs {
     return date.clone();
   }
 }

--- a/packages/date-adapters/src/index.ts
+++ b/packages/date-adapters/src/index.ts
@@ -1,18 +1,5 @@
-/**
- * To add a new adapter, then, add the adapter's date object to `DateFrameworkTypeMap` interface
- *
- * declare module "./types" {
- *   interface DateFrameworkTypeMap {
- *     luxon: DateTime;
- *   }
- * }
- */
-// biome-ignore lint/complexity/noBannedTypes: type augmented by configured adapters
-export type DateFrameworkTypeMap = {};
-
-export * from "./date-fns";
-export * from "./dayjs";
-export * from "./luxon";
-export * from "./moment";
-
+export * from "./date-fns-adapter";
+export * from "./dayjs-adapter";
+export * from "./luxon-adapter";
+export * from "./moment-adapter";
 export * from "./types";

--- a/packages/date-adapters/src/index.ts
+++ b/packages/date-adapters/src/index.ts
@@ -1,5 +1,1 @@
-export * from "./date-fns-adapter";
-export * from "./dayjs-adapter";
-export * from "./luxon-adapter";
-export * from "./moment-adapter";
 export * from "./types";

--- a/packages/date-adapters/src/luxon-adapter/index.ts
+++ b/packages/date-adapters/src/luxon-adapter/index.ts
@@ -1,7 +1,7 @@
 import { DateTime, Duration, Settings } from "luxon";
 import {
   type AdapterOptions,
-  DateDetailErrorEnum,
+  DateDetailError,
   type ParserResult,
   type RecommendedFormats,
   type SaltDateAdapter,
@@ -9,7 +9,7 @@ import {
   type Timezone,
 } from "../types";
 
-declare module "../types" {
+declare module "@salt-ds/date-adapters" {
   interface DateFrameworkTypeMap {
     luxon: DateTime;
   }
@@ -234,8 +234,8 @@ export class AdapterLuxon implements SaltDateAdapter<DateTime, string> {
         {
           message: isDateDefined ? "not a valid date" : "no date defined",
           type: isDateDefined
-            ? DateDetailErrorEnum.INVALID_DATE
-            : DateDetailErrorEnum.UNSET,
+            ? DateDetailError.INVALID_DATE
+            : DateDetailError.UNSET,
         },
       ],
     };

--- a/packages/date-adapters/src/moment-adapter/index.ts
+++ b/packages/date-adapters/src/moment-adapter/index.ts
@@ -1,12 +1,7 @@
-import defaultDayjs, { type Dayjs } from "dayjs";
-import customParseFormat from "dayjs/plugin/customParseFormat";
-import localeData from "dayjs/plugin/localeData";
-import timezone from "dayjs/plugin/timezone";
-import utc from "dayjs/plugin/utc";
-import weekday from "dayjs/plugin/weekday";
+import defaultMoment, { type Moment } from "moment";
 import {
   type AdapterOptions,
-  DateDetailErrorEnum,
+  DateDetailError,
   type ParserResult,
   type RecommendedFormats,
   type SaltDateAdapter,
@@ -14,32 +9,24 @@ import {
   type Timezone,
 } from "../types";
 
-type Constructor = {
-  (...args: Parameters<typeof defaultDayjs>): Dayjs;
-  tz?: (value: Parameters<typeof defaultDayjs>[0], timezone: string) => Dayjs;
-  utc?: (value?: Parameters<typeof defaultDayjs>[0]) => Dayjs;
-};
-
-declare module "../types" {
-  interface DateFrameworkTypeMap {
-    dayjs: Dayjs;
+declare module "@salt-ds/date-adapters" {
+  export interface DateFrameworkTypeMap {
+    moment: Moment;
   }
 }
 
-defaultDayjs.extend(utc);
-defaultDayjs.extend(timezone);
-defaultDayjs.extend(weekday);
-defaultDayjs.extend(localeData);
-
 /**
- * Adapter for Day.js library, implementing the SaltDateAdapter interface.
- * Provides methods for date manipulation and formatting using Day.js.
+ * Adapter for Moment.js library, implementing the SaltDateAdapter interface.
+ * Provides methods for date manipulation and formatting using Moment.js.
+ * Salt provides a Moment adapter to aid migration to a maintained library.
+ *
+ * @deprecated Moment date library has been deprecated by its maintainers since September 2020, consider migration to a maintained OSS library.
  */
-export class AdapterDayjs implements SaltDateAdapter<Dayjs, string> {
+export class AdapterMoment implements SaltDateAdapter<Moment, string> {
   /**
-   * The Day.js instance used for date operations.
+   * The Moment.js instance used for date operations.
    */
-  public dayjs: Constructor;
+  public moment: typeof defaultMoment;
 
   /**
    * The locale used for date formatting.
@@ -49,139 +36,146 @@ export class AdapterDayjs implements SaltDateAdapter<Dayjs, string> {
   /**
    * The name of the date library.
    */
-  public lib = "dayjs";
+  public lib = "moment";
 
   /**
-   * Creates an instance of AdapterDayjs.
-   * @param options - Adapter options including locale.
-   * @param instance - The Day.js instance to use.
+   * Creates an instance of AdapterMoment.
+   * @param options - Adapter options including locale and instance.
    */
-  constructor(
-    { locale }: AdapterOptions<string, typeof defaultDayjs> = {},
-    instance?: Constructor,
-  ) {
+  constructor({
+    locale,
+    instance,
+  }: AdapterOptions<string, typeof defaultMoment> = {}) {
+    this.moment = instance || defaultMoment;
     this.locale = locale || "en";
-    this.dayjs = instance || defaultDayjs;
-
-    // Allow user customization
-    if (!instance) {
-      defaultDayjs.extend(customParseFormat);
-    }
   }
 
   /**
-   * Type guard for Dayjs object
-   * @param date
-   * @private
+   * Checks if the timezone plugin is available.
+   * @returns True if the timezone plugin is available, false otherwise.
    */
-  private isDayjs(date: any): date is Dayjs {
-    return date instanceof this.dayjs().constructor;
-  }
+  private hasTimezonePlugin = () =>
+    typeof (this.moment as any).tz !== "undefined";
 
   /**
-   * Creates a Day.js date object in the system timezone.
+   * Creates a Moment.js date object in the system timezone.
    * @param value - The date string to parse.
    * @param locale - The locale to use for parsing.
-   * @returns The parsed Day.js date object.
+   * @returns The parsed Moment.js date object.
    */
   private createSystemDate = (
     value: string | undefined,
     locale?: string,
-  ): Dayjs => {
-    return this.dayjs(value).locale(locale ?? this.locale);
+  ): Moment => {
+    const parsedValue = this.moment(value).local();
+    if (this.locale === undefined && locale === undefined) {
+      return parsedValue;
+    }
+
+    return parsedValue.locale(locale ?? this.locale);
   };
 
   /**
-   * Creates a Day.js date object in UTC.
+   * Creates a Moment.js date object in UTC.
    * @param value - The date string to parse.
    * @param locale - The locale to use for parsing.
-   * @returns The parsed Day.js date object.
-   * @throws Error if the UTC plugin is missing.
+   * @returns The parsed Moment.js date object.
    */
-  private createUTCDate = (
-    value: string | undefined,
-    locale?: string,
-  ): Dayjs => {
-    if (!this.dayjs.utc) {
-      throw new Error("Salt Day.js adapter: missing UTC plugin");
+  private createUTCDate = (value: string, locale?: string): Moment => {
+    const parsedValue = this.moment.utc(value);
+    if (this.locale === undefined && locale === undefined) {
+      return parsedValue;
     }
-    return this.dayjs.utc(value).locale(locale ?? this.locale);
+
+    return parsedValue.locale(locale ?? this.locale);
   };
 
   /**
-   * Creates a Day.js date object in a specified timezone.
+   * Creates a Moment.js date object in a specified timezone.
    * @param value - The date string to parse.
    * @param timezone - The timezone to use.
    * @param locale - The locale to use for parsing.
-   * @returns The parsed Day.js date object.
+   * @returns The parsed Moment.js date object.
    * @throws Error if the timezone plugin is missing.
    */
   private createTZDate = (
-    value: string | undefined,
+    value: string,
     timezone: Timezone,
     locale?: string,
-  ): Dayjs => {
-    if (!this.dayjs.tz) {
-      throw new Error("Salt Day.js adapter: missing timezone plugin");
+  ): Moment => {
+    if (!this.hasTimezonePlugin()) {
+      throw new Error("Salt moment adapter: missing timezone plugin");
     }
-    return timezone === "default"
-      ? this.dayjs(value).locale(locale ?? this.locale)
-      : this.dayjs.tz(value, timezone).locale(locale ?? this.locale);
+    const parsedValue =
+      timezone === "default"
+        ? this.moment(value)
+        : (this.moment as any).tz(value, timezone);
+
+    if (this.locale === undefined && locale === undefined) {
+      return parsedValue;
+    }
+    return parsedValue.locale(locale ?? this.locale);
   };
 
   /**
-   * Creates a Day.js date object from a string or returns an invalid date.
+   * Creates a Moment.js date object from a string or returns an invalid date.
    * @param value - The date string to parse.
    * @param timezone - The timezone to use (default is "default").
    * @param locale - The locale to use for parsing.
-   * @returns The parsed Day.js date object or an invalid date object.
+   * @returns The parsed Moment.js date object or an invalid date object.
    */
   public date = <T extends string | undefined>(
     value?: T,
     timezone: Timezone = "default",
     locale?: string,
-  ): Dayjs => {
+  ): Moment => {
     if (!value || !this.isValidDateString(value)) {
-      return this.dayjs("Invalid Date");
-    }
-    let date: Dayjs;
-    if (timezone === "UTC") {
-      date = this.createUTCDate(value, locale);
-    } else if (timezone === "system" || timezone === "default") {
-      date = this.createSystemDate(value, locale);
-    } else {
-      date = this.createTZDate(value, timezone, locale);
+      return this.moment.invalid();
     }
 
-    return date;
+    if (timezone === "UTC") {
+      return this.createUTCDate(value, locale);
+    }
+
+    if (
+      timezone === "system" ||
+      (timezone === "default" && !this.hasTimezonePlugin())
+    ) {
+      return this.createSystemDate(value, locale);
+    }
+
+    return this.createTZDate(value, timezone, locale);
   };
 
   /**
-   * Formats a Day.js date object using the specified format string.
+   * Formats a Moment.js date object using the specified format string.
    * Returns an empty string when null or undefined date is given.
-   * @param date - The Day.js date object to format.
+   * @param date - The Moment.js date object to format.
    * @param format - The format string to use.
    * @param locale - The locale to use for formatting.
    * @returns The formatted date string.
    */
   public format(
-    date: Dayjs | null | undefined,
+    date: Moment | null | undefined,
     format: RecommendedFormats = "DD MMM YYYY",
     locale?: string,
   ): string {
     if (this.isValid(date)) {
-      return date.locale(locale ?? this.locale).format(format);
+      return date
+        .clone()
+        .locale(locale ?? this.locale)
+        .format(format);
     }
     return "";
   }
 
   /**
-   * Compares two Day.js date objects.
-   * @param dateA - The first Day.js date object.
-   * @param dateB - The second Day.js date object.
+   * Compares two Moment.js date objects.
+   * @param dateA - The first Moment.js date object.
+   * @param dateB - The second Moment.js date object.
    * @returns 0 if equal, 1 if dateA is after dateB, -1 if dateA is before dateB.
    */
-  public compare(dateA: Dayjs, dateB: Dayjs): number {
+  public compare(dateA: Moment, dateB: Moment): number {
     if (dateA.isSame(dateB)) {
       return 0;
     }
@@ -202,13 +196,11 @@ export class AdapterDayjs implements SaltDateAdapter<Dayjs, string> {
     value: string,
     format: string,
     locale?: string,
-  ): ParserResult<Dayjs> {
-    const parsedDate = this.dayjs(
-      value?.trim(),
-      format,
-      locale ?? this.locale,
-      false,
-    );
+  ): ParserResult<Moment> {
+    const parsedDate =
+      this.locale || locale
+        ? this.moment(value, format, locale ?? this.locale, true)
+        : this.moment(value, format, true);
     if (parsedDate.isValid()) {
       return {
         date: parsedDate,
@@ -217,36 +209,36 @@ export class AdapterDayjs implements SaltDateAdapter<Dayjs, string> {
     }
     const isDateDefined = !!value?.trim().length;
     return {
-      date: this.dayjs("Invalid Date"),
+      date: parsedDate,
       value,
       errors: [
         {
           message: isDateDefined ? "not a valid date" : "no date defined",
           type: isDateDefined
-            ? DateDetailErrorEnum.INVALID_DATE
-            : DateDetailErrorEnum.UNSET,
+            ? DateDetailError.INVALID_DATE
+            : DateDetailError.UNSET,
         },
       ],
     };
   }
 
   /**
-   * Checks if a Day.js date object is valid.
-   * @param date - The Day.js date object to check.
+   * Checks if a Moment.js date object is valid.
+   * @param date - The Moment.js date object to check.
    * @returns True if the date is valid date object, false otherwise.
    */
-  public isValid(date: any): date is Dayjs {
-    return this.isDayjs(date) ? date.isValid() : false;
+  public isValid(date: any): date is Moment {
+    return this.moment.isMoment(date) ? date.isValid() : false;
   }
 
   /**
-   * Subtracts time from a Day.js date object.
-   * @param date - The Day.js date object to subtract from.
+   * Subtracts time from a Moment.js date object.
+   * @param date - The Moment.js date object to subtract from.
    * @param duration - The duration to subtract.
-   * @returns The resulting Day.js date object.
+   * @returns The resulting Moment.js date object.
    */
   public subtract(
-    date: Dayjs,
+    date: Moment,
     {
       days,
       weeks,
@@ -266,19 +258,19 @@ export class AdapterDayjs implements SaltDateAdapter<Dayjs, string> {
       seconds?: number;
       milliseconds?: number;
     },
-  ): Dayjs {
-    let newDate = date;
+  ): Moment {
+    let newDate = date.clone();
     if (days) {
-      newDate = newDate.subtract(days, "day");
+      newDate = newDate.subtract(days, "days");
     }
     if (weeks) {
-      newDate = newDate.subtract(weeks, "week");
+      newDate = newDate.subtract(weeks, "weeks");
     }
     if (months) {
-      newDate = newDate.subtract(months, "month");
+      newDate = newDate.subtract(months, "months");
     }
     if (years) {
-      newDate = newDate.subtract(years, "year");
+      newDate = newDate.subtract(years, "years");
     }
     if (hours) {
       newDate = newDate.subtract(hours, "hours");
@@ -296,13 +288,13 @@ export class AdapterDayjs implements SaltDateAdapter<Dayjs, string> {
   }
 
   /**
-   * Adds time to a Day.js date object.
-   * @param date - The Day.js date object to add to.
+   * Adds time to a Moment.js date object.
+   * @param date - The Moment.js date object to add to.
    * @param duration - The duration to add.
-   * @returns The resulting Day.js date object.
+   * @returns The resulting Moment.js date object.
    */
   public add(
-    date: Dayjs,
+    date: Moment,
     {
       days,
       weeks,
@@ -322,19 +314,19 @@ export class AdapterDayjs implements SaltDateAdapter<Dayjs, string> {
       seconds?: number;
       milliseconds?: number;
     },
-  ): Dayjs {
-    let newDate = date;
+  ): Moment {
+    let newDate = date.clone();
     if (days) {
-      newDate = newDate.add(days, "day");
+      newDate = newDate.add(days, "days");
     }
     if (weeks) {
-      newDate = newDate.add(weeks, "week");
+      newDate = newDate.add(weeks, "weeks");
     }
     if (months) {
-      newDate = newDate.add(months, "month");
+      newDate = newDate.add(months, "months");
     }
     if (years) {
-      newDate = newDate.add(years, "year");
+      newDate = newDate.add(years, "years");
     }
     if (hours) {
       newDate = newDate.add(hours, "hour");
@@ -352,13 +344,13 @@ export class AdapterDayjs implements SaltDateAdapter<Dayjs, string> {
   }
 
   /**
-   * Sets specific components of a Day.js date object.
-   * @param date - The Day.js date object to modify.
+   * Sets specific components of a Moment.js date object.
+   * @param date - The Moment.js date object to modify.
    * @param components - The components to set, the month is a number (1-12).
-   * @returns The resulting Day.js date object.
+   * @returns The resulting Moment.js date object.
    */
   public set(
-    date: Dayjs,
+    date: Moment,
     {
       day,
       month,
@@ -376,7 +368,7 @@ export class AdapterDayjs implements SaltDateAdapter<Dayjs, string> {
       second?: number;
       millisecond?: number;
     },
-  ): Dayjs {
+  ): Moment {
     let newDate = date.clone();
     if (day) {
       newDate = newDate.date(day);
@@ -403,48 +395,50 @@ export class AdapterDayjs implements SaltDateAdapter<Dayjs, string> {
   }
 
   /**
-   * Checks if two Day.js date objects are the same based on the specified granularity.
-   * @param dateA - The first Day.js date object.
-   * @param dateB - The second Day.js date object.
+   * Checks if two Moment.js date objects are the same based on the specified granularity.
+   * @param dateA - The first Moment.js date object.
+   * @param dateB - The second Moment.js date object.
    * @param granularity - The granularity to compare by ("day", "month", "year").
    * @returns True if the dates are the same, false otherwise.
    */
   public isSame(
-    dateA: Dayjs,
-    dateB: Dayjs,
+    dateA: Moment,
+    dateB: Moment,
     granularity: "day" | "month" | "year" = "day",
   ): boolean {
     return dateA.isSame(dateB, granularity);
   }
 
   /**
-   * Gets the start of a specified time period for a Day.js date object.
-   * @param date - The Day.js date object.
+   * Gets the start of a specified time period for a Moment.js date object.
+   * @param date - The Moment.js date object.
    * @param offset - The time period ("day", "week", "month", "year").
    * @param locale - The locale to use.
-   * @returns The Day.js date object representing the start of the period.
+   * @returns The Moment.js date object representing the start of the period.
    */
   public startOf(
-    date: Dayjs,
+    date: Moment,
     offset: "day" | "week" | "month" | "year",
     locale?: string,
-  ): Dayjs {
-    return date.locale(locale ?? this.locale).startOf(offset);
+  ): Moment {
+    const newDate = date.clone().locale(locale ?? this.locale);
+    return newDate.startOf(offset);
   }
 
   /**
-   * Gets the end of a specified time period for a Day.js date object.
-   * @param date - The Day.js date object.
+   * Gets the end of a specified time period for a Moment.js date object.
+   * @param date - The Moment.js date object.
    * @param offset - The time period ("day", "week", "month", "year").
    * @param locale - The locale to use.
-   * @returns The Day.js date object representing the end of the period.
+   * @returns The Moment.js date object representing the end of the period.
    */
   public endOf(
-    date: Dayjs,
+    date: Moment,
     offset: "day" | "week" | "month" | "year",
     locale?: string,
-  ): Dayjs {
-    return date.locale(locale ?? this.locale).endOf(offset);
+  ): Moment {
+    const newDate = date.clone().locale(locale ?? this.locale);
+    return newDate.endOf(offset);
   }
 
   /**
@@ -452,8 +446,8 @@ export class AdapterDayjs implements SaltDateAdapter<Dayjs, string> {
    * @param locale - The locale to use.
    * @returns The current date at the start of the day.
    */
-  public today(locale?: string): Dayjs {
-    return this.dayjs()
+  public today(locale?: string): Moment {
+    return this.moment()
       .locale(locale ?? this.locale)
       .startOf("day");
   }
@@ -463,25 +457,15 @@ export class AdapterDayjs implements SaltDateAdapter<Dayjs, string> {
    * @param locale - The locale to use.
    * @returns The current date and time.
    */
-  public now(locale?: string): Dayjs {
-    return this.dayjs().locale(locale ?? this.locale);
-  }
-
-  /**
-   * Gets the day of the week for a Day.js date object.
-   * @param date - The Day.js date object.
-   * @param locale - The locale to use.
-   * @returns The day of the week as a number (0-6).
-   */
-  public getDayOfWeek(date: Dayjs, locale?: string): number {
-    return date.locale(locale ?? this.locale).day();
+  public now(locale?: string): Moment {
+    return this.moment().locale(locale ?? this.locale);
   }
 
   /**
    * Gets the name of the day of the week.
    * @param dow - The day of the week as a number (0-6).
    * @param format - The format for the day name ("long", "short", "narrow").
-   * @param locale - The locale to use
+   * @param locale - The locale to use.
    * @returns The name of the day of the week.
    */
   public getDayOfWeekName(
@@ -489,52 +473,59 @@ export class AdapterDayjs implements SaltDateAdapter<Dayjs, string> {
     format: "long" | "short" | "narrow",
     locale?: string,
   ): string {
-    const date = this.dayjs()
+    const day = this.moment()
       .locale(locale ?? this.locale)
       .weekday(dow);
-    const formatString =
-      format === "long" ? "dddd" : format === "short" ? "ddd" : "dd";
-    return date.format(formatString);
+    return format === "narrow" ? day.format("dd")[0] : day.format("dddd");
   }
 
   /**
-   * Gets the day of the month for a Day.js date object.
-   * @param date - The Day.js date object.
+   * Gets the day of the week for a Moment.js date object.
+   * @param date - The Moment.js date object.
+   * @returns The day of the week as a number (0-6).
+   */
+  public getDayOfWeek(date: Moment): number {
+    return date.day();
+  }
+
+  /**
+   * Gets the day of the month for a Moment.js date object.
+   * @param date - The Moment.js date object.
    * @returns The day of the month as a number (1-31).
    */
-  public getDay(date: Dayjs): number {
+  public getDay(date: Moment): number {
     return date.date();
   }
 
   /**
-   * Gets the month for a Day.js date object.
-   * @param date - The Day.js date object.
-   * @returns The month as a number (0-11).
+   * Gets the month for a Moment.js date object.
+   * @param date - The Moment.js date object.
+   * @returns The month as a number (1-12).
    */
-  public getMonth(date: Dayjs): number {
+  public getMonth(date: Moment): number {
     return date.month() + 1;
   }
 
   /**
-   * Gets the year for a Day.js date object.
-   * @param date - The Day.js date object.
+   * Gets the year for a Moment.js date object.
+   * @param date - The Moment.js date object.
    * @returns The year as a number.
    */
-  public getYear(date: Dayjs): number {
+  public getYear(date: Moment): number {
     return date.year();
   }
 
   /**
-   * Gets the time components for a Day.js date object.
-   * @param date - The Day.js date object.
+   * Gets the time components for a Moment.js date object.
+   * @param date - The Moment.js date object.
    * @returns An object containing the hour, minute, second, and millisecond.
    */
-  public getTime(date: Dayjs): TimeFields {
+  public getTime(date: Moment): TimeFields {
     return {
-      hour: date.get("hour"),
-      minute: date.get("minute"),
-      second: date.get("second"),
-      millisecond: date.get("millisecond"),
+      hour: date.hour(),
+      minute: date.minute(),
+      second: date.second(),
+      millisecond: date.millisecond(),
     };
   }
 
@@ -543,16 +534,15 @@ export class AdapterDayjs implements SaltDateAdapter<Dayjs, string> {
    * @param value
    */
   public isValidDateString(value: string): boolean {
-    // Attempt to parse the string as an ISO 8601 date
-    const date = this.dayjs(value, { format: "YYYY-MM-DDTHH:mm:ssZ" });
-    return date.isValid();
+    /** Ensure ISO 8601 format of date string is passed to Moment to avoid warning **/
+    return this.moment(value, this.moment.ISO_8601, true).isValid();
   }
 
   /**
    * Clone the date object
    * @param date
    */
-  public clone(date: Dayjs): Dayjs {
+  public clone(date: Moment): Moment {
     return date.clone();
   }
 }

--- a/packages/date-adapters/src/types/DateFrameworkTypeMap.ts
+++ b/packages/date-adapters/src/types/DateFrameworkTypeMap.ts
@@ -1,0 +1,12 @@
+/**
+ * To add a new adapter, then, add the adapter's date object to `DateFrameworkTypeMap` interface
+ *
+ * declare module "@salt-ds/date-adapters" {
+ *   interface DateFrameworkTypeMap {
+ *     luxon: DateTime;
+ *   }
+ * }
+ */
+
+// biome-ignore lint/complexity/noBannedTypes: type augmented by configured adapters
+export type DateFrameworkTypeMap = {};

--- a/packages/date-adapters/src/types/index.ts
+++ b/packages/date-adapters/src/types/index.ts
@@ -1,3 +1,4 @@
+import type { DateFrameworkTypeMap } from "./DateFrameworkTypeMap";
 /**
  * Represents the date object of a date framework.
  *
@@ -11,27 +12,29 @@ export type DateFrameworkType = keyof DateFrameworkTypeMap extends never
 /**
  * Enum representing possible date detail error types.
  */
-export enum DateDetailErrorEnum {
+export const DateDetailError = {
   /** Error type for unset values */
-  UNSET = "unset",
+  UNSET: "unset",
   /** Error type for values that are not a date */
-  NOT_A_DATE = "not-a-date",
+  NOT_A_DATE: "not-a-date",
   /** Error type for invalid date values */
-  INVALID_DATE = "date",
+  INVALID_DATE: "date",
   /** Error type for invalid month values */
-  INVALID_MONTH = "month",
+  INVALID_MONTH: "month",
   /** Error type for invalid day values */
-  INVALID_DAY = "day",
+  INVALID_DAY: "day",
   /** Error type for invalid year values */
-  INVALID_YEAR = "year",
-}
+  INVALID_YEAR: "year",
+} as const;
+export type DateDetailErrorType =
+  (typeof DateDetailError)[keyof typeof DateDetailError];
 
 /**
  * Represents an error detail for a date.
  */
 export type DateDetailError = {
   /** The error code */
-  type: DateDetailErrorEnum | string;
+  type: DateDetailErrorType | string;
   /** The error message */
   message: string;
 };

--- a/packages/date-adapters/tsconfig.json
+++ b/packages/date-adapters/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "declaration": false,
+    "outDir": "./dist",
+    "module": "commonjs",
+    "target": "es2016",
+    "moduleResolution": "node",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.a11y.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.a11y.cy.tsx
@@ -1,7 +1,9 @@
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
+import {
+  AdapterDateFns,
+  AdapterDayjs,
+  AdapterLuxon,
+  AdapterMoment,
+} from "@salt-ds/date-adapters";
 
 import * as calendarStories from "@stories/calendar/calendar.stories";
 import { composeStories } from "@storybook/react";

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.a11y.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.a11y.cy.tsx
@@ -1,9 +1,7 @@
-import {
-  AdapterDateFns,
-  AdapterDayjs,
-  AdapterLuxon,
-  AdapterMoment,
-} from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 
 import * as calendarStories from "@stories/calendar/calendar.stories";
 import { composeStories } from "@storybook/react";

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.cy.tsx
@@ -1,11 +1,11 @@
-import {
-  AdapterDateFns,
-  AdapterDayjs,
-  AdapterLuxon,
-  AdapterMoment,
-  type DateFrameworkType,
-  type SaltDateAdapter,
+import type {
+  DateFrameworkType,
+  SaltDateAdapter,
 } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import {
   Calendar,
   CalendarGrid,

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.cy.tsx
@@ -1,11 +1,11 @@
-import type {
-  DateFrameworkType,
-  SaltDateAdapter,
+import {
+  AdapterDateFns,
+  AdapterDayjs,
+  AdapterLuxon,
+  AdapterMoment,
+  type DateFrameworkType,
+  type SaltDateAdapter,
 } from "@salt-ds/date-adapters";
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
 import {
   Calendar,
   CalendarGrid,

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.multiselect.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.multiselect.cy.tsx
@@ -1,11 +1,11 @@
-import {
-  AdapterDateFns,
-  AdapterDayjs,
-  AdapterLuxon,
-  AdapterMoment,
-  type DateFrameworkType,
-  type SaltDateAdapter,
+import type {
+  DateFrameworkType,
+  SaltDateAdapter,
 } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import {
   Calendar,
   CalendarGrid,

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.multiselect.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.multiselect.cy.tsx
@@ -1,11 +1,11 @@
-import type {
-  DateFrameworkType,
-  SaltDateAdapter,
+import {
+  AdapterDateFns,
+  AdapterDayjs,
+  AdapterLuxon,
+  AdapterMoment,
+  type DateFrameworkType,
+  type SaltDateAdapter,
 } from "@salt-ds/date-adapters";
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
 import {
   Calendar,
   CalendarGrid,

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.offset.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.offset.cy.tsx
@@ -1,11 +1,11 @@
-import {
-  AdapterDateFns,
-  AdapterDayjs,
-  AdapterLuxon,
-  AdapterMoment,
-  type DateFrameworkType,
-  type SaltDateAdapter,
+import type {
+  DateFrameworkType,
+  SaltDateAdapter,
 } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import {
   Calendar,
   CalendarGrid,

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.offset.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.offset.cy.tsx
@@ -1,11 +1,11 @@
-import type {
-  DateFrameworkType,
-  SaltDateAdapter,
+import {
+  AdapterDateFns,
+  AdapterDayjs,
+  AdapterLuxon,
+  AdapterMoment,
+  type DateFrameworkType,
+  type SaltDateAdapter,
 } from "@salt-ds/date-adapters";
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
 import {
   Calendar,
   CalendarGrid,

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.range.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.range.cy.tsx
@@ -1,11 +1,11 @@
-import {
-  AdapterDateFns,
-  AdapterDayjs,
-  AdapterLuxon,
-  AdapterMoment,
-  type DateFrameworkType,
-  type SaltDateAdapter,
+import type {
+  DateFrameworkType,
+  SaltDateAdapter,
 } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import {
   Calendar,
   CalendarGrid,

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.single.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.single.cy.tsx
@@ -1,11 +1,11 @@
-import {
-  AdapterDateFns,
-  AdapterDayjs,
-  AdapterLuxon,
-  AdapterMoment,
-  type DateFrameworkType,
-  type SaltDateAdapter,
+import type {
+  DateFrameworkType,
+  SaltDateAdapter,
 } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import {
   Calendar,
   CalendarGrid,

--- a/packages/lab/src/__tests__/__e2e__/calendar/Calendar.single.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/calendar/Calendar.single.cy.tsx
@@ -1,11 +1,11 @@
-import type {
-  DateFrameworkType,
-  SaltDateAdapter,
+import {
+  AdapterDateFns,
+  AdapterDayjs,
+  AdapterLuxon,
+  AdapterMoment,
+  type DateFrameworkType,
+  type SaltDateAdapter,
 } from "@salt-ds/date-adapters";
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
 import {
   Calendar,
   CalendarGrid,

--- a/packages/lab/src/__tests__/__e2e__/date-input/DateInput.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-input/DateInput.cy.tsx
@@ -1,7 +1,9 @@
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
+import {
+  AdapterDateFns,
+  AdapterDayjs,
+  AdapterLuxon,
+  AdapterMoment,
+} from "@salt-ds/date-adapters";
 import * as dateInputStories from "@stories/date-input/date-input.stories";
 import { composeStories } from "@storybook/react";
 import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";

--- a/packages/lab/src/__tests__/__e2e__/date-input/DateInput.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-input/DateInput.cy.tsx
@@ -1,9 +1,7 @@
-import {
-  AdapterDateFns,
-  AdapterDayjs,
-  AdapterLuxon,
-  AdapterMoment,
-} from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import * as dateInputStories from "@stories/date-input/date-input.stories";
 import { composeStories } from "@storybook/react";
 import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";

--- a/packages/lab/src/__tests__/__e2e__/date-input/DateInputRange.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-input/DateInputRange.cy.tsx
@@ -1,13 +1,13 @@
 import {
-  AdapterDateFns,
-  AdapterDayjs,
-  AdapterLuxon,
-  AdapterMoment,
   DateDetailError,
   type DateFrameworkType,
   type ParserResult,
   type SaltDateAdapter,
 } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import {
   DateInputRange,
   type DateParserField,

--- a/packages/lab/src/__tests__/__e2e__/date-input/DateInputRange.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-input/DateInputRange.cy.tsx
@@ -1,9 +1,9 @@
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
 import {
-  DateDetailErrorEnum,
+  AdapterDateFns,
+  AdapterDayjs,
+  AdapterLuxon,
+  AdapterMoment,
+  DateDetailError,
   type DateFrameworkType,
   type ParserResult,
   type SaltDateAdapter,
@@ -77,7 +77,7 @@ function assertDateChange(
     // assert empty start date
     expect(adapter.isValid(date.startDate)).to.equal(false);
     expect(details.startDate.errors).to.deep.equal([
-      { type: DateDetailErrorEnum.UNSET, message: "no date defined" },
+      { type: DateDetailError.UNSET, message: "no date defined" },
     ]);
     expect(details.startDate).to.have.property(
       "value",
@@ -87,7 +87,7 @@ function assertDateChange(
     // assert invalid start date
     expect(adapter.isValid(date.startDate)).to.equal(false);
     expect(details.startDate.errors).to.deep.equal([
-      { type: DateDetailErrorEnum.INVALID_DATE, message: "not a valid date" },
+      { type: DateDetailError.INVALID_DATE, message: "not a valid date" },
     ]);
     expect(details.startDate).to.have.property(
       "value",
@@ -105,14 +105,14 @@ function assertDateChange(
     // assert empty end date
     expect(adapter.isValid(date.endDate)).to.equal(false);
     expect(details.endDate.errors).to.deep.equal([
-      { type: DateDetailErrorEnum.UNSET, message: "no date defined" },
+      { type: DateDetailError.UNSET, message: "no date defined" },
     ]);
     expect(details.endDate).to.have.property("value", expectedValue.endDate);
   } else if (expectedDate?.endDate === null) {
     // assert invalid end date
     expect(adapter.isValid(date.endDate)).to.equal(false);
     expect(details.endDate.errors).to.deep.equal([
-      { type: DateDetailErrorEnum.INVALID_DATE, message: "not a valid date" },
+      { type: DateDetailError.INVALID_DATE, message: "not a valid date" },
     ]);
     expect(details.endDate).to.have.property("value", expectedValue.endDate);
   }
@@ -367,7 +367,7 @@ describe("GIVEN a DateInputRange", () => {
                   value: "",
                   errors: [
                     {
-                      type: DateDetailErrorEnum.UNSET,
+                      type: DateDetailError.UNSET,
                       message: "no date defined",
                     },
                   ],

--- a/packages/lab/src/__tests__/__e2e__/date-input/DateInputSingle.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-input/DateInputSingle.cy.tsx
@@ -1,13 +1,13 @@
 import {
-  DateDetailErrorEnum,
+  AdapterDateFns,
+  AdapterDayjs,
+  AdapterLuxon,
+  AdapterMoment,
+  DateDetailError,
   type DateFrameworkType,
   type ParserResult,
   type SaltDateAdapter,
 } from "@salt-ds/date-adapters";
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
 import { DateInputSingle } from "@salt-ds/lab";
 
 import { es as dateFnsEs } from "date-fns/locale";
@@ -70,16 +70,14 @@ function assertDateChange(
     // assert empty date
     expect(adapter.isValid(date)).to.equal(false);
     expect(details).to.deep.equal({
-      errors: [{ type: DateDetailErrorEnum.UNSET, message: "no date defined" }],
+      errors: [{ type: DateDetailError.UNSET, message: "no date defined" }],
       value: expectedValue,
     });
   } else if (expectedValidDate === null) {
     // assert invalid date
     expect(adapter.isValid(date)).to.equal(false);
     expect(details).to.deep.equal({
-      errors: [
-        { type: DateDetailErrorEnum.UNSET, message: "not a valid date" },
-      ],
+      errors: [{ type: DateDetailError.UNSET, message: "not a valid date" }],
       value: expectedValue,
     });
   }

--- a/packages/lab/src/__tests__/__e2e__/date-input/DateInputSingle.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-input/DateInputSingle.cy.tsx
@@ -1,13 +1,13 @@
 import {
-  AdapterDateFns,
-  AdapterDayjs,
-  AdapterLuxon,
-  AdapterMoment,
   DateDetailError,
   type DateFrameworkType,
   type ParserResult,
   type SaltDateAdapter,
 } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import { DateInputSingle } from "@salt-ds/lab";
 
 import { es as dateFnsEs } from "date-fns/locale";

--- a/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.cy.tsx
@@ -1,9 +1,7 @@
-import {
-  AdapterDateFns,
-  AdapterDayjs,
-  AdapterLuxon,
-  AdapterMoment,
-} from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import * as datePickerStories from "@stories/date-picker/date-picker.stories";
 import { composeStories } from "@storybook/react";
 import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";

--- a/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.cy.tsx
@@ -1,7 +1,9 @@
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
+import {
+  AdapterDateFns,
+  AdapterDayjs,
+  AdapterLuxon,
+  AdapterMoment,
+} from "@salt-ds/date-adapters";
 import * as datePickerStories from "@stories/date-picker/date-picker.stories";
 import { composeStories } from "@storybook/react";
 import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";

--- a/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.range.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.range.cy.tsx
@@ -1,12 +1,12 @@
 import {
-  DateDetailErrorEnum,
+  AdapterDateFns,
+  AdapterDayjs,
+  AdapterLuxon,
+  AdapterMoment,
+  DateDetailError,
   type DateFrameworkType,
   type SaltDateAdapter,
 } from "@salt-ds/date-adapters";
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
 import {
   DatePicker,
   DatePickerOverlay,
@@ -210,7 +210,7 @@ describe("GIVEN a DatePicker where selectionVariant is single", () => {
               value: "",
               errors: [
                 {
-                  type: DateDetailErrorEnum.UNSET,
+                  type: DateDetailError.UNSET,
                   message: "no date defined",
                 },
               ],
@@ -256,7 +256,7 @@ describe("GIVEN a DatePicker where selectionVariant is single", () => {
               value: "bad date",
               errors: [
                 {
-                  type: DateDetailErrorEnum.INVALID_DATE,
+                  type: DateDetailError.INVALID_DATE,
                   message: "not a valid date",
                 },
               ],

--- a/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.range.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.range.cy.tsx
@@ -1,12 +1,12 @@
 import {
-  AdapterDateFns,
-  AdapterDayjs,
-  AdapterLuxon,
-  AdapterMoment,
   DateDetailError,
   type DateFrameworkType,
   type SaltDateAdapter,
 } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import {
   DatePicker,
   DatePickerOverlay,

--- a/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.single.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.single.cy.tsx
@@ -3,12 +3,10 @@ import {
   type DateFrameworkType,
   type SaltDateAdapter,
 } from "@salt-ds/date-adapters";
-import {
-  AdapterDateFns,
-  AdapterDayjs,
-  AdapterLuxon,
-  AdapterMoment,
-} from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import {
   DatePicker,
   DatePickerOverlay,

--- a/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.single.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/date-picker/DatePicker.single.cy.tsx
@@ -1,12 +1,14 @@
 import {
-  DateDetailErrorEnum,
+  DateDetailError,
   type DateFrameworkType,
   type SaltDateAdapter,
 } from "@salt-ds/date-adapters";
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
+import {
+  AdapterDateFns,
+  AdapterDayjs,
+  AdapterLuxon,
+  AdapterMoment,
+} from "@salt-ds/date-adapters";
 import {
   DatePicker,
   DatePickerOverlay,
@@ -139,7 +141,7 @@ describe("GIVEN a DatePicker where selectionVariant is single", () => {
             value: "bad date",
             errors: [
               {
-                type: DateDetailErrorEnum.INVALID_DATE,
+                type: DateDetailError.INVALID_DATE,
                 message: "not a valid date",
               },
             ],
@@ -156,7 +158,7 @@ describe("GIVEN a DatePicker where selectionVariant is single", () => {
             value: "another bad date 2",
             errors: [
               {
-                type: DateDetailErrorEnum.INVALID_DATE,
+                type: DateDetailError.INVALID_DATE,
                 message: "not a valid date",
               },
             ],

--- a/packages/lab/src/calendar/useCalendarSelection.ts
+++ b/packages/lab/src/calendar/useCalendarSelection.ts
@@ -400,7 +400,7 @@ export function useCalendarSelection<TDate extends DateFrameworkType>(
         case "single":
           return (
             isSingleSelectionValueType(selectedDate) &&
-            dateAdapter.isSame(selectedDate, date, "day")
+            dateAdapter.isSame(selectedDate as TDate, date, "day")
           );
         case "multiselect":
           return (

--- a/packages/lab/src/date-picker/DatePickerRangeInput.tsx
+++ b/packages/lab/src/date-picker/DatePickerRangeInput.tsx
@@ -1,6 +1,6 @@
 import { Button, makePrefixer, useControlled, useIcon } from "@salt-ds/core";
 import {
-  DateDetailErrorEnum,
+  DateDetailError,
   type DateFrameworkType,
   type SaltDateAdapter,
 } from "@salt-ds/date-adapters";
@@ -57,7 +57,7 @@ export function defaultRangeValidator<TDate extends DateFrameworkType>(
     details.startDate = details.startDate || {};
     details.startDate.errors = details.startDate.errors || [];
     details.startDate.errors.push({
-      type: DateDetailErrorEnum.UNSET,
+      type: DateDetailError.UNSET,
       message: "no start date defined",
     });
   }
@@ -65,7 +65,7 @@ export function defaultRangeValidator<TDate extends DateFrameworkType>(
     details.endDate = details.endDate || {};
     details.endDate.errors = details.endDate.errors || [];
     details.endDate.errors.push({
-      type: DateDetailErrorEnum.UNSET,
+      type: DateDetailError.UNSET,
       message: "no end date defined",
     });
   }

--- a/packages/lab/src/date-picker/DatePickerSingleInput.tsx
+++ b/packages/lab/src/date-picker/DatePickerSingleInput.tsx
@@ -1,6 +1,6 @@
 import { Button, makePrefixer, useControlled } from "@salt-ds/core";
 import {
-  DateDetailErrorEnum,
+  DateDetailError,
   type DateFrameworkType,
   type SaltDateAdapter,
 } from "@salt-ds/date-adapters";
@@ -53,7 +53,7 @@ function defaultSingleValidation<TDate extends DateFrameworkType>(
   if (!date) {
     details.errors = details.errors ?? [];
     details.errors?.push({
-      type: DateDetailErrorEnum.UNSET,
+      type: DateDetailError.UNSET,
       message: "no date defined",
     });
   } else {

--- a/packages/lab/stories/date-picker/date-picker.stories.tsx
+++ b/packages/lab/stories/date-picker/date-picker.stories.tsx
@@ -10,7 +10,7 @@ import {
   Text,
 } from "@salt-ds/core";
 import {
-  DateDetailErrorEnum,
+  DateDetailError,
   type DateFrameworkType,
   type ParserResult,
   type TimeFields,
@@ -1575,7 +1575,7 @@ export const SingleWithCustomParser: StoryFn<
           date: parsedDate.date,
           value: inputDate,
           errors: [
-            { type: DateDetailErrorEnum.UNSET, message: "no date provided" },
+            { type: DateDetailError.UNSET, message: "no date provided" },
           ],
         };
       }
@@ -1714,7 +1714,7 @@ export const RangeWithCustomParser: StoryFn<
           date: parsedDate.date,
           value: inputDate,
           errors: [
-            { type: DateDetailErrorEnum.UNSET, message: "no date provided" },
+            { type: DateDetailError.UNSET, message: "no date provided" },
           ],
         };
       }
@@ -1795,7 +1795,7 @@ export const SingleWithCustomValidation: StoryFn<
       if (date && isWeekend(date)) {
         updatedDetails.errors = updatedDetails?.errors ?? [];
         updatedDetails.errors?.push({
-          type: DateDetailErrorEnum.INVALID_DAY,
+          type: DateDetailError.INVALID_DAY,
           message: "date must be a weekday",
         });
       }
@@ -1842,7 +1842,7 @@ export const SingleWithCustomValidation: StoryFn<
         return details;
       }
       details.errors = details.errors.map((error) => {
-        if (error.type === DateDetailErrorEnum.NOT_A_DATE) {
+        if (error.type === DateDetailError.NOT_A_DATE) {
           error.message = "valid dates are any weekday";
         }
         return error;

--- a/scripts/makeTypings.mjs
+++ b/scripts/makeTypings.mjs
@@ -24,8 +24,8 @@ export function reportTSDiagnostics(diagnostics) {
   }
 }
 
-export async function makeTypings(outDir) {
-  const typescriptConfig = await getTypescriptConfig(cwd);
+export async function makeTypings(outDir, srcDir = path.join(cwd, "src")) {
+  const typescriptConfig = await getTypescriptConfig(cwd, srcDir);
 
   console.log("generating .d.ts files");
 

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1,17 +1,16 @@
-import path from "node:path";
 import { getTsconfig } from "get-tsconfig";
 
 export function distinct(arr) {
   return [...new Set(arr)];
 }
 
-export async function getTypescriptConfig(cwd) {
+export async function getTypescriptConfig(cwd, srcDir) {
   const typescriptConfig = {};
 
   const result = getTsconfig(cwd);
 
   Object.assign(typescriptConfig, result.config, {
-    include: [path.join(cwd, "src")],
+    include: [srcDir],
     exclude: distinct(
       [
         // all TS test files, regardless whether co-located or in test/ etc

--- a/site/docs/components/localization-provider/usage.mdx
+++ b/site/docs/components/localization-provider/usage.mdx
@@ -37,25 +37,25 @@ To import your chosen adapter adapter use one of the following :
 ### date-fns
 
 ```
-import { AdapterDateFns } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
 ```
 
 ### dayjs
 
 ```
-import { AdapterDayJs } from "@salt-ds/date-adapters";
+import { AdapterDayJs } from "@salt-ds/date-adapters/dayjs";
 ```
 
 ### luxon
 
 ```
-import { AdapterLuxon } from "@salt-ds/date-adapters";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
 ```
 
 ### moment (legacy)
 
 ```
-import { AdapterMoment } from "@salt-ds/date-adapters";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 ```
 
 ## Usage
@@ -69,6 +69,7 @@ Each adapter imports the date library defined by your peer dependency but for da
 Passing `dayjs` to `AdapterDayJs` enables you to preconfigure defaults.
 
 ```
+import { AdapterDayJs } from "@salt-ds/date-adapters/dayjs";
 import dayjs from "dayjs";
 dayjs.tz.setDefault('America/New_York');
 
@@ -78,6 +79,7 @@ const dayjsAdapter = new AdapterDayJs(locale, dayjs);
 Passing `moment-timezone` to `AdapterMoment` adapter enables timezone support.
 
 ```
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import moment from "moment-timezone";
 
 const momentAdapter = new AdapterMoment(locale, moment);
@@ -376,7 +378,7 @@ Not normally necessary, but in order to add a new adapter that is a valid `TDate
 /**
  * To add a new adapter, then, add the adapter's date object to `DateFrameworkTypeMap` interface
  */
- declare module "./types" {
+ declare module "@salt-ds/date-adapters" {
    interface DateFrameworkTypeMap {
      luxon: DateTime;
    }

--- a/site/src/components/components/LivePreview.tsx
+++ b/site/src/components/components/LivePreview.tsx
@@ -14,7 +14,7 @@ import useIsMobileView from "../../utils/useIsMobileView";
 import { Pre } from "../mdx/pre";
 import { useLivePreviewControls } from "./useLivePreviewControls";
 
-import { AdapterDateFns } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
 import { LocalizationProvider } from "@salt-ds/lab";
 import styles from "./LivePreview.module.css";
 

--- a/site/src/examples/calendar/WithLocale.tsx
+++ b/site/src/examples/calendar/WithLocale.tsx
@@ -1,4 +1,4 @@
-import { AdapterDateFns } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
 import {
   Calendar,
   CalendarGrid,

--- a/site/src/examples/date-picker/SingleWithCustomParser.tsx
+++ b/site/src/examples/date-picker/SingleWithCustomParser.tsx
@@ -4,7 +4,7 @@ import {
   FormFieldLabel as FormLabel,
 } from "@salt-ds/core";
 import {
-  DateDetailErrorEnum,
+  DateDetailError,
   type DateFrameworkType,
   type ParserResult,
 } from "@salt-ds/date-adapters";
@@ -40,7 +40,7 @@ export const SingleWithCustomParser = (): ReactElement => {
   >(null);
   const handleSelectionChange = useCallback(
     (
-      event: SyntheticEvent,
+      _event: SyntheticEvent,
       date: SingleDateSelection<DateFrameworkType> | null,
       details: DateInputSingleDetails | undefined,
     ) => {
@@ -83,7 +83,7 @@ export const SingleWithCustomParser = (): ReactElement => {
           date: parsedDate.date,
           value: inputDate,
           errors: [
-            { type: DateDetailErrorEnum.UNSET, message: "no date provided" },
+            { type: DateDetailError.UNSET, message: "no date provided" },
           ],
         };
       }

--- a/site/src/examples/localization-provider/Locale.tsx
+++ b/site/src/examples/localization-provider/Locale.tsx
@@ -4,6 +4,10 @@ import {
   RadioButton,
   RadioButtonGroup,
 } from "@salt-ds/core";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import {
   Calendar,
   CalendarGrid,
@@ -13,10 +17,6 @@ import {
 } from "@salt-ds/lab";
 import { type ChangeEventHandler, type ReactElement, useState } from "react";
 import "dayjs/locale/en";
-import { AdapterDateFns } from "@salt-ds/date-adapters";
-import { AdapterDayjs } from "@salt-ds/date-adapters";
-import { AdapterLuxon } from "@salt-ds/date-adapters";
-import { AdapterMoment } from "@salt-ds/date-adapters";
 import moment from "moment";
 import "moment/locale/zh-cn"; // Import the Chinese locale
 import { enUS as dateFnsEnUs } from "date-fns/locale";

--- a/site/src/examples/localization-provider/MinMax.tsx
+++ b/site/src/examples/localization-provider/MinMax.tsx
@@ -1,5 +1,6 @@
 import { FormField, FormFieldHelperText, FormFieldLabel } from "@salt-ds/core";
-import { AdapterDateFns, type DateFrameworkType } from "@salt-ds/date-adapters";
+import type { DateFrameworkType } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
 import {
   Calendar,
   CalendarGrid,

--- a/site/src/pages/_app.tsx
+++ b/site/src/pages/_app.tsx
@@ -25,7 +25,7 @@ import {
   SaltProviderNext,
   useCurrentBreakpoint,
 } from "@salt-ds/core";
-import { AdapterDateFns } from "@salt-ds/date-adapters";
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
 import { LocalizationProvider } from "@salt-ds/lab";
 import clsx from "clsx";
 import { SessionProvider } from "next-auth/react";

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "baseUrl": ".",
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "paths": {
+      "@salt-ds/date-adapters/*": ["../packages/date-adapters/src/index.ts"]
+    }
   },
   "include": ["src/**/*", "globals.d.ts"],
   "exclude": ["node_modules"]

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -5,7 +5,9 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "@salt-ds/date-adapters/*": ["../packages/date-adapters/src/index.ts"]
+      "@salt-ds/date-adapters/*": [
+        "../packages/date-adapters/src/*-adapter/index.ts"
+      ]
     }
   },
   "include": ["src/**/*", "globals.d.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,9 @@
         "packages/icons/stories/*",
         "packages/lab/stories/*",
         "packages/theme/stories/*"
+      ],
+      "@salt-ds/date-adapters/*": [
+        "./packages/date-adapters/src/*-adapter/index.ts"
       ]
     },
     "types": ["cypress", "@testing-library/cypress", "node"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,8 @@
+import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  plugins: [tsconfigPaths() as any],
   test: {
     include: ["**/*.spec.[jt]s?(x)"],
   },


### PR DESCRIPTION
…esolution

```diff
- import { AdapterDateFns } from "@salt-ds/date-adapters";
- import { AdapterDayjs } from "@salt-ds/date-adapters";
- import { AdapterLuxon } from "@salt-ds/date-adapters";
- import { AdapterMoment } from "@salt-ds/date-adapters";
+ import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+ import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
+ import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+ import { AdapterMoment } from "@salt-ds/date-adapters/moment";
```