### PR TITLE
Update accordion accessibility docs

### DIFF
--- a/site/docs/components/accordion/accessibility.mdx
+++ b/site/docs/components/accordion/accessibility.mdx
@@ -38,6 +38,6 @@ data:
 </KeyboardControls>
 
 ## Known Issue
-- VoiceOver/Safari on Mac does not report state changes dynamically for Accordion buttons.
+- VoiceOver/Safari on Mac bug: VoiceOver does not report state changes dynamically for Accordion buttons. __(This is not a Salt bug)__
   - Only workaround is to tab away and shift+tab back to this control then it will announce the state.
   - This is reproducible in the [APG accordion example](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/examples/accordion/) as well. 

--- a/site/docs/components/accordion/accessibility.mdx
+++ b/site/docs/components/accordion/accessibility.mdx
@@ -8,8 +8,9 @@ data:
   $ref: ./#/data
 ---
 
+The chevron icon is hidden from screen readers by default. The state is conveyed though aria-expanded.
+
 ## Best practices
-- Hide the chevron icon from screen readers.
 - For assistive technologies, the visible label on a control usually acts as the accessible name. 
   - If modifying the accessible name, the accordion's accessible name must include the visible name (the label).
 - Within a group of accordion headers, all headers should be the same heading level. 

--- a/site/docs/components/accordion/accessibility.mdx
+++ b/site/docs/components/accordion/accessibility.mdx
@@ -8,8 +8,6 @@ data:
   $ref: ./#/data
 ---
 
-The chevron icon is hidden from screen readers by default. The state is conveyed though aria-expanded.
-
 ## Best practices
 - For assistive technologies, the visible label on a control usually acts as the accessible name. 
   - If modifying the accessible name, the accordion's accessible name must include the visible name (the label).

--- a/site/docs/components/accordion/accessibility.mdx
+++ b/site/docs/components/accordion/accessibility.mdx
@@ -9,7 +9,7 @@ data:
 ---
 
 ## Best practices
-- The chevron icon should be hidden from screen readers.
+- Hide the chevron icon from screen readers.
 - For assistive technologies, the visible label on a control usually acts as the accessible name. 
   - If modifying the accessible name, the accordion's accessible name must include the visible name (the label).
 - Within a group of accordion headers, all headers should be the same heading level. 
@@ -39,5 +39,5 @@ data:
 
 ## Known Issue
 - VoiceOver/Safari on Mac does not report state changes dynamically for Accordion buttons.
-  - Only Workaround is to tab away and shift+tab back to this control then it will announce the state.
+  - Only workaround is to tab away and shift+tab back to this control then it will announce the state.
   - This is reproducible in the [APG accordion example](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/examples/accordion/) as well. 

--- a/site/docs/components/accordion/accessibility.mdx
+++ b/site/docs/components/accordion/accessibility.mdx
@@ -8,6 +8,15 @@ data:
   $ref: ./#/data
 ---
 
+## Best practices
+- The chevron icon should be hidden from screen readers.
+- For assistive technologies, the visible label on a control usually acts as the accessible name. 
+  - If modifying the accessible name, the accordion's accessible name must include the visible name (the label).
+- Within a group of accordion headers, all headers should be the same heading level. 
+  - Ensure heading levels align with the overall page hierarchy.
+- Avoid nested accordions. 
+  - Don't put an accordion in another accordion. 
+
 ## Keyboard interactions
 
 <KeyboardControls>
@@ -27,3 +36,8 @@ data:
 
 </KeyboardControl>
 </KeyboardControls>
+
+## Known Issue
+- VoiceOver/Safari on Mac does not report state changes dynamically for Accordion buttons.
+  - Only Workaround is to tab away and shift+tab back to this control then it will announce the state.
+  - This is reproducible in the [APG accordion example](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/examples/accordion/) as well. 

--- a/site/docs/components/accordion/accessibility.mdx
+++ b/site/docs/components/accordion/accessibility.mdx
@@ -9,12 +9,13 @@ data:
 ---
 
 ## Best practices
-- For assistive technologies, the visible label on a control usually acts as the accessible name. 
+
+- For assistive technologies, the visible label on a control usually acts as the accessible name.
   - If modifying the accessible name, the accordion's accessible name must include the visible name (the label).
-- Within a group of accordion headers, all headers should be the same heading level. 
+- Within a group of accordion headers, all headers should be the same heading level.
   - Ensure heading levels align with the overall page hierarchy.
-- Avoid nested accordions. 
-  - Don't put an accordion in another accordion. 
+- Avoid nested accordions.
+  - Don't put an accordion in another accordion.
 
 ## Keyboard interactions
 
@@ -37,6 +38,7 @@ data:
 </KeyboardControls>
 
 ## Known Issue
-- VoiceOver/Safari on Mac bug: VoiceOver does not report state changes dynamically for Accordion buttons. __(This is not a Salt bug)__
+
+- VoiceOver/Safari on Mac bug: VoiceOver does not report state changes dynamically for Accordion buttons. **(This is not a Salt bug)**
   - Only workaround is to tab away and shift+tab back to this control then it will announce the state.
-  - This is reproducible in the [APG accordion example](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/examples/accordion/) as well. 
+  - This is reproducible in the [APG accordion example](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/examples/accordion/) as well.


### PR DESCRIPTION
Adding Known Issue with Safari/VoiceOver - does not report state changes dynamically. (e.g. expanded/collapsed) Not a Salt Bug

Is a Safari/Mac/VoiceOver bug.

Add A11y best practices

Closes issue: https://github.com/jpmorganchase/salt-ds/issues/4814