### PR TITLE
Slider - Code review feedback

### DIFF
--- a/packages/lab/src/__tests__/__e2e__/slider/RangeSlider.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/slider/RangeSlider.cy.tsx
@@ -103,18 +103,10 @@ describe("Given a Range Slider", () => {
     cy.findAllByRole("slider").eq(0).focus().realPress("Home");
     cy.findAllByRole("slider").eq(0).should("have.value", "0");
     cy.get("@changeSpy").should("have.callCount", 3);
-    // Try to change the minimum/previous value
-    cy.findAllByRole("slider").eq(0).realPress("ArrowLeft");
-    cy.findAllByRole("slider").eq(0).should("have.value", "0");
-    cy.get("@changeSpy").should("have.callCount", 3);
 
     // Focus second thumb and press and End key
     cy.findAllByRole("slider").eq(1).focus().realPress("End");
     cy.findAllByRole("slider").eq(1).should("have.value", "30");
-    cy.get("@changeSpy").should("have.callCount", 4);
-    // Try to change the maximum/previous value
-    cy.findAllByRole("slider").eq(1).focus().realPress("ArrowRight");
-    cy.findAllByRole("slider").eq(0).should("have.value", "30");
     cy.get("@changeSpy").should("have.callCount", 4);
 
     // Focus first thumb and press and Page Up key
@@ -123,7 +115,7 @@ describe("Given a Range Slider", () => {
     cy.findAllByRole("slider").eq(0).should("have.value", "2");
     cy.get("@changeSpy").should("have.callCount", 5);
 
-    // Focus second thumb and press and Page Up key
+    // Focus second thumb and press and Page Down key
     cy.findAllByRole("slider").eq(1).focus().realPress("PageDown");
     // It should have a greater step decrease
     cy.findAllByRole("slider").eq(1).should("have.value", "28");
@@ -163,26 +155,31 @@ describe("Given a Range Slider", () => {
   });
 
   it("should not allow thumbs to go beyond min and max values", () => {
+    const changeSpy = cy.stub().as("changeSpy");
     cy.mount(
       <Default
         min={2}
         max={9}
         defaultValue={[4, 8]}
+        onChange={changeSpy}
         style={{ width: "400px" }}
       />,
     );
-
     // Focus first thumb, press Home key and then Arrow Left
     cy.findAllByRole("slider").eq(0).focus().realPress("Home");
     cy.findAllByRole("slider").eq(0).focus().realPress("ArrowLeft");
-    // Thumb shouldn't go less than min value
+    cy.get("@changeSpy").should("have.callCount", 1);
+    // Thumb shouldn't go less than min and onChange should not be called
     cy.findAllByRole("slider").eq(0).should("have.value", "2");
+    cy.get("@changeSpy").should("have.callCount", 1);
 
     // Focus second thumb, press End key and then Arrow Right
     cy.findAllByRole("slider").eq(1).focus().realPress("End");
     cy.findAllByRole("slider").eq(1).focus().realPress("ArrowRight");
-    // Thumb shouldn't go more than max value
+    cy.get("@changeSpy").should("have.callCount", 2);
+    // Thumb shouldn't go more than max value and onChange should not be called
     cy.findAllByRole("slider").eq(1).should("have.value", "9");
+    cy.get("@changeSpy").should("have.callCount", 2);
   });
 
   it("should display a tooltip with correct value only when thumb is hovered", () => {

--- a/packages/lab/src/__tests__/__e2e__/slider/RangeSlider.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/slider/RangeSlider.cy.tsx
@@ -78,40 +78,56 @@ describe("Given a Range Slider", () => {
   });
 
   it("should change thumb positions based on keyboard navigation", () => {
+    const changeSpy = cy.stub().as("changeSpy");
     cy.mount(
       <Default
         defaultValue={[4, 8]}
         min={0}
         max={30}
+        onChange={changeSpy}
         style={{ width: "400px" }}
       />,
     );
 
-    // Focus and move first thumb
+    // Focus first thumb and press ArrowRight key
     cy.findAllByRole("slider").eq(0).focus().realPress("ArrowRight");
     cy.findAllByRole("slider").eq(0).should("have.value", "5");
+    cy.get("@changeSpy").should("have.callCount", 1);
 
-    // Focus and move second thumb
+    // Focus second thumb and press ArrowLeft key
     cy.findAllByRole("slider").eq(1).focus().realPress("ArrowLeft");
     cy.findAllByRole("slider").eq(1).should("have.value", "7");
+    cy.get("@changeSpy").should("have.callCount", 2);
 
     // Focus first thumb and press and Home key
     cy.findAllByRole("slider").eq(0).focus().realPress("Home");
     cy.findAllByRole("slider").eq(0).should("have.value", "0");
+    cy.get("@changeSpy").should("have.callCount", 3);
+    // Try to change the minimum/previous value
+    cy.findAllByRole("slider").eq(0).realPress("ArrowLeft");
+    cy.findAllByRole("slider").eq(0).should("have.value", "0");
+    cy.get("@changeSpy").should("have.callCount", 3);
 
     // Focus second thumb and press and End key
     cy.findAllByRole("slider").eq(1).focus().realPress("End");
     cy.findAllByRole("slider").eq(1).should("have.value", "30");
+    cy.get("@changeSpy").should("have.callCount", 4);
+    // Try to change the maximum/previous value
+    cy.findAllByRole("slider").eq(1).focus().realPress("ArrowRight");
+    cy.findAllByRole("slider").eq(0).should("have.value", "30");
+    cy.get("@changeSpy").should("have.callCount", 4);
 
     // Focus first thumb and press and Page Up key
     cy.findAllByRole("slider").eq(0).focus().realPress("PageUp");
     // It should have a greater step increase
     cy.findAllByRole("slider").eq(0).should("have.value", "2");
+    cy.get("@changeSpy").should("have.callCount", 5);
 
     // Focus second thumb and press and Page Up key
     cy.findAllByRole("slider").eq(1).focus().realPress("PageDown");
     // It should have a greater step decrease
     cy.findAllByRole("slider").eq(1).should("have.value", "28");
+    cy.get("@changeSpy").should("have.callCount", 6);
   });
 
   it("should move the thumb in larger increments when step multiplier is increased", () => {

--- a/packages/lab/src/__tests__/__e2e__/slider/RangeSlider.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/slider/RangeSlider.cy.tsx
@@ -210,26 +210,26 @@ describe("Given a Range Slider", () => {
     cy.get(".saltSliderTooltip").should("not.be.visible");
   });
 
-  it("should render markers when provided", () => {
+  it("should render marks when provided", () => {
     cy.mount(
       <Default
         style={{ width: "400px" }}
-        markers={[
+        marks={[
           { value: 2, label: "2" },
           { value: 3, label: "3" },
         ]}
       />,
     );
 
-    cy.findAllByTestId("marker").eq(0).should("have.text", "2");
-    cy.findAllByTestId("marker").eq(1).should("have.text", "3");
+    cy.findAllByTestId("mark").eq(0).should("have.text", "2");
+    cy.findAllByTestId("mark").eq(1).should("have.text", "3");
   });
 
-  it("should not render inline min/max labels when markers are provided", () => {
+  it("should not render inline min/max labels when marks are provided", () => {
     cy.mount(
       <Default
         style={{ width: "400px" }}
-        markers={[
+        marks={[
           { value: 2, label: "2" },
           { value: 3, label: "3" },
         ]}

--- a/packages/lab/src/__tests__/__e2e__/slider/Slider.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/slider/Slider.cy.tsx
@@ -130,26 +130,26 @@ describe("Given a Slider", () => {
     cy.findByTestId("sliderTooltip").should("not.be.visible");
   });
 
-  it("should render markers when provided", () => {
+  it("should render marks when provided", () => {
     cy.mount(
       <Default
         style={{ width: "400px" }}
-        markers={[
+        marks={[
           { value: 2, label: "2" },
           { value: 3, label: "3" },
         ]}
       />,
     );
 
-    cy.findAllByTestId("marker").eq(0).should("have.text", "2");
-    cy.findAllByTestId("marker").eq(1).should("have.text", "3");
+    cy.findAllByTestId("mark").eq(0).should("have.text", "2");
+    cy.findAllByTestId("mark").eq(1).should("have.text", "3");
   });
 
-  it("should not render inline min/max labels when markers are provided", () => {
+  it("should not render inline min/max labels when marks are provided", () => {
     cy.mount(
       <Default
         style={{ width: "400px" }}
-        markers={[
+        marks={[
           { value: 2, label: "2" },
           { value: 3, label: "3" },
         ]}

--- a/packages/lab/src/__tests__/__e2e__/slider/Slider.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/slider/Slider.cy.tsx
@@ -42,26 +42,40 @@ describe("Given a Slider", () => {
         onChange={changeSpy}
       />,
     );
+    // Focus and press and ArrowRight key
     cy.findByRole("slider").focus().realPress("ArrowRight");
     cy.findByRole("slider").should("have.value", "105");
     cy.get("@changeSpy").should("have.callCount", 1);
 
+    // Press ArrowLeft key
+    cy.findByRole("slider").realPress("ArrowLeft");
+    cy.findByRole("slider").should("have.value", "100");
+    cy.get("@changeSpy").should("have.callCount", 2);
+    // Try to change the previous/previous value
     cy.findByRole("slider").realPress("ArrowLeft");
     cy.findByRole("slider").should("have.value", "100");
     cy.get("@changeSpy").should("have.callCount", 2);
 
+    // Press End key
     cy.findByRole("slider").realPress("End");
     cy.findByRole("slider").should("have.value", "125");
     cy.get("@changeSpy").should("have.callCount", 3);
+    // Try to change the maximum/previous value
+    cy.findByRole("slider").focus().realPress("ArrowRight");
+    cy.findByRole("slider").should("have.value", "125");
+    cy.get("@changeSpy").should("have.callCount", 3);
 
+    // Press Home key
     cy.findByRole("slider").realPress("Home");
     cy.findByRole("slider").should("have.value", "5");
     cy.get("@changeSpy").should("have.callCount", 4);
 
+    // Press PageUp key
     cy.findByRole("slider").focus().realPress("PageUp");
     // It should have a greater step increase
     cy.findByRole("slider").should("have.value", "15");
 
+    // Press PageDown key
     cy.findByRole("slider").focus().realPress("PageDown");
     // It should have a greater step decrease
     cy.findByRole("slider").should("have.value", "5");

--- a/packages/lab/src/__tests__/__e2e__/slider/Slider.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/slider/Slider.cy.tsx
@@ -42,7 +42,7 @@ describe("Given a Slider", () => {
         onChange={changeSpy}
       />,
     );
-    // Focus and press and ArrowRight key
+    // Focus and press ArrowRight key
     cy.findByRole("slider").focus().realPress("ArrowRight");
     cy.findByRole("slider").should("have.value", "105");
     cy.get("@changeSpy").should("have.callCount", 1);
@@ -51,34 +51,28 @@ describe("Given a Slider", () => {
     cy.findByRole("slider").realPress("ArrowLeft");
     cy.findByRole("slider").should("have.value", "100");
     cy.get("@changeSpy").should("have.callCount", 2);
-    // Try to change the previous/previous value
-    cy.findByRole("slider").realPress("ArrowLeft");
-    cy.findByRole("slider").should("have.value", "100");
-    cy.get("@changeSpy").should("have.callCount", 2);
-
-    // Press End key
-    cy.findByRole("slider").realPress("End");
-    cy.findByRole("slider").should("have.value", "125");
-    cy.get("@changeSpy").should("have.callCount", 3);
-    // Try to change the maximum/previous value
-    cy.findByRole("slider").focus().realPress("ArrowRight");
-    cy.findByRole("slider").should("have.value", "125");
-    cy.get("@changeSpy").should("have.callCount", 3);
-
-    // Press Home key
-    cy.findByRole("slider").realPress("Home");
-    cy.findByRole("slider").should("have.value", "5");
-    cy.get("@changeSpy").should("have.callCount", 4);
 
     // Press PageUp key
     cy.findByRole("slider").focus().realPress("PageUp");
     // It should have a greater step increase
-    cy.findByRole("slider").should("have.value", "15");
+    cy.findByRole("slider").should("have.value", "110");
+    cy.get("@changeSpy").should("have.callCount", 3);
 
     // Press PageDown key
     cy.findByRole("slider").focus().realPress("PageDown");
     // It should have a greater step decrease
+    cy.findByRole("slider").should("have.value", "100");
+    cy.get("@changeSpy").should("have.callCount", 4);
+
+    // Press Home key
+    cy.findByRole("slider").realPress("Home");
     cy.findByRole("slider").should("have.value", "5");
+    cy.get("@changeSpy").should("have.callCount", 5);
+
+    // // Press End key
+    cy.findByRole("slider").realPress("End");
+    cy.findByRole("slider").should("have.value", "125");
+    cy.get("@changeSpy").should("have.callCount", 6);
   });
 
   it("should move the thumb in larger increments when step multiplier is increased", () => {
@@ -169,19 +163,30 @@ describe("Given a Slider", () => {
   });
 
   it("should not allow the thumb to go beyond min and max values", () => {
-    cy.mount(<Default style={{ width: "400px" }} min={5} max={20} />);
-
-    // Focus the thumb, press the Home key and then Arrow Left
+    const changeSpy = cy.stub().as("changeSpy");
+    cy.mount(
+      <Default
+        style={{ width: "400px" }}
+        min={5}
+        max={20}
+        onChange={changeSpy}
+      />,
+    );
+    // Focus the thumb, press the Home key and then Arrow Left.
     cy.findByRole("slider").focus().realPress("Home");
     cy.findByRole("slider").focus().realPress("ArrowLeft");
-    // Thumb shouldn't go less than min
+    cy.get("@changeSpy").should("have.callCount", 1);
+    // Thumb shouldn't go less than min and onChange should not be called
     cy.findByRole("slider").should("have.attr", "aria-valuenow", "5");
+    cy.get("@changeSpy").should("have.callCount", 1);
 
     // Focus the thumb, press the End key and then Arrow Right
     cy.findByRole("slider").focus().realPress("End");
     cy.findByRole("slider").focus().realPress("ArrowRight");
-    // Thumb shouldn't go less than min
+    cy.get("@changeSpy").should("have.callCount", 2);
+    // Thumb shouldn't go less than min and onChange should not be called
     cy.findByRole("slider").should("have.attr", "aria-valuenow", "20");
+    cy.get("@changeSpy").should("have.callCount", 2);
   });
 
   it("should render custom min max labels when passed", () => {

--- a/packages/lab/src/slider/RangeSlider.tsx
+++ b/packages/lab/src/slider/RangeSlider.tsx
@@ -32,9 +32,9 @@ export interface RangeSliderProps
    */
   labelPosition?: "bottom" | "inline";
   /**
-   * The markers to show under the slider to label some values
+   * Marks that are displayed under the track.
    */
-  markers?: { label: string; value: number }[];
+  marks?: { label: string; value: number }[];
   /**
    * Maximum slider value
    */
@@ -90,7 +90,7 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>(
       disabled: disabledProp = false,
       format,
       labelPosition = "inline",
-      markers,
+      marks,
       max = 10,
       min = 0,
       maxLabel,
@@ -180,7 +180,7 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>(
         handlePointerDown={handlePointerDownOnTrack}
         isDragging={isDragging}
         labelPosition={labelPosition}
-        markers={markers}
+        marks={marks}
         min={min}
         minLabel={minLabel}
         max={max}

--- a/packages/lab/src/slider/RangeSlider.tsx
+++ b/packages/lab/src/slider/RangeSlider.tsx
@@ -111,7 +111,7 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>(
       name: "RangeSlider",
       state: "value",
     });
-    const lastValueState = useRef(valueState);
+    const lastValueRef = useRef<[number, number]>(valueState);
 
     const {
       a11yProps: { "aria-labelledby": formFieldLabelledBy } = {},
@@ -161,13 +161,15 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>(
     ) => {
       const parsedValue = toFloat(event.target.value);
       const values = preventThumbOverlap(parsedValue, value, thumbIndex);
-      const hasValuesChanged = values[0] !== lastValueState.current[0] || values[1] !== lastValueState.current[1];
-      if (hasValuesChanged) {
+      const haveValuesChanged =
+        values[0] !== lastValueRef.current[0] ||
+        values[1] !== lastValueRef.current[1];
+      if (haveValuesChanged) {
         const values = preventThumbOverlap(parsedValue, value, thumbIndex);
         setValue(values as [number, number]);
         onChange?.(event, values as [number, number]);
         onChangeEnd?.(event, values as [number, number]);
-        lastValueState.current= values;
+        lastValueRef.current = values;
       }
     };
 

--- a/packages/lab/src/slider/RangeSlider.tsx
+++ b/packages/lab/src/slider/RangeSlider.tsx
@@ -3,6 +3,7 @@ import {
   type HTMLAttributes,
   type SyntheticEvent,
   forwardRef,
+  useRef,
 } from "react";
 
 import { useControlled, useFormFieldProps } from "@salt-ds/core";
@@ -110,6 +111,7 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>(
       name: "RangeSlider",
       state: "value",
     });
+    const lastValueState = useRef(valueState);
 
     const {
       a11yProps: { "aria-labelledby": formFieldLabelledBy } = {},
@@ -159,9 +161,14 @@ export const RangeSlider = forwardRef<HTMLDivElement, RangeSliderProps>(
     ) => {
       const parsedValue = toFloat(event.target.value);
       const values = preventThumbOverlap(parsedValue, value, thumbIndex);
-      setValue(values as [number, number]);
-      onChange?.(event, values as [number, number]);
-      onChangeEnd?.(event, values as [number, number]);
+      const hasValuesChanged = values[0] !== lastValueState.current[0] || values[1] !== lastValueState.current[1];
+      if (hasValuesChanged) {
+        const values = preventThumbOverlap(parsedValue, value, thumbIndex);
+        setValue(values as [number, number]);
+        onChange?.(event, values as [number, number]);
+        onChangeEnd?.(event, values as [number, number]);
+        lastValueState.current= values;
+      }
     };
 
     return (

--- a/packages/lab/src/slider/Slider.tsx
+++ b/packages/lab/src/slider/Slider.tsx
@@ -3,6 +3,7 @@ import {
   type HTMLAttributes,
   type SyntheticEvent,
   forwardRef,
+  useRef
 } from "react";
 
 import { useControlled, useFormFieldProps } from "@salt-ds/core";
@@ -104,6 +105,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
     name: "Slider",
     state: "value",
   });
+  const lastValueState = useRef(valueState);
 
   const {
     handlePointerDownOnThumb,
@@ -131,9 +133,12 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const parsedValue = toFloat(event.target.value);
-    setValue(parsedValue);
-    onChange?.(event, parsedValue);
-    onChangeEnd?.(event, parsedValue);
+    if (parsedValue !== lastValueState.current) {
+      setValue(parsedValue);
+      onChange?.(event, parsedValue);
+      onChangeEnd?.(event, parsedValue);
+      lastValueState.current = parsedValue;
+    }
   };
 
   return (

--- a/packages/lab/src/slider/Slider.tsx
+++ b/packages/lab/src/slider/Slider.tsx
@@ -32,9 +32,9 @@ export interface SliderProps
    */
   labelPosition?: "bottom" | "inline";
   /**
-   * The markers to show under the slider to label some values
+   * Marks that are displayed under the track.
    */
-  markers?: { label: string; value: number }[];
+  marks?: { label: string; value: number }[];
   /**
    * Maximum slider value
    */
@@ -85,7 +85,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
     disabled: disabledProp = false,
     format,
     labelPosition = "inline",
-    markers,
+    marks,
     min = 0,
     minLabel,
     max = 10,
@@ -152,7 +152,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
       minLabel={minLabel}
       max={max}
       maxLabel={maxLabel}
-      markers={markers}
+      marks={marks}
       progressPercentage={progressPercentage}
       ref={ref}
       sliderRef={sliderRef}

--- a/packages/lab/src/slider/Slider.tsx
+++ b/packages/lab/src/slider/Slider.tsx
@@ -3,7 +3,7 @@ import {
   type HTMLAttributes,
   type SyntheticEvent,
   forwardRef,
-  useRef
+  useRef,
 } from "react";
 
 import { useControlled, useFormFieldProps } from "@salt-ds/core";
@@ -105,7 +105,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(function Slider(
     name: "Slider",
     state: "value",
   });
-  const lastValueState = useRef(valueState);
+  const lastValueState = useRef<number>(valueState);
 
   const {
     handlePointerDownOnThumb,

--- a/packages/lab/src/slider/internal/SliderThumb.tsx
+++ b/packages/lab/src/slider/internal/SliderThumb.tsx
@@ -1,10 +1,11 @@
 import { makePrefixer, useId } from "@salt-ds/core";
 import { useComponentCssInjection } from "@salt-ds/styles";
 import { useWindow } from "@salt-ds/window";
-import clsx from "clsx";
+import { clsx } from "clsx";
 import {
   type ChangeEvent,
   type ComponentPropsWithoutRef,
+  useCallback,
   useEffect,
   useRef,
   useState,
@@ -71,12 +72,18 @@ export const SliderThumb = ({
     const value = Array.isArray(sliderValue) ? sliderValue[index] : sliderValue;
     const formattedValue = format ? format(value) : value;
 
+    const handleKeyDown = useCallback((event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsTooltipVisible(false);
+      }
+    }, []);
+
     useEffect(() => {
       if (isTooltipVisible) {
         targetWindow?.addEventListener("keydown", handleKeyDown);
       }
       return () => targetWindow?.removeEventListener("keydown", handleKeyDown);
-    }, [targetWindow, isTooltipVisible]);
+    }, [handleKeyDown, targetWindow, isTooltipVisible]);
 
     const handlePointerEnter = () => setIsTooltipVisible(true);
 
@@ -96,12 +103,6 @@ export const SliderThumb = ({
     const handleBlur = () => {
       setIsFocused(false);
       setIsTooltipVisible(false);
-    };
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setIsTooltipVisible(false);
-      }
     };
 
     const handleKeydownOnThumb = (event: React.KeyboardEvent) => {

--- a/packages/lab/src/slider/internal/SliderTrack.css
+++ b/packages/lab/src/slider/internal/SliderTrack.css
@@ -4,7 +4,7 @@
   --slider-progressPercentageStart: 0%;
   --slider-progressPercentageEnd: 0%;
 
-  --slider-marker-percentage: 0%;
+  --slider-mark-percentage: 0%;
   --slider-track-background: var(--salt-track-borderColor);
   --slider-track-fill: var(--salt-accent-borderColor);
 
@@ -13,7 +13,7 @@
   width: 100%;
 }
 
-.saltSliderTrack-withMarkers {
+.saltSliderTrack-withMarks {
   justify-content: unset;
 }
 
@@ -130,15 +130,15 @@
   pointer-events: none;
 }
 
-.saltSliderTrack-markers {
+.saltSliderTrack-marks {
   position: absolute;
   user-select: none;
   width: 100%;
   top: var(--salt-size-base);
 }
 
-.saltSliderTrack-markerLabel {
+.saltSliderTrack-markLabel {
   position: absolute;
-  left: var(--slider-marker-percentage);
+  left: var(--slider-mark-percentage);
   transform: translateX(-50%);
 }

--- a/packages/lab/src/slider/internal/SliderTrack.tsx
+++ b/packages/lab/src/slider/internal/SliderTrack.tsx
@@ -4,7 +4,7 @@ import { useWindow } from "@salt-ds/window";
 import { clsx } from "clsx";
 import { type HTMLAttributes, type RefObject, forwardRef } from "react";
 import sliderTrackCss from "./SliderTrack.css";
-import { calculateMarkerPosition } from "./utils";
+import { calculateMarkPosition } from "./utils";
 
 const withBaseName = makePrefixer("saltSliderTrack");
 
@@ -17,7 +17,7 @@ interface SliderTrackProps
   isDragging: boolean;
   isRange?: boolean;
   labelPosition: "inline" | "bottom";
-  markers?: { label: string; value: number }[];
+  marks?: { label: string; value: number }[];
   max: number;
   maxLabel?: number | string;
   min: number;
@@ -37,7 +37,7 @@ export const SliderTrack = forwardRef<HTMLDivElement, SliderTrackProps>(
       isDragging,
       isRange = false,
       labelPosition,
-      markers,
+      marks,
       max,
       maxLabel,
       min,
@@ -62,9 +62,9 @@ export const SliderTrack = forwardRef<HTMLDivElement, SliderTrackProps>(
           [withBaseName("disabled")]: disabled,
           [withBaseName("dragging")]: isDragging,
           [withBaseName("withInlineLabels")]:
-            !markers && labelPosition === "inline",
+            !marks && labelPosition === "inline",
           [withBaseName("range")]: isRange,
-          [withBaseName("withMarkers")]: markers,
+          [withBaseName("withMarks")]: marks,
         })}
         data-testid="sliderTrack"
         ref={ref}
@@ -116,24 +116,24 @@ export const SliderTrack = forwardRef<HTMLDivElement, SliderTrackProps>(
             {maxLabel || format?.(max) || max}
           </Text>
         </div>
-        {/* Markers */}
-        {markers && (
-          <div className={withBaseName("markers")}>
-            {markers.map(({ label, value }) => {
+        {/* Marks */}
+        {marks && (
+          <div className={withBaseName("marks")}>
+            {marks.map(({ label, value }) => {
               return (
                 value !== min &&
                 value !== max && (
                   <Text
                     aria-hidden
-                    className={withBaseName("markerLabel")}
-                    data-testid="marker"
+                    className={withBaseName("markLabel")}
+                    data-testid="mark"
                     disabled={disabled}
                     color="secondary"
                     key={value}
                     styleAs="label"
                     style={
                       {
-                        "--slider-marker-percentage": `${calculateMarkerPosition(value, max, min)}%`,
+                        "--slider-mark-percentage": `${calculateMarkPosition(value, max, min)}%`,
                       } as React.CSSProperties
                     }
                   >

--- a/packages/lab/src/slider/internal/SliderTrack.tsx
+++ b/packages/lab/src/slider/internal/SliderTrack.tsx
@@ -89,9 +89,15 @@ export const SliderTrack = forwardRef<HTMLDivElement, SliderTrackProps>(
               ref={sliderRef}
               style={
                 {
-                  "--slider-progressPercentage": `${progressPercentage}%`,
-                  "--slider-progressPercentageStart": `${progressPercentageRange?.[0]}%`,
-                  "--slider-progressPercentageEnd": `${progressPercentageRange?.[1]}%`,
+                  ...(progressPercentage !== undefined && {
+                    "--slider-progressPercentage": `${progressPercentage}%`,
+                  }),
+                  ...(progressPercentageRange?.[0] !== undefined && {
+                    "--slider-progressPercentageStart": `${progressPercentageRange[0]}%`,
+                  }),
+                  ...(progressPercentageRange?.[1] !== undefined && {
+                    "--slider-progressPercentageEnd": `${progressPercentageRange[1]}%`,
+                  }),
                 } as React.CSSProperties
               }
             >

--- a/packages/lab/src/slider/internal/useRangeSliderThumb.ts
+++ b/packages/lab/src/slider/internal/useRangeSliderThumb.ts
@@ -35,7 +35,7 @@ export const useRangeSliderThumb = ({
 }: UseRangeSliderThumbProps) => {
   const [isDragging, setIsDragging] = useState(false);
   const [thumbIndexState, setIsThumbIndex] = useState<number>(0);
-  const currentValueRef = useRef<[number, number]>(valueState);
+  const lastValueRef = useRef<[number, number]>(valueState);
   const sliderRef = useRef<HTMLDivElement>(null);
   const sliderValues = clampRange(valueState, max, min);
   const targetWindow = useWindow();
@@ -77,10 +77,10 @@ export const useRangeSliderThumb = ({
       );
 
       if (
-        newValues[0] !== currentValueRef.current[0] ||
-        newValues[1] !== currentValueRef.current[1]
+        newValues[0] !== lastValueRef.current[0] ||
+        newValues[1] !== lastValueRef.current[1]
       ) {
-        currentValueRef.current = newValues;
+        lastValueRef.current = newValues;
         setValue(newValues);
         onChange?.(event, newValues);
       }
@@ -100,7 +100,7 @@ export const useRangeSliderThumb = ({
   const handlePointerUp = useCallback(
     (event: PointerEvent) => {
       setIsDragging(false);
-      onChangeEnd?.(event, currentValueRef.current);
+      onChangeEnd?.(event, lastValueRef.current);
     },
     [onChangeEnd],
   );
@@ -172,10 +172,10 @@ export const useRangeSliderThumb = ({
         }
       }
       if (
-        newValues[0] !== currentValueRef.current[0] ||
-        newValues[1] !== currentValueRef.current[1]
+        newValues[0] !== lastValueRef.current[0] ||
+        newValues[1] !== lastValueRef.current[1]
       ) {
-        currentValueRef.current = newValues;
+        lastValueRef.current = newValues;
         setValue(newValues);
         onChange?.(event, newValues);
       }

--- a/packages/lab/src/slider/internal/useSliderThumb.ts
+++ b/packages/lab/src/slider/internal/useSliderThumb.ts
@@ -28,7 +28,7 @@ export const useSliderThumb = ({
   valueState,
 }: UseSliderThumbProps) => {
   const [isDragging, setIsDragging] = useState(false);
-  const currentValueRef = useRef<number>(valueState);
+  const lastValueRef = useRef<number>(valueState);
   const sliderRef = useRef<HTMLDivElement>(null);
   const targetWindow = useWindow();
 
@@ -42,10 +42,10 @@ export const useSliderThumb = ({
         min,
         step,
       );
-      if (newValue === undefined || currentValueRef.current === newValue) {
+      if (newValue === undefined || lastValueRef.current === newValue) {
         return;
       }
-      currentValueRef.current = newValue;
+      lastValueRef.current = newValue;
       setValue(newValue);
       onChange?.(event, newValue);
     },
@@ -55,7 +55,7 @@ export const useSliderThumb = ({
   const handlePointerUp = useCallback(
     (event: PointerEvent) => {
       setIsDragging(false);
-      onChangeEnd?.(event, currentValueRef.current);
+      onChangeEnd?.(event, lastValueRef.current);
     },
     [onChangeEnd],
   );
@@ -94,10 +94,10 @@ export const useSliderThumb = ({
         min,
         step,
       );
-      if (newValue === undefined || currentValueRef.current === newValue) {
+      if (newValue === undefined || lastValueRef.current === newValue) {
         return;
       }
-      currentValueRef.current = newValue;
+      lastValueRef.current = newValue;
       setValue(newValue);
       onChange?.(event, newValue);
     },

--- a/packages/lab/src/slider/internal/utils.ts
+++ b/packages/lab/src/slider/internal/utils.ts
@@ -15,7 +15,7 @@ export const calculateMarkerPosition = (
     ? min
     : Math.min(Math.max(toFloat(value), min), max);
   const markerPosition = ((clampedValue - min) / (max - min)) * 100;
-  return markerPosition;
+  return Math.round(markerPosition * 100) / 100;
 };
 
 export const calculatePercentage = (value: number, max: number, min: number) =>

--- a/packages/lab/src/slider/internal/utils.ts
+++ b/packages/lab/src/slider/internal/utils.ts
@@ -3,7 +3,7 @@ import type { RefObject } from "react";
 export const toFloat = (value: number | string) =>
   typeof value === "string" ? Number.parseFloat(value) : value;
 
-export const calculateMarkerPosition = (
+export const calculateMarkPosition = (
   value: number | string,
   max: number,
   min: number,
@@ -14,8 +14,8 @@ export const calculateMarkerPosition = (
   const clampedValue = Number.isNaN(toFloat(value))
     ? min
     : Math.min(Math.max(toFloat(value), min), max);
-  const markerPosition = ((clampedValue - min) / (max - min)) * 100;
-  return Math.round(markerPosition * 100) / 100;
+  const markPosition = ((clampedValue - min) / (max - min)) * 100;
+  return Math.round(markPosition * 100) / 100;
 };
 
 export const calculatePercentage = (value: number, max: number, min: number) =>

--- a/packages/lab/stories/range-slider/range-slider.qa.stories.tsx
+++ b/packages/lab/stories/range-slider/range-slider.qa.stories.tsx
@@ -23,7 +23,7 @@ export const ExamplesGrid: StoryFn<QAContainerProps> = (props) => {
         max={5}
         min={-5}
         step={1}
-        markers={[
+        marks={[
           { value: -4, label: "-4" },
           { value: -3, label: "-3" },
           { value: -2, label: "-2" },

--- a/packages/lab/stories/range-slider/range-slider.stories.tsx
+++ b/packages/lab/stories/range-slider/range-slider.stories.tsx
@@ -5,7 +5,7 @@ import {
   Input,
   StackLayout,
 } from "@salt-ds/core";
-import { RangeSlider, type RangeSliderProps } from "@salt-ds/lab";
+import {RangeSlider, type RangeSliderProps, Slider} from "@salt-ds/lab";
 import type { StoryFn } from "@storybook/react";
 import { toFloat } from "packages/lab/src/slider/internal/utils";
 import { type ChangeEvent, useState } from "react";
@@ -278,7 +278,7 @@ export const WithCustomStep = () => (
 );
 
 export const WithNonNumericValues = () => {
-  const [value, setValue] = useState<[number, number]>();
+  const [value, setValue] = useState<[number, number]>([1, 3]);
 
   const daysOfTheWeek = [
     { label: "Monday", value: 1 },
@@ -296,19 +296,18 @@ export const WithNonNumericValues = () => {
   };
 
   return (
-    <div style={{ width: "500px" }}>
-      <RangeSlider
-        minLabel={"Monday"}
-        maxLabel={"Sunday"}
-        min={1}
-        max={7}
-        value={value}
-        onChange={(_e, value) => setValue(value)}
-        format={getDayOfTheWeek}
-        markers={daysOfTheWeek.map((day) => {
-          return { value: day.value, label: day.label };
-        })}
-      />
-    </div>
+    <RangeSlider
+      style={{ width: "500px" }}
+      minLabel={"Monday"}
+      maxLabel={"Sunday"}
+      min={1}
+      max={7}
+      value={value}
+      onChange={(_e, value) => setValue(value)}
+      format={getDayOfTheWeek}
+      markers={daysOfTheWeek.map((day) => {
+        return { value: day.value, label: day.label };
+      })}
+    />
   );
 };

--- a/packages/lab/stories/range-slider/range-slider.stories.tsx
+++ b/packages/lab/stories/range-slider/range-slider.stories.tsx
@@ -75,7 +75,7 @@ WithMarks.args = {
   min: 0,
   max: 10,
   defaultValue: [0, 5],
-  markers: [
+  marks: [
     {
       label: "5",
       value: 5,
@@ -85,7 +85,7 @@ WithMarks.args = {
       value: 8,
     },
   ],
-  "aria-label": "With Markers",
+  "aria-label": "With Marks",
 };
 
 export const WithinFormFieldAndInlineLabels: StoryFn<RangeSliderProps> = () => {
@@ -305,7 +305,7 @@ export const WithNonNumericValues = () => {
       value={value}
       onChange={(_e, value) => setValue(value)}
       format={getDayOfTheWeek}
-      markers={daysOfTheWeek.map((day) => {
+      marks={daysOfTheWeek.map((day) => {
         return { value: day.value, label: day.label };
       })}
     />

--- a/packages/lab/stories/range-slider/range-slider.stories.tsx
+++ b/packages/lab/stories/range-slider/range-slider.stories.tsx
@@ -5,7 +5,7 @@ import {
   Input,
   StackLayout,
 } from "@salt-ds/core";
-import {RangeSlider, type RangeSliderProps, Slider} from "@salt-ds/lab";
+import { RangeSlider, type RangeSliderProps } from "@salt-ds/lab";
 import type { StoryFn } from "@storybook/react";
 import { toFloat } from "packages/lab/src/slider/internal/utils";
 import { type ChangeEvent, useState } from "react";

--- a/packages/lab/stories/slider/slider.qa.stories.tsx
+++ b/packages/lab/stories/slider/slider.qa.stories.tsx
@@ -23,7 +23,7 @@ export const ExamplesGrid: StoryFn<QAContainerProps> = (props) => {
         max={5}
         min={-5}
         step={1}
-        markers={[
+        marks={[
           { value: -4, label: "-4" },
           { value: -3, label: "-3" },
           { value: -2, label: "-2" },

--- a/packages/lab/stories/slider/slider.stories.tsx
+++ b/packages/lab/stories/slider/slider.stories.tsx
@@ -84,7 +84,7 @@ WithMarks.args = {
   min: 0,
   max: 10,
   defaultValue: 5,
-  markers: [
+  marks: [
     {
       label: "5",
       value: 5,
@@ -94,7 +94,7 @@ WithMarks.args = {
       value: 8,
     },
   ],
-  "aria-label": "With Markers",
+  "aria-label": "With Marks",
 };
 
 export const WithinFormFieldAndInlineLabels: StoryFn<SliderProps> = () => {
@@ -270,7 +270,7 @@ export const WithNonNumericValues = () => {
         value={value}
         onChange={(_e, value) => setValue(value)}
         format={getDayOfTheWeek}
-        markers={daysOfTheWeek.map((day) => {
+        marks={daysOfTheWeek.map((day) => {
           return { value: day.value, label: day.label };
         })}
       />

--- a/packages/lab/stories/slider/slider.stories.tsx
+++ b/packages/lab/stories/slider/slider.stories.tsx
@@ -242,7 +242,7 @@ export const WithCustomStep = () => (
 );
 
 export const WithNonNumericValues = () => {
-  const [value, setValue] = useState<number>();
+  const [value, setValue] = useState<number>(3);
 
   const daysOfTheWeek = [
     { label: "Monday", value: 1 },

--- a/site/docs/components/range-slider/examples.mdx
+++ b/site/docs/components/range-slider/examples.mdx
@@ -31,7 +31,7 @@ A tooltip displays the value of the `RangeSlider`'s "thumbs" when a thumb is foc
 
 ## Custom Step
 
-By default, the `RangeSlider` step increment is set to 1. This can be customized by using the ‘step’ prop. Custom step values can be set to any number, including decimal values up to two decimal places.
+By default, the `RangeSlider` step increment is set to 1. This can be customized by using the `step` prop. Custom step values can be set to any number, including decimal values up to two decimal places.
 
 </LivePreview>
 

--- a/site/docs/components/range-slider/examples.mdx
+++ b/site/docs/components/range-slider/examples.mdx
@@ -43,7 +43,7 @@ You can pass a callback function to the `format()` prop to format the display va
 
 ### Best practices
 
-- When formatting the values, it is recommended to add the same formatting to the markers if passed.
+- When formatting the values, it is recommended to add the same formatting to the marks if passed.
 
 </LivePreview>
 
@@ -76,11 +76,11 @@ You can display inputs with a `RangeSlider`. Inputs are used to enter a numeric 
 
 </LivePreview>
 
-<LivePreview componentName="range-slider" exampleName="WithMarkers">
+<LivePreview componentName="range-slider" exampleName="WithMarks">
 
-## With Markers
+## With Marks
 
-You can display markers under the values of your choice with custom labels.
+You can display marks under the values of your choice with custom labels.
 
 </LivePreview>
 

--- a/site/docs/components/slider/accessibility.mdx
+++ b/site/docs/components/slider/accessibility.mdx
@@ -50,13 +50,13 @@ data:
 
 <KeyboardControl keyOrCombos="Page Up">
 
-- Increase the slider value by an amount larger than the step change made by Up Arrow
+- Increase the slider value by a multiple of the standard step size used by the Up Arrow.
 
 </KeyboardControl>
 
 <KeyboardControl keyOrCombos="Page Down">
 
-- Decrease the slider value by an amount larger than the step change made by Down Arrow.
+- Decrease the slider value by a multiple of the standard step size used by the Down Arrow.
 
 </KeyboardControl>
 

--- a/site/docs/components/slider/examples.mdx
+++ b/site/docs/components/slider/examples.mdx
@@ -42,7 +42,7 @@ You can pass a callback function to the `format()` prop to format the display va
 
 ### Best practices
 
-- When formatting the values, it is recommended to add the same formatting to the markers if passed.
+- When formatting the values, it is recommended to add the same formatting to the marks if passed.
 
 </LivePreview>
 
@@ -76,11 +76,11 @@ You can display inputs with the `Slider`. Inputs are used to enter a numeric val
 
 </LivePreview>
 
-<LivePreview componentName="slider" exampleName="WithMarkers">
+<LivePreview componentName="slider" exampleName="WithMarks">
 
-## With Markers
+## With Marks
 
-You can display markers under the values of your choice with custom labels.
+You can display marks under the values of your choice with custom labels.
 
 </LivePreview>
 

--- a/site/docs/components/slider/examples.mdx
+++ b/site/docs/components/slider/examples.mdx
@@ -30,7 +30,7 @@ Selection of a single value from a `Slider` track. A tooltip displays the value 
 
 ## Custom Step
 
-By default, the `Slider` step increment is set to 1. This can be customized by using the ‘step’ prop. Custom step values can be set to any number, including decimal values up to two decimal places.
+By default, the `Slider` step increment is set to 1. This can be customized by using the `step` prop. Custom step values can be set to any number, including decimal values up to two decimal places.
 
 </LivePreview>
 
@@ -102,11 +102,8 @@ The `Slider` maps numeric values to meaningful non-numeric options, enabling int
 
 ### Best practices:
 
-- State Management: Utilizes `useState` to track the selected option.
-
-- Dynamic Labels: Converts numeric values to descriptive labels for both display and accessibility.
-
-- Markers: Configured to visually represent each option on the slider track.
+- create a controlled slider and use your format function to create formatted labels
+- update `aria-valuetext` with the formatted current slider value
 
 This approach ensures a user-friendly and accessible interface for selecting non-numeric values.
 

--- a/site/src/examples/range-slider/WithMarks.tsx
+++ b/site/src/examples/range-slider/WithMarks.tsx
@@ -1,7 +1,7 @@
 import { RangeSlider } from "@salt-ds/lab";
 import type { ReactElement } from "react";
 
-export const WithMarkers = (): ReactElement => (
+export const WithMarks = (): ReactElement => (
   <RangeSlider
     aria-label="single"
     min={0}
@@ -9,7 +9,7 @@ export const WithMarkers = (): ReactElement => (
     defaultValue={[20, 50]}
     style={{ width: "400px" }}
     labelPosition="bottom"
-    markers={[
+    marks={[
       {
         value: 10,
         label: "10",

--- a/site/src/examples/range-slider/WithNonNumericValues.tsx
+++ b/site/src/examples/range-slider/WithNonNumericValues.tsx
@@ -27,7 +27,7 @@ export const WithNonNumericValues = (): ReactElement => {
       min={1}
       max={7}
       value={value}
-      onChange={(e, value) => setValue(value)}
+      onChange={(_e, value) => setValue(value)}
       format={getDayOfTheWeek}
       markers={daysOfTheWeek.map((day) => {
         return { value: day.value, label: day.label };

--- a/site/src/examples/range-slider/WithNonNumericValues.tsx
+++ b/site/src/examples/range-slider/WithNonNumericValues.tsx
@@ -29,7 +29,7 @@ export const WithNonNumericValues = (): ReactElement => {
       value={value}
       onChange={(_e, value) => setValue(value)}
       format={getDayOfTheWeek}
-      markers={daysOfTheWeek.map((day) => {
+      marks={daysOfTheWeek.map((day) => {
         return { value: day.value, label: day.label };
       })}
     />

--- a/site/src/examples/range-slider/index.ts
+++ b/site/src/examples/range-slider/index.ts
@@ -6,5 +6,5 @@ export * from "./WithCustomLabels";
 export * from "./WithFormatting";
 export * from "./WithFormField";
 export * from "./WithInput";
-export * from "./WithMarkers";
+export * from "./WithMarks";
 export * from "./WithNonNumericValues";

--- a/site/src/examples/slider/WithMarks.tsx
+++ b/site/src/examples/slider/WithMarks.tsx
@@ -1,7 +1,7 @@
 import { Slider } from "@salt-ds/lab";
 import type { ReactElement } from "react";
 
-export const WithMarkers = (): ReactElement => (
+export const WithMarks = (): ReactElement => (
   <Slider
     aria-label="single"
     min={0}
@@ -9,7 +9,7 @@ export const WithMarkers = (): ReactElement => (
     defaultValue={30}
     style={{ width: "400px" }}
     labelPosition="bottom"
-    markers={[
+    marks={[
       {
         value: 10,
         label: "10",

--- a/site/src/examples/slider/WithNonNumericValues.tsx
+++ b/site/src/examples/slider/WithNonNumericValues.tsx
@@ -21,20 +21,19 @@ export const WithNonNumericValues = (): ReactElement => {
   };
 
   return (
-    <StackLayout gap={3} style={{ width: "500px" }}>
-      <Slider
-        aria-valuetext={getDayOfTheWeek(value)}
-        minLabel={"Monday"}
-        maxLabel={"Sunday"}
-        min={1}
-        max={7}
-        value={value}
-        onChange={(e, value) => setValue(value)}
-        format={getDayOfTheWeek}
-        markers={daysOfTheWeek.map((day) => {
-          return { value: day.value, label: day.label };
-        })}
-      />
-    </StackLayout>
+    <Slider
+      style={{ width: "500px" }}
+      aria-valuetext={getDayOfTheWeek(value)}
+      minLabel={"Monday"}
+      maxLabel={"Sunday"}
+      min={1}
+      max={7}
+      value={value}
+      onChange={(_e, value) => setValue(value)}
+      format={getDayOfTheWeek}
+      markers={daysOfTheWeek.map((day) => {
+        return { value: day.value, label: day.label };
+      })}
+    />
   );
 };

--- a/site/src/examples/slider/WithNonNumericValues.tsx
+++ b/site/src/examples/slider/WithNonNumericValues.tsx
@@ -30,7 +30,7 @@ export const WithNonNumericValues = (): ReactElement => {
       value={value}
       onChange={(_e, value) => setValue(value)}
       format={getDayOfTheWeek}
-      markers={daysOfTheWeek.map((day) => {
+      marks={daysOfTheWeek.map((day) => {
         return { value: day.value, label: day.label };
       })}
     />

--- a/site/src/examples/slider/WithNonNumericValues.tsx
+++ b/site/src/examples/slider/WithNonNumericValues.tsx
@@ -1,4 +1,3 @@
-import { StackLayout } from "@salt-ds/core";
 import { Slider } from "@salt-ds/lab";
 import { type ReactElement, useState } from "react";
 

--- a/site/src/examples/slider/index.ts
+++ b/site/src/examples/slider/index.ts
@@ -6,5 +6,5 @@ export * from "./WithCustomLabels";
 export * from "./WithFormatting";
 export * from "./WithFormField";
 export * from "./WithInput";
-export * from "./WithMarkers";
+export * from "./WithMarks";
 export * from "./WithNonNumericValues";


### PR DESCRIPTION
- if you clicked on a track but did not drag it, onChangeEnd was called with a stale value
- if you tried to exceed the min/max of the slider, onChange was called
- polish of docs
- performance improvements, each render created a new function and useEffect would potential add multiple listeners
- examples warnings from useControlled
- clean up dom of un-rounded percentages and undefined vars in dynamic css vars