### PR TITLE
Indication pattern

### DIFF
--- a/packages/core/stories/patterns/indication/indication.stories.tsx
+++ b/packages/core/stories/patterns/indication/indication.stories.tsx
@@ -1,0 +1,117 @@
+import { Button, FlowLayout } from "@salt-ds/core";
+import {
+  ErrorIcon,
+  InfoIcon,
+  ProgressCancelledIcon,
+  ProgressClosedIcon,
+  ProgressCompleteIcon,
+  ProgressDraftIcon,
+  ProgressInprogressIcon,
+  ProgressOnholdIcon,
+  ProgressPendingIcon,
+  ProgressRejectedIcon,
+  ProgressTodoIcon,
+  SuccessCircleIcon,
+  UrgencyHighIcon,
+  UrgencyLowIcon,
+  UrgencyMediumIcon,
+  UrgencyNoneIcon,
+  WarningIcon,
+} from "@salt-ds/icons";
+import type { Meta } from "@storybook/react";
+
+export default {
+  title: "Patterns/Indication",
+} as Meta;
+
+export const Status = () => {
+  return (
+    <FlowLayout>
+      <InfoIcon size={2} style={{ color: "var(--salt-color-blue-500)" }} />
+      <WarningIcon size={2} style={{ color: "var(--salt-color-orange-500)" }} />
+      <ErrorIcon size={2} style={{ color: "var(--salt-color-red-500)" }} />
+      <SuccessCircleIcon
+        size={2}
+        style={{ color: "var(--salt-color-blue-500)" }}
+      />
+    </FlowLayout>
+  );
+};
+
+export const Sentiment = () => {
+  return (
+    <FlowLayout>
+      <Button sentiment="neutral">Neutral</Button>
+      <Button sentiment="accented">Accented</Button>
+      <Button sentiment="caution">Caution</Button>
+      <Button sentiment="negative">Negative</Button>
+      <Button sentiment="positive">Positive</Button>
+    </FlowLayout>
+  );
+};
+
+export const Progression = () => {
+  return (
+    <FlowLayout>
+      <ProgressTodoIcon
+        size={2}
+        style={{ color: "var(--salt-color-gray-500)" }}
+      />
+      <ProgressDraftIcon
+        size={2}
+        style={{ color: "var(--salt-color-gray-500)" }}
+      />
+      <ProgressOnholdIcon
+        size={2}
+        style={{ color: "var(--salt-palette-accent)" }}
+      />
+      <ProgressInprogressIcon
+        size={2}
+        style={{ color: "var(--salt-palette-accent)" }}
+      />
+      <ProgressPendingIcon
+        size={2}
+        style={{ color: "var(--salt-color-orange-500)" }}
+      />
+      <ProgressCancelledIcon
+        size={2}
+        style={{ color: "var(--salt-color-red-500)" }}
+      />
+      <ProgressRejectedIcon
+        size={2}
+        style={{ color: "var(--salt-color-red-500)" }}
+      />
+      <ProgressCompleteIcon
+        size={2}
+        style={{ color: "var(--salt-color-green-500)" }}
+      />
+      <ProgressClosedIcon
+        size={2}
+        style={{ color: "var(--salt-color-green-500)" }}
+      />
+    </FlowLayout>
+  );
+};
+
+export const Urgency = () => {
+  return (
+    <FlowLayout>
+      <UrgencyNoneIcon
+        size={2}
+        style={{ color: "var(--salt-color-gray-500)" }}
+      />
+      <UrgencyLowIcon
+        size={2}
+        style={{ color: "var(--salt-palette-accent)" }}
+      />
+      <UrgencyMediumIcon
+        size={2}
+        style={{ color: "var(--salt-color-orange-500)" }}
+      />
+      <UrgencyHighIcon
+        size={2}
+        style={{ color: "var(--salt-color-red-500)" }}
+      />
+    </FlowLayout>
+  );
+};

--- a/site/docs/patterns/indication.mdx
+++ b/site/docs/patterns/indication.mdx
@@ -1,6 +1,6 @@
 ---
 title: Indication
-description: "The indication pattern provides a starting point for designers to apply common indication scenarios, with consideration for color, iconography and recommended labelling guidelines. "
+description: "The indication pattern provides a starting point for designers to apply common indication scenarios, with consideration for color, iconography and recommended labeling guidelines. "
 layout: DetailPattern
 tags:
   - pattern
@@ -26,9 +26,9 @@ There are four types of indication:
 
 ## Status
 
-Status indicates the state or condition of a system or process. Each status help users understand what’s happening, what actions are needed, and whether any issues need to be addressed.
+Status indicates the state or condition of a system or process. Each status helps users understand what’s happening, what actions are needed, and whether any issues need to be addressed.
 
-The Salt design system includes 4 statuses with associated colors and icons:
+The Salt Design System includes 4 statuses with associated colors and icons:
 
 | Status | Color | Icon | 
 | --- | --- | --- |
@@ -59,7 +59,7 @@ The Salt design system includes 5 sentiments with associated colors:
 
 A progression is a sequence of steps through which a piece of work passes from initiation to completion.
 
-Progression is sequential but does not escalate. Not all steps are mandatory and can be skipped or repeated. Some processes may branch or result in different outcomes. The statuses are usually unique to a particular journey. Some processes may be relatively simple in nature (e.g. To-do, Doing, Done) others more complex, with the possibility of sub-status’ (e.g. In Progress, In Progress - Pending approval, In Progress - Approved). 
+Progression is sequential but does not escalate. Not all steps are mandatory and can be skipped or repeated. Some processes may branch or result in different outcomes. The statuses are usually unique to a particular journey. Some processes may be relatively simple in nature (e.g. To-do, Doing, Done). Others are more complex, with the possibility of sub-status’ (e.g. In Progress, In Progress - Pending approval, In Progress - Approved). 
 
 There are 5 main stages of progression with associated colors and icons:
 
@@ -73,7 +73,7 @@ There are 5 main stages of progression with associated colors and icons:
 - **Alart**: 
     - Pending – An item is being worked on but may be waiting for another process or input
 - **At Risk**: 
-    - Cancelled – An item has been deliberately closed or removed, likely due to a negative circumstance
+    - Canceled – An item has been deliberately closed or removed, likely due to a negative circumstance
     - Rejected – An item has been dismissed or failed, likely due to an error, and requires further action
 - **Complete**: 
     - Completed – An item is finished or ready, and requires no further action
