### PR TITLE
Center vertical alignment of MenuItem - #4571

### DIFF
--- a/.changeset/tasty-jobs-jump.md
+++ b/.changeset/tasty-jobs-jump.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Added centered vertical alignment to MenuItem

--- a/packages/core/src/menu/MenuItem.css
+++ b/packages/core/src/menu/MenuItem.css
@@ -14,6 +14,7 @@
   cursor: var(--salt-selectable-cursor-hover);
   box-sizing: border-box;
   flex-shrink: 0;
+  align-items: center;
 }
 
 .saltMenuItem:focus-visible {


### PR DESCRIPTION
Fixes #4571 
Correctly aligns Icons to text
As with the original ticket raised - feel free to close and disregard if the current formatting is intentional 

Before:
![image](https://github.com/user-attachments/assets/e39235f3-6a87-4482-8d59-994f2f0841bd)
After:
![image](https://github.com/user-attachments/assets/baaea0cd-3b62-4017-854f-c1a85def9d47)
