### PR TITLE
Remove align self center from form field

### DIFF
--- a/.changeset/hungry-schools-hope.md
+++ b/.changeset/hungry-schools-hope.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Fixed FormField incorrectly applying `align-self` when `labelPlacement` is `"left"` or `"right"`.

--- a/packages/core/src/form-field/FormField.css
+++ b/packages/core/src/form-field/FormField.css
@@ -24,13 +24,11 @@
 }
 
 .saltFormField-labelLeft {
-  align-self: center;
   grid-template-columns: var(--saltFormField-label-width, var(--formField-label-width, 40%)) 1fr;
   grid-template-areas: "label controls";
 }
 
 .saltFormField-labelRight {
-  align-self: center;
   grid-template-columns: var(--saltFormField-label-width, var(--formField-label-width, 40%)) 1fr;
   grid-template-areas: "label controls";
 }


### PR DESCRIPTION
Closes #3794 

This is aligning our form fields in the middle of our layouts and to my knowledge is unnecessary for form field styling itself(?)

we have been applying
:global(.saltFormField-labelLeft),
:global(.saltFormField-labelRight) {
  align-self: unset;
}