@@ -92,7 +92,7 @@ There are 5 main stages of progression with associated colors and icons:
 
 ## Urgency
 
-Urgency indicates the level of risk associated to an item, process, or entity to be communicated. 
+Urgency indicates the level of risk associated with an item, process or entity to be communicated. 
 
 Urgency levels escalate, but do not have to be followed in a sequence. An item may step through each level, but can also jump between levels depending on its condition. Factors determining urgency include:
 
@@ -104,9 +104,9 @@ There are 5 levels of urgency with associated colors and icons:
 
 - **None**: No urgency or priority level, neutral item with no action required from the user
 - **Low**: Non-priority item with low threat to threshold/deadline, doesn’t require immediate acknowledgement from the user
-- **Medium**: Moderate level of priority nearing threshold/dealine, item can be addressed at a later stage by the user
+- **Medium**: Moderate level of priority nearing threshold/deadline, item can be addressed at a later stage by the user
 - **High**: Nearing threshold/deadline, item to be addressed by user to prevent a more serious outcome in workflow
-- **On Time**: Indicates that the process has begun, but not enough time has elapsed to increase the urgency to "low."
+- **On Time**: Indicates that the process has begun, but not enough time has elapsed to increase the urgency to "low"
 
 
 | Urgency | Color | Icon |

--- a/site/docs/patterns/indication.mdx
+++ b/site/docs/patterns/indication.mdx
@@ -1,0 +1,71 @@
+---
+title: Indication
+description: "The indication pattern provides a starting point for designers to apply common indication scenarios, with consideration for color, iconography and recommended labelling guidelines. "
+layout: DetailPattern
+tags:
+  - pattern
+aliases:
+  - /salt/patterns/indication
+data:
+  resources:
+    [
+      { href: "https://storybook.saltdesignsystem.com/?path=/story/patterns-indication", label: "Examples" }
+    ]
+  components: ["Icon"]
+  showThemeControl: true
+---
+
+## Indication types
+
+There are four types of indication:
+
+- Status
+- Sentiment
+- Progression
+- Urgency
+
+## Status
+
+Status indicates the state or condition of a system or process. Each status help users understand what’s happening, what actions are needed, and whether any issues need to be addressed.
+
+The Salt design system includes 4 statuses with associated colors and icons:
+
+<LivePreview componentName="pattern-indication" exampleName="Status" />
+
+## Sentiment
+
+Sentiment helps guide users through an interface by providing visual cues about potential outcomes. Each sentiment evokes specific feelings such as negativity, carefulness, comfort, trust or positivity.
+
+The Salt design system includes 5 sentiments with associated colors:
+
+<LivePreview componentName="pattern-indication" exampleName="Sentiment" hideCode />
+
+## Progression
+
+A progression is a sequence of steps through which a piece of work passes from initiation to completion.
+
+Progression is sequential but does not escalate. Not all steps are mandatory and can be skipped or repeated. Some processes may branch or result in different outcomes. The statuses are usually unique to a particular journey. Some processes may be relatively simple in nature (e.g. To-do, Doing, Done) others more complex, with the possibility of sub-status’ (e.g. In Progress, In Progress - Pending approval, In Progress - Approved). 
+
+There are 5 main stages of progression with associated colors and icons:
+
+<LivePreview componentName="pattern-indication" exampleName="Progression" hideCode />
+
+## Urgency
+
+Urgency indicates the level of risk associated to an item, process, or entity to be communicated. 
+
+Urgency levels escalate, but do not have to be followed in a sequence. An item may step through each level, but can also jump between levels depending on its condition. Factors determining urgency include:
+
+- Risk
+- Escalation
+- Age
+
+There are 5 levels of urgency with associated colors and icons:
+
+- **None**: No urgency or priority level, neutral item with no action required from the user
+- **Low**: Non-priority item with low threat to threshold/deadline, doesn’t require immediate acknowledgement from the user
+- **Medium**: Moderate level of priority nearing threshold/dealine, item can be addressed at a later stage by the user
+- **High**: Nearing threshold/deadline, item to be addressed by user to prevent a more serious outcome in workflow
+- **On Time**: Indicates that the process has begun, but not enough time has elapsed to increase the urgency to "low."
+
+<LivePreview componentName="pattern-indication" exampleName="Urgency" />

--- a/site/docs/patterns/indication.mdx
+++ b/site/docs/patterns/indication.mdx
@@ -30,6 +30,13 @@ Status indicates the state or condition of a system or process. Each status help
 
 The Salt design system includes 4 statuses with associated colors and icons:
 
+| Status | Color | Icon | 
+| --- | --- | --- |
+| Info | <ColorIndicator fillColor="blue" size={1.5}/> | `InfoIcon` |
+| Warning | <ColorIndicator fillColor="orange" size={1.5}/> | `WarningIcon` |
+| Error | <ColorIndicator fillColor="red" size={1.5}/> | `ErrorIcon` |
+| Success | <ColorIndicator fillColor="green" size={1.5}/> | `SuccessCircleIcon` |
+
 <LivePreview componentName="pattern-indication" exampleName="Status" />
 
 ## Sentiment
@@ -38,7 +45,15 @@ Sentiment helps guide users through an interface by providing visual cues about 
 
 The Salt design system includes 5 sentiments with associated colors:
 
-<LivePreview componentName="pattern-indication" exampleName="Sentiment" hideCode />
+
+| Sentiment | Color | Feeling | 
+| --- | --- | --- |
+| Neutral | <ColorIndicator fillColor="gray" size={1.5}/> | Comfort |
+| Accented | <ColorIndicator fillColor="accent" size={1.5}/> | Trust |
+| Caution | <ColorIndicator fillColor="orange" size={1.5}/> | Carefulness |
+| Negative | <ColorIndicator fillColor="red" size={1.5}/> | Negativity |
+| Positive | <ColorIndicator fillColor="green" size={1.5}/> | Positivity |
+
 
 ## Progression
 
@@ -48,7 +63,32 @@ Progression is sequential but does not escalate. Not all steps are mandatory and
 
 There are 5 main stages of progression with associated colors and icons:
 
-<LivePreview componentName="pattern-indication" exampleName="Progression" hideCode />
+
+- **Static**:
+    - To do – An item that is ready to be picked up or assigned to a user
+    - Draft – An item has been picked up or assigned to a user, and is ready to be worked on/addressed
+- **In Progress**: 
+    - On hold – An item is temporarily not being dealt with and is paused
+    - In progress – An item is actively being worked on/addressed, with no blockers
+- **Alart**: 
+    - Pending – An item is being worked on but may be waiting for another process or input
+- **At Risk**: 
+    - Cancelled – An item has been deliberately closed or removed, likely due to a negative circumstance
+    - Rejected – An item has been dismissed or failed, likely due to an error, and requires further action
+- **Complete**: 
+    - Completed – An item is finished or ready, and requires no further action
+    - Closed – An item is not being actively worked on and does not require further action
+
+
+| Progression | Color | Icon |
+| --- | --- | --- | 
+| Static | <ColorIndicator fillColor="gray" size={1.5}/> | `ProgressTodoIcon` `ProgressDraftIcon` |
+| In Progress | <ColorIndicator fillColor="accent" size={1.5}/> | `ProgressOnhold` `ProgressInprogressIcon` |
+| Alert | <ColorIndicator fillColor="orange" size={1.5}/> | `ProgressPending` |
+| At Risk | <ColorIndicator fillColor="red" size={1.5}/> | `ProgressCancelledIcon` `ProgressRejectedIcon` |
+| Complete | <ColorIndicator fillColor="green" size={1.5}/> | `ProgressCompleteIcon` `ProgressClosedIcon` |
+
+<LivePreview componentName="pattern-indication" exampleName="Progression" />
 
 ## Urgency
 
@@ -67,5 +107,14 @@ There are 5 levels of urgency with associated colors and icons:
 - **Medium**: Moderate level of priority nearing threshold/dealine, item can be addressed at a later stage by the user
 - **High**: Nearing threshold/deadline, item to be addressed by user to prevent a more serious outcome in workflow
 - **On Time**: Indicates that the process has begun, but not enough time has elapsed to increase the urgency to "low."
+
+
+| Urgency | Color | Icon |
+| --- | --- | --- | 
+| None | <ColorIndicator fillColor="gray" size={1.5}/> | `UrgencyNoneIcon` |
+| Low | <ColorIndicator fillColor="accent" size={1.5}/> | `UrgencyLowIcon` |
+| Medium | <ColorIndicator fillColor="orange" size={1.5}/> | `UrgencyMediumIcon` |
+| High | <ColorIndicator fillColor="red" size={1.5}/> | `UrgencyHighIcon` |
+| On Time | <ColorIndicator fillColor="green" size={1.5}/> | Icon TBD |
 
 <LivePreview componentName="pattern-indication" exampleName="Urgency" />

--- a/site/src/components/components/LivePreview.tsx
+++ b/site/src/components/components/LivePreview.tsx
@@ -18,11 +18,13 @@ import styles from "./LivePreview.module.css";
 type LivePreviewProps = {
   componentName: string;
   exampleName: string;
+  hideCode?: boolean;
 };
 
 export const LivePreview: FC<LivePreviewProps> = ({
   componentName,
   exampleName,
+  hideCode,
 }) => {
   const siteMode = useColorMode();
   const [showCode, setShowCode] = useState<boolean>(false);
@@ -85,35 +87,38 @@ export const LivePreview: FC<LivePreviewProps> = ({
                 </ChosenSaltProvider>
               </div>
             </ChosenSaltProvider>
-            <SaltProviderNext density="medium" applyClassesTo="child">
-              <div className={styles.toolbar}>
-                <Switch
-                  checked={showCode}
-                  onChange={handleShowCodeToggle}
-                  className={styles.switch}
-                  label="Show code"
-                  aria-controls={panelId}
-                />
-              </div>
-            </SaltProviderNext>
+            {!hideCode && (
+              <SaltProviderNext density="medium" applyClassesTo="child">
+                <div className={styles.toolbar}>
+                  <Switch
+                    checked={showCode}
+                    onChange={handleShowCodeToggle}
+                    className={styles.switch}
+                    label="Show code"
+                    aria-controls={panelId}
+                  />
+                </div>
+              </SaltProviderNext>
+            )}
           </div>
         </LocalizationProvider>
       </div>
-
-      <div
-        className={styles.codePanel}
-        aria-hidden={!showCode}
-        hidden={!showCode}
-        id={panelId}
-      >
-        <div className={styles.codePanelInner}>
-          <Pre className={styles.codePreview}>
-            <div className="language-tsx">
-              {ComponentExample.sourceCode.trimEnd()}
-            </div>
-          </Pre>
+      {!hideCode && (
+        <div
+          className={styles.codePanel}
+          aria-hidden={!showCode}
+          hidden={!showCode}
+          id={panelId}
+        >
+          <div className={styles.codePanelInner}>
+            <Pre className={styles.codePreview}>
+              <div className="language-tsx">
+                {ComponentExample.sourceCode.trimEnd()}
+              </div>
+            </Pre>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/site/src/components/components/LivePreview.tsx
+++ b/site/src/components/components/LivePreview.tsx
@@ -18,13 +18,11 @@ import styles from "./LivePreview.module.css";
 type LivePreviewProps = {
   componentName: string;
   exampleName: string;
-  hideCode?: boolean;
 };
 
 export const LivePreview: FC<LivePreviewProps> = ({
   componentName,
   exampleName,
-  hideCode,
 }) => {
   const siteMode = useColorMode();
   const [showCode, setShowCode] = useState<boolean>(false);
@@ -87,38 +85,34 @@ export const LivePreview: FC<LivePreviewProps> = ({
                 </ChosenSaltProvider>
               </div>
             </ChosenSaltProvider>
-            {!hideCode && (
-              <SaltProviderNext density="medium" applyClassesTo="child">
-                <div className={styles.toolbar}>
-                  <Switch
-                    checked={showCode}
-                    onChange={handleShowCodeToggle}
-                    className={styles.switch}
-                    label="Show code"
-                    aria-controls={panelId}
-                  />
-                </div>
-              </SaltProviderNext>
-            )}
+            <SaltProviderNext density="medium" applyClassesTo="child">
+              <div className={styles.toolbar}>
+                <Switch
+                  checked={showCode}
+                  onChange={handleShowCodeToggle}
+                  className={styles.switch}
+                  label="Show code"
+                  aria-controls={panelId}
+                />
+              </div>
+            </SaltProviderNext>
           </div>
         </LocalizationProvider>
       </div>
-      {!hideCode && (
-        <div
-          className={styles.codePanel}
-          aria-hidden={!showCode}
-          hidden={!showCode}
-          id={panelId}
-        >
-          <div className={styles.codePanelInner}>
-            <Pre className={styles.codePreview}>
-              <div className="language-tsx">
-                {ComponentExample.sourceCode.trimEnd()}
-              </div>
-            </Pre>
-          </div>
+      <div
+        className={styles.codePanel}
+        aria-hidden={!showCode}
+        hidden={!showCode}
+        id={panelId}
+      >
+        <div className={styles.codePanelInner}>
+          <Pre className={styles.codePreview}>
+            <div className="language-tsx">
+              {ComponentExample.sourceCode.trimEnd()}
+            </div>
+          </Pre>
         </div>
-      )}
+      </div>
     </div>
   );
 };

--- a/site/src/components/components/ThemeControls.module.css
+++ b/site/src/components/components/ThemeControls.module.css
@@ -1,0 +1,8 @@
+.toggleGroup.toggleGroup {
+  width: 100%;
+}
+
+.toggleGroup.toggleGroup button {
+  width: unset;
+  flex: 1;
+}

--- a/site/src/components/components/ThemeControls.tsx
+++ b/site/src/components/components/ThemeControls.tsx
@@ -1,0 +1,64 @@
+import {
+  StackLayout,
+  Text,
+  ToggleButton,
+  ToggleButtonGroup,
+} from "@salt-ds/core";
+import { useLivePreviewControls } from "./LivePreviewProvider";
+import styles from "./ThemeControls.module.css";
+
+export function ThemeControls() {
+  const { density, mode, theme, setDensity, setMode, setTheme } =
+    useLivePreviewControls();
+
+  return (
+    <StackLayout gap={1} padding={{ md: 1 }}>
+      <StackLayout gap={0.75} align="baseline" padding={0}>
+        <Text styleAs="label" color="secondary">
+          <strong>Density</strong>
+        </Text>
+        <ToggleButtonGroup
+          className={styles.toggleGroup}
+          aria-label="Select density"
+          value={density}
+          onChange={(event) => setDensity(event.currentTarget.value as any)}
+        >
+          <ToggleButton value="high">High</ToggleButton>
+          <ToggleButton value="medium">Medium</ToggleButton>
+          <ToggleButton value="low">Low</ToggleButton>
+          <ToggleButton value="touch">Touch</ToggleButton>
+        </ToggleButtonGroup>
+      </StackLayout>
+      <StackLayout gap={0.75} align="baseline" padding={0}>
+        <Text styleAs="label" color="secondary">
+          <strong>Mode</strong>
+        </Text>
+        <ToggleButtonGroup
+          className={styles.toggleGroup}
+          aria-label="Select mode"
+          onChange={(event) => setMode(event.currentTarget.value as any)}
+          value={mode}
+        >
+          <ToggleButton value="system">System</ToggleButton>
+          <ToggleButton value="light">Light</ToggleButton>
+          <ToggleButton value="dark">Dark</ToggleButton>
+        </ToggleButtonGroup>
+      </StackLayout>
+      <StackLayout gap={0.75} align="baseline" padding={0}>
+        <Text styleAs="label" color="secondary">
+          <strong>Themes</strong>
+        </Text>
+
+        <ToggleButtonGroup
+          className={styles.toggleGroup}
+          aria-label="Select themes"
+          onChange={(event) => setTheme(event.currentTarget.value as any)}
+          value={theme}
+        >
+          <ToggleButton value="legacy">Legacy</ToggleButton>
+          <ToggleButton value="brand">JPM Brand</ToggleButton>
+        </ToggleButtonGroup>
+      </StackLayout>
+    </StackLayout>
+  );
+}

--- a/site/src/components/patterns/ColorIndicator.tsx
+++ b/site/src/components/patterns/ColorIndicator.tsx
@@ -1,0 +1,23 @@
+import { FlexLayout, Text, capitalize } from "@salt-ds/core";
+import { Icon, type IconProps } from "@salt-ds/icons";
+
+const COLORS = ["blue", "orange", "red", "green", "gray", "accent"] as const;
+const getToken = (color: (typeof COLORS)[number]) => {
+  return color === "accent"
+    ? "var(--salt-palette-accent)"
+    : `var(--salt-color-${color}-500)`;
+};
+
+export const ColorIndicator = ({
+  fillColor,
+  ...restProps
+}: { fillColor: (typeof COLORS)[number] } & IconProps) => {
+  return (
+    <FlexLayout gap={0.5} align="center">
+      <Icon viewBox="0 0 24 24" fill="none" aria-hidden {...restProps}>
+        <circle cx="12" cy="12" r="12" fill={getToken(fillColor)} />
+      </Icon>
+      <Text>{capitalize(fillColor)}</Text>
+    </FlexLayout>
+  );
+};

--- a/site/src/components/patterns/index.ts
+++ b/site/src/components/patterns/index.ts
@@ -1,1 +1,2 @@
 export * from "./OverviewList";
+export * from "./ColorIndicator";

--- a/site/src/examples/pattern-indication/PatternIndication.module.css
+++ b/site/src/examples/pattern-indication/PatternIndication.module.css
@@ -1,0 +1,3 @@
+.valueCell {
+  padding: var(--grid-cell-padding);
+}

--- a/site/src/examples/pattern-indication/Progression.tsx
+++ b/site/src/examples/pattern-indication/Progression.tsx
@@ -1,16 +1,19 @@
-import { StackLayout } from "@salt-ds/core";
-import { Grid, type GridCellValueProps, GridColumn } from "@salt-ds/data-grid";
+import { Code, FlexLayout, FlowLayout, StackLayout } from "@salt-ds/core";
+import type { GridCellValueProps } from "@salt-ds/data-grid";
 import {
   type IconProps,
+  ProgressCancelledIcon,
+  ProgressClosedIcon,
+  ProgressCompleteIcon,
   ProgressDraftIcon,
+  ProgressInprogressIcon,
+  ProgressOnholdIcon,
+  ProgressPendingIcon,
+  ProgressRejectedIcon,
   ProgressTodoIcon,
 } from "@salt-ds/icons";
 import type { FC } from "react";
-import {
-  ColorCellValue,
-  type ColorValueCellProps,
-  IconDisplay,
-} from "./ValueCells";
+import { type ColorValueCellProps, IconDisplay } from "./ValueCells";
 
 type ProgressionData = {
   progression: string;
@@ -56,35 +59,71 @@ const IconValueCell = (props: GridCellValueProps<ProgressionData>) => {
 
 export const Progression = () => {
   return (
-    <Grid
-      rowData={data}
-      rowKeyGetter={rowIdGetter}
-      zebra={false}
-      style={{
-        width: "var(--grid-total-width)",
-        height: "var(--grid-total-height)",
-      }}
-    >
-      <GridColumn
-        name="Progression"
-        id="progression"
-        defaultWidth={100}
-        getValue={(r) => r.progression}
-      />
-      <GridColumn
-        name="Color"
-        id="color"
-        defaultWidth={120}
-        getValue={(r) => r.color}
-        cellValueComponent={ColorCellValue}
-      />
-      <GridColumn
-        name="Icon"
-        id="icon"
-        defaultWidth={150}
-        getValue={(r) => r.progression}
-        cellValueComponent={IconValueCell}
-      />
-    </Grid>
+    <FlowLayout>
+      <FlexLayout gap={0.5} align="center">
+        <ProgressTodoIcon
+          size={2}
+          style={{ color: "var(--salt-color-gray-500)" }}
+        />
+        <Code>progress-todo</Code>
+      </FlexLayout>
+
+      <FlexLayout gap={0.5} align="center">
+        <ProgressDraftIcon
+          size={2}
+          style={{ color: "var(--salt-color-gray-500)" }}
+        />
+        <Code>progress-draft</Code>
+      </FlexLayout>
+      <FlexLayout gap={0.5} align="center">
+        <ProgressOnholdIcon
+          size={2}
+          style={{ color: "var(--salt-palette-accent)" }}
+        />
+        <Code>progress-onhold</Code>
+      </FlexLayout>
+      <FlexLayout gap={0.5} align="center">
+        <ProgressInprogressIcon
+          size={2}
+          style={{ color: "var(--salt-palette-accent)" }}
+        />
+        <Code>progress-inprogress</Code>
+      </FlexLayout>
+      <FlexLayout gap={0.5} align="center">
+        <ProgressPendingIcon
+          size={2}
+          style={{ color: "var(--salt-color-orange-500)" }}
+        />
+        <Code>progress-pending</Code>
+      </FlexLayout>
+      <FlexLayout gap={0.5} align="center">
+        <ProgressCancelledIcon
+          size={2}
+          style={{ color: "var(--salt-color-red-500)" }}
+        />
+        <Code>progress-cancelled</Code>
+      </FlexLayout>
+      <FlexLayout gap={0.5} align="center">
+        <ProgressRejectedIcon
+          size={2}
+          style={{ color: "var(--salt-color-red-500)" }}
+        />
+        <Code>progress-rejected</Code>
+      </FlexLayout>
+      <FlexLayout gap={0.5} align="center">
+        <ProgressCompleteIcon
+          size={2}
+          style={{ color: "var(--salt-color-green-500)" }}
+        />
+        <Code>progress-complete</Code>
+      </FlexLayout>
+      <FlexLayout gap={0.5} align="center">
+        <ProgressClosedIcon
+          size={2}
+          style={{ color: "var(--salt-color-green-500)" }}
+        />
+        <Code>progress-closed</Code>
+      </FlexLayout>
+    </FlowLayout>
   );
 };

--- a/site/src/examples/pattern-indication/Progression.tsx
+++ b/site/src/examples/pattern-indication/Progression.tsx
@@ -1,0 +1,90 @@
+import { StackLayout } from "@salt-ds/core";
+import { Grid, type GridCellValueProps, GridColumn } from "@salt-ds/data-grid";
+import {
+  type IconProps,
+  ProgressDraftIcon,
+  ProgressTodoIcon,
+} from "@salt-ds/icons";
+import type { FC } from "react";
+import {
+  ColorCellValue,
+  type ColorValueCellProps,
+  IconDisplay,
+} from "./ValueCells";
+
+type ProgressionData = {
+  progression: string;
+  icons: { name: string; ExampleIcon: FC<IconProps> }[];
+  usage: string[];
+} & ColorValueCellProps;
+
+const data = [
+  {
+    progression: "Static",
+    color: "gray",
+    icons: [
+      { name: "progress-todo", ExampleIcon: ProgressTodoIcon },
+      { name: "progress-draft", ExampleIcon: ProgressDraftIcon },
+    ],
+    usage: [
+      "To do – An item that is ready to be picked up or assigned to a user",
+      "Draft – An item has been picked up or assigned to a user, and is ready to be worked on/addressed",
+    ],
+  },
+] satisfies ProgressionData[];
+
+const rowIdGetter = (row: ProgressionData) => row.progression;
+
+const IconValueCell = (props: GridCellValueProps<ProgressionData>) => {
+  const { row } = props;
+
+  const { color, icons } = row.data;
+
+  return (
+    <StackLayout gap={1}>
+      {icons.map(({ ExampleIcon, name }) => (
+        <IconDisplay
+          iconName={name}
+          ExampleIcon={ExampleIcon}
+          color={color}
+          key={name}
+        />
+      ))}
+    </StackLayout>
+  );
+};
+
+export const Progression = () => {
+  return (
+    <Grid
+      rowData={data}
+      rowKeyGetter={rowIdGetter}
+      zebra={false}
+      style={{
+        width: "var(--grid-total-width)",
+        height: "var(--grid-total-height)",
+      }}
+    >
+      <GridColumn
+        name="Progression"
+        id="progression"
+        defaultWidth={100}
+        getValue={(r) => r.progression}
+      />
+      <GridColumn
+        name="Color"
+        id="color"
+        defaultWidth={120}
+        getValue={(r) => r.color}
+        cellValueComponent={ColorCellValue}
+      />
+      <GridColumn
+        name="Icon"
+        id="icon"
+        defaultWidth={150}
+        getValue={(r) => r.progression}
+        cellValueComponent={IconValueCell}
+      />
+    </Grid>
+  );
+};

--- a/site/src/examples/pattern-indication/Progression.tsx
+++ b/site/src/examples/pattern-indication/Progression.tsx
@@ -31,7 +31,7 @@ const data = [
       "Draft – An item has been picked up or assigned to a user, and is ready to be worked on/addressed",
     ],
   },
-] satisfies ProgressionData[];
+] as ProgressionData[];
 
 const rowIdGetter = (row: ProgressionData) => row.progression;
 

--- a/site/src/examples/pattern-indication/Sentiment.tsx
+++ b/site/src/examples/pattern-indication/Sentiment.tsx
@@ -1,0 +1,51 @@
+import { Grid, GridColumn } from "@salt-ds/data-grid";
+import { ColorCellValue, type ColorValueCellProps } from "./ValueCells";
+
+type SentimentData = {
+  sentiment: string;
+  feeling: string;
+} & ColorValueCellProps;
+
+const data = [
+  { sentiment: "Neutral", color: "gray", feeling: "Comfort" },
+  { sentiment: "Accented", color: "accent", feeling: "Trust" },
+  { sentiment: "Caution", color: "orange", feeling: "Carefullness" },
+  { sentiment: "Negative", color: "red", feeling: "Negativity" },
+  { sentiment: "Positive", color: "green", feeling: "Positivity" },
+] satisfies SentimentData[];
+
+const rowIdGetter = (row: SentimentData) => row.sentiment;
+
+export const Sentiment = () => {
+  return (
+    <Grid
+      rowData={data}
+      rowKeyGetter={rowIdGetter}
+      zebra={false}
+      style={{
+        width: "var(--grid-total-width)",
+        height: "var(--grid-total-height)",
+      }}
+    >
+      <GridColumn
+        name="Sentiment"
+        id="sentiment"
+        defaultWidth={100}
+        getValue={(r) => r.sentiment}
+      />
+      <GridColumn
+        name="Color"
+        id="color"
+        defaultWidth={120}
+        getValue={(r) => r.color}
+        cellValueComponent={ColorCellValue}
+      />
+      <GridColumn
+        name="Feeling"
+        id="feeling"
+        defaultWidth={150}
+        getValue={(r) => r.feeling}
+      />
+    </Grid>
+  );
+};

--- a/site/src/examples/pattern-indication/Sentiment.tsx
+++ b/site/src/examples/pattern-indication/Sentiment.tsx
@@ -12,7 +12,7 @@ const data = [
   { sentiment: "Caution", color: "orange", feeling: "Carefullness" },
   { sentiment: "Negative", color: "red", feeling: "Negativity" },
   { sentiment: "Positive", color: "green", feeling: "Positivity" },
-] satisfies SentimentData[];
+] as SentimentData[];
 
 const rowIdGetter = (row: SentimentData) => row.sentiment;
 

--- a/site/src/examples/pattern-indication/Status.tsx
+++ b/site/src/examples/pattern-indication/Status.tsx
@@ -27,9 +27,8 @@ export const Status = () => {
       <FlexLayout gap={0.5} align="center">
         <SuccessCircleIcon
           size={2}
-          style={{ color: "var(--salt-color-blue-500)" }}
+          style={{ color: "var(--salt-color-green-500)" }}
         />
-
         <Code>success-circle</Code>
       </FlexLayout>
     </FlowLayout>

--- a/site/src/examples/pattern-indication/Status.tsx
+++ b/site/src/examples/pattern-indication/Status.tsx
@@ -1,0 +1,37 @@
+import { Code, FlexLayout, FlowLayout } from "@salt-ds/core";
+import {
+  ErrorIcon,
+  InfoIcon,
+  SuccessCircleIcon,
+  WarningIcon,
+} from "@salt-ds/icons";
+
+export const Status = () => {
+  return (
+    <FlowLayout>
+      <FlexLayout gap={0.5} align="center">
+        <InfoIcon size={2} style={{ color: "var(--salt-color-blue-500)" }} />
+        <Code>info</Code>
+      </FlexLayout>
+      <FlexLayout gap={0.5} align="center">
+        <WarningIcon
+          size={2}
+          style={{ color: "var(--salt-color-orange-500)" }}
+        />
+        <Code>warning</Code>
+      </FlexLayout>
+      <FlexLayout gap={0.5} align="center">
+        <ErrorIcon size={2} style={{ color: "var(--salt-color-red-500)" }} />
+        <Code>error</Code>
+      </FlexLayout>
+      <FlexLayout gap={0.5} align="center">
+        <SuccessCircleIcon
+          size={2}
+          style={{ color: "var(--salt-color-blue-500)" }}
+        />
+
+        <Code>success-circle</Code>
+      </FlexLayout>
+    </FlowLayout>
+  );
+};

--- a/site/src/examples/pattern-indication/StatusTable.tsx
+++ b/site/src/examples/pattern-indication/StatusTable.tsx
@@ -30,7 +30,7 @@ const data = [
     iconName: "success-circle",
     ExampleIcon: SuccessCircleIcon,
   },
-] satisfies StatusData[];
+] as StatusData[];
 
 const rowIdGetter = (row: StatusData) => row.status;
 

--- a/site/src/examples/pattern-indication/StatusTable.tsx
+++ b/site/src/examples/pattern-indication/StatusTable.tsx
@@ -1,0 +1,80 @@
+import { Grid, type GridCellValueProps, GridColumn } from "@salt-ds/data-grid";
+import {
+  ErrorIcon,
+  type IconProps,
+  InfoIcon,
+  SuccessCircleIcon,
+  WarningIcon,
+} from "@salt-ds/icons";
+import { ColorCellValue, IconDisplay } from "./ValueCells";
+
+type StatusData = {
+  status: "Info" | "Warning" | "Error" | "Success";
+  color: "blue" | "orange" | "red" | "green" | "gray";
+  iconName: string;
+  ExampleIcon: React.FC<IconProps>;
+};
+
+const data = [
+  { status: "Info", color: "blue", iconName: "info", ExampleIcon: InfoIcon },
+  {
+    status: "Warning",
+    color: "orange",
+    iconName: "warning",
+    ExampleIcon: WarningIcon,
+  },
+  { status: "Error", color: "red", iconName: "error", ExampleIcon: ErrorIcon },
+  {
+    status: "Success",
+    color: "green",
+    iconName: "success-circle",
+    ExampleIcon: SuccessCircleIcon,
+  },
+] satisfies StatusData[];
+
+const rowIdGetter = (row: StatusData) => row.status;
+
+const IconValueCell = (props: GridCellValueProps<StatusData>) => {
+  const { row } = props;
+
+  const { iconName, ExampleIcon, color } = row.data;
+
+  return (
+    <IconDisplay iconName={iconName} ExampleIcon={ExampleIcon} color={color} />
+  );
+};
+
+export const StatusTable = () => {
+  return (
+    <Grid
+      rowData={data}
+      rowKeyGetter={rowIdGetter}
+      zebra={false}
+      style={{
+        width: "var(--grid-total-width)",
+        height: "var(--grid-total-height)",
+      }}
+    >
+      <GridColumn
+        name="Status"
+        id="status"
+        defaultWidth={100}
+        getValue={(r) => r.status}
+      />
+      <GridColumn
+        name="Color"
+        id="color"
+        defaultWidth={120}
+        getValue={(r) => r.color}
+        cellValueComponent={ColorCellValue}
+      />
+      <GridColumn
+        name="Icon"
+        id="icon"
+        defaultWidth={150}
+        getValue={(r) => r.iconName}
+        cellValueComponent={IconValueCell}
+      />
+    </Grid>
+  );
+};

--- a/site/src/examples/pattern-indication/Urgency.tsx
+++ b/site/src/examples/pattern-indication/Urgency.tsx
@@ -32,7 +32,7 @@ export const Urgency = () => {
       <FlexLayout gap={0.5} align="center">
         <UrgencyMediumIcon
           size={2}
-          style={{ color: "var(--salt-color-warning-500)" }}
+          style={{ color: "var(--salt-color-orange-500)" }}
         />
         <Code>urgency-medium</Code>
       </FlexLayout>

--- a/site/src/examples/pattern-indication/Urgency.tsx
+++ b/site/src/examples/pattern-indication/Urgency.tsx
@@ -1,0 +1,49 @@
+import { Code, FlexLayout, FlowLayout, useTheme } from "@salt-ds/core";
+import {
+  UrgencyHighIcon,
+  UrgencyLowIcon,
+  UrgencyMediumIcon,
+  UrgencyNoneIcon,
+} from "@salt-ds/icons";
+
+export const Urgency = () => {
+  const { themeNext } = useTheme();
+
+  return (
+    <FlowLayout>
+      <FlexLayout gap={0.5} align="center">
+        <UrgencyNoneIcon
+          size={2}
+          style={{ color: "var(--salt-color-gray-500)" }}
+        />
+        <Code>urgency-none</Code>
+      </FlexLayout>
+      <FlexLayout gap={0.5} align="center">
+        <UrgencyLowIcon
+          size={2}
+          style={{
+            color: themeNext
+              ? "var(--salt-palette-accent)"
+              : "var(--salt-color-blue-500)",
+          }}
+        />
+        <Code>urgency-low</Code>
+      </FlexLayout>
+      <FlexLayout gap={0.5} align="center">
+        <UrgencyMediumIcon
+          size={2}
+          style={{ color: "var(--salt-color-warning-500)" }}
+        />
+        <Code>urgency-medium</Code>
+      </FlexLayout>
+      <FlexLayout gap={0.5} align="center">
+        <UrgencyHighIcon
+          size={2}
+          style={{ color: "var(--salt-color-red-500)" }}
+        />
+
+        <Code>urgency-high</Code>
+      </FlexLayout>
+    </FlowLayout>
+  );
+};

--- a/site/src/examples/pattern-indication/ValueCells.tsx
+++ b/site/src/examples/pattern-indication/ValueCells.tsx
@@ -1,0 +1,56 @@
+import { FlexLayout, capitalize } from "@salt-ds/core";
+import type { GridCellValueProps } from "@salt-ds/data-grid";
+import { Icon, type IconProps } from "@salt-ds/icons";
+import type { FC } from "react";
+import styles from "./PatternIndication.module.css";
+
+export type ColorValueCellProps = {
+  color: "blue" | "orange" | "red" | "green" | "gray" | "accent";
+};
+
+const DotIcon = ({ fill, ...restProps }: { fill: string } & IconProps) => (
+  <Icon viewBox="0 0 24 24" fill="none" {...restProps}>
+    <circle cx="12" cy="12" r="12" fill={fill} />
+  </Icon>
+);
+
+export const getIconColor = (color: ColorValueCellProps["color"]) => {
+  return color === "accent"
+    ? "var(--salt-palette-accent)"
+    : `var(--salt-color-${color}-500)`;
+};
+
+export const ColorCellValue = (
+  props: GridCellValueProps<ColorValueCellProps>,
+) => {
+  const { row } = props;
+
+  const { color } = row.data;
+
+  const fillColor = getIconColor(color);
+
+  return (
+    <FlexLayout gap={0.5} align="center" className={styles.valueCell}>
+      <DotIcon fill={fillColor} size={1.5} />
+      <span>{capitalize(color)}</span>
+    </FlexLayout>
+  );
+};
+
+export const IconDisplay = (props: {
+  iconName: string;
+  ExampleIcon: FC<IconProps>;
+  color: ColorValueCellProps["color"];
+}) => {
+  const { ExampleIcon, color, iconName } = props;
+
+  return (
+    <FlexLayout gap={0.5} align="center" className={styles.valueCell}>
+      <ExampleIcon
+        style={{ color: `var(--salt-color-${color}-500)` }}
+        size={1.5}
+      />
+      <code>{iconName}</code>
+    </FlexLayout>
+  );
+};

--- a/site/src/examples/pattern-indication/index.ts
+++ b/site/src/examples/pattern-indication/index.ts
@@ -1,0 +1,5 @@
+export * from "./Status";
+export * from "./StatusTable";
+export * from "./Sentiment";
+export * from "./Progression";
+export * from "./Urgency";

--- a/site/src/layouts/DetailComponent/ComponentPageHeading.tsx
+++ b/site/src/layouts/DetailComponent/ComponentPageHeading.tsx
@@ -6,83 +6,20 @@ import {
   OverlayPanel,
   OverlayPanelContent,
   OverlayTrigger,
-  StackLayout,
   Tag,
   Text,
-  ToggleButton,
-  ToggleButtonGroup,
 } from "@salt-ds/core";
 import { GithubIcon, SettingsSolidIcon } from "@salt-ds/icons";
 import dynamic from "next/dynamic";
+import { ThemeControls } from "../../components/components/ThemeControls";
 import { CTALink } from "../../components/cta-link/CTALink";
-import { useLivePreviewControls } from "../../components/index";
 import { LinkBase } from "../../components/link/Link";
 import type { PageHeadingProps } from "../Base/PageHeading";
 import headingStyles from "./ComponentPageHeading.module.css";
 import type { CustomSiteState } from "./DetailComponent";
 import styles from "./DetailComponent.module.css";
 
-function ThemeControls() {
-  const { density, mode, theme, setDensity, setMode, setTheme } =
-    useLivePreviewControls();
-
-  return (
-    <StackLayout gap={1} padding={{ md: 1 }}>
-      <StackLayout gap={0.75} align="baseline" padding={0}>
-        <Text styleAs="label" color="secondary">
-          <strong>Density</strong>
-        </Text>
-        <ToggleButtonGroup
-          className={styles.toggleGroup}
-          aria-label="Select density"
-          value={density}
-          onChange={(event) => setDensity(event.currentTarget.value as any)}
-        >
-          <ToggleButton value="high">High</ToggleButton>
-          <ToggleButton value="medium">Medium</ToggleButton>
-          <ToggleButton value="low">Low</ToggleButton>
-          <ToggleButton value="touch">Touch</ToggleButton>
-        </ToggleButtonGroup>
-      </StackLayout>
-      <StackLayout gap={0.75} align="baseline" padding={0}>
-        <Text styleAs="label" color="secondary">
-          <strong>Mode</strong>
-        </Text>
-        <ToggleButtonGroup
-          className={styles.toggleGroup}
-          aria-label="Select mode"
-          onChange={(event) => setMode(event.currentTarget.value as any)}
-          value={mode}
-        >
-          <ToggleButton value="system">System</ToggleButton>
-          <ToggleButton value="light">Light</ToggleButton>
-          <ToggleButton value="dark">Dark</ToggleButton>
-        </ToggleButtonGroup>
-      </StackLayout>
-      <StackLayout gap={0.75} align="baseline" padding={0}>
-        <Text styleAs="label" color="secondary">
-          <strong>Themes</strong>
-        </Text>
-
-        <ToggleButtonGroup
-          className={styles.toggleGroup}
-          aria-label="Select themes"
-          onChange={(event) => setTheme(event.currentTarget.value as any)}
-          value={theme}
-        >
-          <ToggleButton value="legacy">Legacy</ToggleButton>
-          <ToggleButton value="brand">JPM Brand</ToggleButton>
-        </ToggleButtonGroup>
-      </StackLayout>
-    </StackLayout>
-  );
-}
-
 const Markdown = dynamic(import("../../components/markdown/Markdown"));
-
-const statusMapToCategory = {
-  "Lab component": 11,
-};
 
 export default function ComponentPageHeading({ title, id }: PageHeadingProps) {
   const {

--- a/site/src/layouts/DetailComponent/DetailComponent.module.css
+++ b/site/src/layouts/DetailComponent/DetailComponent.module.css
@@ -16,15 +16,6 @@
   gap: var(--salt-spacing-100);
 }
 
-.toggleGroup.toggleGroup {
-  width: 100%;
-}
-
-.toggleGroup.toggleGroup button {
-  width: unset;
-  flex: 1;
-}
-
 .overlay {
   max-width: 100vw;
 }

--- a/site/src/layouts/DetailPattern/DetailPattern.module.css
+++ b/site/src/layouts/DetailPattern/DetailPattern.module.css
@@ -5,4 +5,7 @@
 
 .headingActions {
   margin-top: var(--salt-spacing-200);
+  display: flex;
+  flex-direction: row;
+  gap: var(--salt-spacing-100);
 }

--- a/site/src/layouts/DetailPattern/DetailPattern.tsx
+++ b/site/src/layouts/DetailPattern/DetailPattern.tsx
@@ -1,6 +1,16 @@
 import type { LayoutProps } from "@jpmorganchase/mosaic-layouts/dist/types";
 import { type SiteState, useStore } from "@jpmorganchase/mosaic-store";
+import {
+  Button,
+  Overlay,
+  OverlayPanel,
+  OverlayPanelContent,
+  OverlayTrigger,
+} from "@salt-ds/core";
+import { SettingsSolidIcon } from "@salt-ds/icons";
 import type { FC } from "react";
+import { LivePreviewProvider } from "../../components";
+import { ThemeControls } from "../../components/components/ThemeControls";
 import { CTALink } from "../../components/cta-link/CTALink";
 import { Image } from "../../components/mdx/image";
 import { PageNavigation } from "../../components/navigation/PageNavigation";
@@ -22,6 +32,7 @@ type ResourcesArray = {
 
 type Data = {
   resources: ResourcesArray;
+  showThemeControl?: boolean;
 };
 
 type CustomSiteState = SiteState & { data?: Data };
@@ -33,6 +44,8 @@ function PatternPageHeading({
 }: PageHeadingProps): JSX.Element {
   const resourcesArray =
     useStore((state: CustomSiteState) => state.data?.resources) ?? [];
+  const showThemeControl =
+    useStore((state: CustomSiteState) => state.data?.showThemeControl) ?? false;
 
   const exampleLink = resourcesArray.filter((resource) =>
     resource.href.startsWith("https://storybook.saltdesignsystem.com"),
@@ -51,6 +64,24 @@ function PatternPageHeading({
             <Image src="/img/storybook_logo.svg" alt={""} aria-hidden /> View
             Example
           </CTALink>
+        )}
+        {showThemeControl && (
+          <Overlay>
+            <OverlayTrigger>
+              <Button
+                sentiment="neutral"
+                appearance="bordered"
+                aria-label="Theme Controls"
+              >
+                <SettingsSolidIcon aria-hidden />
+              </Button>
+            </OverlayTrigger>
+            <OverlayPanel className={styles.overlay}>
+              <OverlayPanelContent>
+                <ThemeControls />
+              </OverlayPanelContent>
+            </OverlayPanel>
+          </Overlay>
         )}
       </div>
     </PageHeading>
@@ -74,12 +105,14 @@ export const DetailPattern: FC<LayoutProps> = ({ children }) => {
   );
 
   return (
-    <Base
-      LeftSidebar={LeftSidebar}
-      RightSidebar={RightSidebar}
-      Heading={PatternPageHeading}
-    >
-      {children}
-    </Base>
+    <LivePreviewProvider>
+      <Base
+        LeftSidebar={LeftSidebar}
+        RightSidebar={RightSidebar}
+        Heading={PatternPageHeading}
+      >
+        {children}
+      </Base>
+    </LivePreviewProvider>
   );
 };


### PR DESCRIPTION
Made some changes to [Figma](https://www.figma.com/design/p6aJv3hER4wRSQrU2poDtj/Indication-Pattern-(DS)?node-id=1-1591&m=dev). Preview [link to page](https://saltdesignsystem-git-3852-indication-pattern-fed-team.vercel.app/salt/patterns/indication).

- Table with very long text doesn't work out nicely on site layout. Breakout usage guidance on top of table
- Does not support 2 colored dots in the table
- Added inline code example as well as storybook (can be removed when general layout be updated)
- Added same theme switch panel from component pages, so icon examples can be toggled between 2 themes

#3852