### PR TITLE
Investigate Ag grid theme performance

### DIFF
--- a/packages/ag-grid-theme/css/parts/ag-body.css
+++ b/packages/ag-grid-theme/css/parts/ag-body.css
@@ -1,15 +1,15 @@
 /* ROW */
 
-div[class*="ag-theme-salt"] .ag-row {
+.ag-row {
   font-size: var(--salt-text-fontSize);
 }
 
-div[class*="ag-theme-salt"] .ag-row-selected {
+.ag-row-selected {
   background-color: var(--salt-selectable-background-selected);
   border-color: var(--salt-selectable-borderColor-selected);
 }
 
-div[class*="ag-theme-salt"] .ag-row-selected:before {
+.ag-row-selected:before {
   background-color: var(--salt-selectable-borderColor-selected);
   background-image: none;
   height: var(--salt-size-border);
@@ -18,15 +18,15 @@ div[class*="ag-theme-salt"] .ag-row-selected:before {
 
 /* CELL */
 
-div[class*="ag-theme-salt"] .ag-cell.ag-cell-last-left-pinned:not(.ag-cell-range-right):not(.ag-cell-range-single-cell) {
+.ag-cell.ag-cell-last-left-pinned:not(.ag-cell-range-right):not(.ag-cell-range-single-cell) {
   border-right-color: var(--salt-separable-secondary-borderColor);
 }
 
-div[class*="ag-theme-salt"] .ag-cell.ag-cell-first-right-pinned:not(.ag-cell-range-left):not(.ag-cell-range-single-cell) {
+.ag-cell.ag-cell-first-right-pinned:not(.ag-cell-range-left):not(.ag-cell-range-single-cell) {
   border-left-color: var(--salt-separable-secondary-borderColor);
 }
 
-div[class*="ag-theme-salt"] .ag-cell {
+.ag-cell {
   border: none;
   line-height: calc(var(--ag-line-height) - 1px);
   padding-left: var(--salt-spacing-100);
@@ -34,55 +34,55 @@ div[class*="ag-theme-salt"] .ag-cell {
 }
 
 /* This is not restricted to `.editable-cell`, so any custom editor would get the same background treatment */
-div[class*="ag-theme-salt"] .ag-cell-inline-editing:focus-within {
+.ag-cell-inline-editing:focus-within {
   background: var(--salt-container-primary-background);
 }
 
 /* This makes sure custom cell editor would start from no padding. Built-in ag grid editor's padding is added below. */
-div[class*="ag-theme-salt"] .ag-cell-inline-editing {
+.ag-cell-inline-editing {
   padding: 0;
   /* When styling option corner='rounded', we don't want this to be flipped between rounded and not between editing and normal state */
   border-radius: 0;
 }
 
-div[class*="ag-theme-salt"] .ag-cell-inline-editing.editable-cell input[class^="ag-"] {
+.ag-cell-inline-editing.editable-cell input[class^="ag-"] {
   padding: 0 var(--salt-spacing-100);
 }
 
-div[class*="ag-theme-salt"] .editable-cell,
-div[class*="ag-theme-salt"] .editable-numeric-cell {
+.editable-cell,
+.editable-numeric-cell {
   outline: var(--salt-size-border) var(--salt-container-borderStyle) var(--salt-editable-borderColor);
   outline-offset: -1px;
 }
 
-div[class*="ag-theme-salt"] .ag-cell.numeric-cell,
-div[class*="ag-theme-salt"] .editable-numeric-cell {
+.ag-cell.numeric-cell,
+.editable-numeric-cell {
   text-align: right;
 }
 
 /* Special case when user finish editing and click out side of the grid. */
-div[class*="ag-theme-salt"] .ag-cell.numeric-cell.ag-cell-inline-editing .ag-cell-editor input:not(:focus) {
+.ag-cell.numeric-cell.ag-cell-inline-editing .ag-cell-editor input:not(:focus) {
   text-align: right;
 }
 
-div[class*="ag-theme-salt"] .ag-has-focus .ag-cell.ag-cell-focus:not(.ag-cell-range-selected),
-div[class*="ag-theme-salt"] .ag-context-menu-open .ag-cell.ag-cell-focus:not(.ag-cell-range-selected),
-div[class*="ag-theme-salt"] .ag-cell-range-single-cell,
-div[class*="ag-theme-salt"] .ag-cell-range-single-cell.ag-cell-range-handle,
-div[class*="ag-theme-salt"] .ag-cell-focus:not(.ag-cell-range-selected):focus-within {
+.ag-has-focus .ag-cell.ag-cell-focus:not(.ag-cell-range-selected),
+.ag-context-menu-open .ag-cell.ag-cell-focus:not(.ag-cell-range-selected),
+.ag-cell-range-single-cell,
+.ag-cell-range-single-cell.ag-cell-range-handle,
+.ag-cell-focus:not(.ag-cell-range-selected):focus-within {
   outline: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);
   outline-offset: -2px;
   border-width: 0;
 }
 
-div[class*="ag-theme-salt"] .ag-cell-wrapper.ag-row-group {
+.ag-cell-wrapper.ag-row-group {
   align-items: center;
 }
 
-div[class*="ag-theme-salt"] .ag-cell.editable-cell.ag-cell-focus:focus:before,
-div[class*="ag-theme-salt"] .ag-cell.editable-numeric-cell.ag-cell-focus:focus:before,
-div[class*="ag-theme-salt"] .ag-cell.editable-cell.ag-cell-focus:focus-within:before,
-div[class*="ag-theme-salt"] .editable-cell.ag-cell-inline-editing:before {
+.ag-cell.editable-cell.ag-cell-focus:focus:before,
+.ag-cell.editable-numeric-cell.ag-cell-focus:focus:before,
+.ag-cell.editable-cell.ag-cell-focus:focus-within:before,
+.editable-cell.ag-cell-inline-editing:before {
   border-bottom: calc(var(--salt-size-adornment) + 4px) solid transparent;
   border-left: calc(var(--salt-size-adornment) + 4px) solid var(--salt-editable-borderColor-hover);
   border-top: 0 solid transparent;
@@ -93,70 +93,70 @@ div[class*="ag-theme-salt"] .editable-cell.ag-cell-inline-editing:before {
   z-index: 2;
 }
 
-div[class*="ag-theme-salt"] .editable-numeric-cell input,
-div[class*="ag-theme-salt"] input[class^="ag-"][type="number"] {
+.editable-numeric-cell input,
+input[class^="ag-"][type="number"] {
   padding: 0 var(--salt-spacing-100);
   height: calc(var(--salt-size-base) + var(--salt-spacing-100));
 }
 
-div[class*="ag-theme-salt"] .editable-cell input,
-div[class*="ag-theme-salt"] .editable-numeric-cell input {
+.editable-cell input,
+.editable-numeric-cell input {
   border: none;
   background-color: transparent;
 }
 
 /* Ag Large Text Cell Editor  */
-div[class*="ag-theme-salt"] .ag-large-text-input {
+.ag-large-text-input {
   padding: 0;
 }
 
 /* Ag Select Cell Editor - all should be scoped with `.editable-cell` so it's not impacting users not using our class */
 
-div[class*="ag-theme-salt"] .editable-cell .ag-picker-field-wrapper {
+.editable-cell .ag-picker-field-wrapper {
   /* Allow cell focus ring to come through */
   background-color: transparent;
   border: none;
 }
 
-div[class*="ag-theme-salt"] .ag-select .ag-picker-field-wrapper {
+.ag-select .ag-picker-field-wrapper {
   border: var(--salt-size-border) var(--salt-separable-borderStyle) var(--salt-editable-borderColor);
   border-radius: 0;
 }
 
-div[class*="ag-theme-salt"] .ag-ltr .editable-cell .ag-select .ag-picker-field-wrapper,
-div[class*="ag-theme-salt"] .ag-ltr .editable-cell .ag-rich-select .ag-picker-field-wrapper {
+.ag-ltr .editable-cell .ag-select .ag-picker-field-wrapper,
+.ag-ltr .editable-cell .ag-rich-select .ag-picker-field-wrapper {
   padding: 0 var(--salt-spacing-100);
   border-radius: 0;
 }
 
-div[class*="ag-theme-salt"] .ag-ltr .editable-cell .ag-select .ag-icon-small-down::before,
-div[class*="ag-theme-salt"] .ag-ltr .editable-cell .ag-rich-select .ag-icon-small-down::before {
+.ag-ltr .editable-cell .ag-select .ag-icon-small-down::before,
+.ag-ltr .editable-cell .ag-rich-select .ag-icon-small-down::before {
   /* Change the icon to be aligned with Salt chevron instead of triangle */
   /* We are not using different icons between collpase / expand, given only collapsed icon is available in ag salt icon font (.ag-picker-collapsed vs .ag-picker-expanded) */
   content: var(--ag-icon-font-code-contracted);
 }
 
-div[class*="ag-theme-salt"] .ag-ltr .ag-select-list-item,
-div[class*="ag-theme-salt"] .ag-ltr .ag-rich-select-row {
+.ag-ltr .ag-select-list-item,
+.ag-ltr .ag-rich-select-row {
   /* This can't be scoped to editable-cell given it's sitting within .ag-popup */
   padding: 0 var(--salt-spacing-100);
 }
 
-div[class*="ag-theme-salt"] .ag-select-list,
-div[class*="ag-theme-salt"] .ag-rich-select-list {
+.ag-select-list,
+.ag-rich-select-list {
   /* Match border to OptionList */
   border: var(--salt-size-border) var(--salt-selectable-borderStyle-selected) var(--salt-selectable-borderColor-selected);
 }
 
-div[class*="ag-theme-salt"] .ag-select-list-item[aria-selected="true"],
-div[class*="ag-theme-salt"] .ag-rich-select-row-selected {
+.ag-select-list-item[aria-selected="true"],
+.ag-rich-select-row-selected {
   /* Match selected row border to Option */
   box-shadow: inset 0px var(--salt-size-border) 0px var(--salt-selectable-borderColor-selected), inset 0px calc(var(--salt-size-border) * -1) 0px var(--salt-selectable-borderColor-selected);
 }
 
 /* Range selection cross cells "fake" outlines */
 
-div[class*="ag-theme-salt"] .ag-cell.ag-cell-range-selected:not(.ag-cell-range-single-cell).ag-cell-range-top::after {
+.ag-cell.ag-cell-range-selected:not(.ag-cell-range-single-cell).ag-cell-range-top::after {
   content: "";
   top: 0;
   right: 0;
@@ -166,7 +166,7 @@ div[class*="ag-theme-salt"] .ag-cell.ag-cell-range-selected:not(.ag-cell-range-s
   border-top: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);
 }
 
-div[class*="ag-theme-salt"] .ag-cell.ag-cell-range-selected:not(.ag-cell-range-single-cell).ag-cell-range-right::after {
+.ag-cell.ag-cell-range-selected:not(.ag-cell-range-single-cell).ag-cell-range-right::after {
   content: "";
   top: 0;
   right: 0;
@@ -176,7 +176,7 @@ div[class*="ag-theme-salt"] .ag-cell.ag-cell-range-selected:not(.ag-cell-range-s
   border-right: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);
 }
 
-div[class*="ag-theme-salt"] .ag-cell.ag-cell-range-selected:not(.ag-cell-range-single-cell).ag-cell-range-bottom::after {
+.ag-cell.ag-cell-range-selected:not(.ag-cell-range-single-cell).ag-cell-range-bottom::after {
   content: "";
   top: 0;
   right: 0;
@@ -186,7 +186,7 @@ div[class*="ag-theme-salt"] .ag-cell.ag-cell-range-selected:not(.ag-cell-range-s
   border-bottom: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);
 }
 
-div[class*="ag-theme-salt"] .ag-cell.ag-cell-range-selected:not(.ag-cell-range-single-cell).ag-cell-range-left::after {
+.ag-cell.ag-cell-range-selected:not(.ag-cell-range-single-cell).ag-cell-range-left::after {
   content: "";
   top: 0;
   right: 0;

--- a/packages/ag-grid-theme/css/parts/ag-body.css
+++ b/packages/ag-grid-theme/css/parts/ag-body.css
@@ -18,17 +18,17 @@
 
 /* CELL */
 
-/* SLoooow */
+/* SLoooow ? */
 .ag-cell.ag-cell-last-left-pinned:not(.ag-cell-range-right):not(.ag-cell-range-single-cell) {
   border-right-color: var(--salt-separable-secondary-borderColor);
 }
 
-/* SLoooow */
+/* SLoooow ? */
 .ag-cell.ag-cell-first-right-pinned:not(.ag-cell-range-left):not(.ag-cell-range-single-cell) {
   border-left-color: var(--salt-separable-secondary-borderColor);
 }
 
-/* SLoooow */
+/* SLoooow ? */
 .ag-cell {
   border: none;
   line-height: calc(var(--ag-line-height) - 1px);
@@ -48,7 +48,7 @@
   border-radius: 0;
 }
 
-/* SLoooow */
+/* SLoooow ? */
 .ag-cell-inline-editing.editable-cell input[class^="ag-"] {
   padding: 0 var(--salt-spacing-100);
 }
@@ -59,7 +59,7 @@
   outline-offset: -1px;
 }
 
-/* SLoooow */
+/* SLoooow ? */
 .ag-cell.numeric-cell,
 .editable-numeric-cell {
   text-align: right;
@@ -70,22 +70,37 @@
   text-align: right;
 }
 
-/* SLoooow */
-.ag-has-focus .ag-cell.ag-cell-focus:not(.ag-cell-range-selected),
-.ag-context-menu-open .ag-cell.ag-cell-focus:not(.ag-cell-range-selected),
-.ag-cell-range-single-cell,
+/* SLoooow yes !!!!!*/
+/* changed to ag grid demo focus ring selectors */
+.ag-ltr.ag-ltr .ag-cell-focus:not(.ag-cell-range-selected):focus-within,
+.ag-ltr.ag-ltr .ag-context-menu-open .ag-cell-focus:not(.ag-cell-range-selected),
+.ag-ltr.ag-ltr .ag-full-width-row.ag-row-focus:focus .ag-cell-wrapper.ag-row-group,
+.ag-ltr.ag-ltr .ag-cell-range-single-cell,
+.ag-ltr.ag-ltr .ag-cell-range-single-cell.ag-cell-range-handle,
+.ag-rtl.ag-rtl .ag-cell-focus:not(.ag-cell-range-selected):focus-within,
+.ag-rtl.ag-rtl .ag-context-menu-open .ag-cell-focus:not(.ag-cell-range-selected),
+.ag-rtl.ag-rtl .ag-full-width-row.ag-row-focus:focus .ag-cell-wrapper.ag-row-group,
+.ag-rtl.ag-rtl .ag-cell-range-single-cell,
+.ag-rtl.ag-rtl .ag-cell-range-single-cell.ag-cell-range-handle {
+  outline: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);
+  outline-offset: -2px;
+  border-width: 0;
+}
+/* .ag-has-focus .ag-cell.ag-cell-focus:not(.ag-cell-range-selected), */
+/* .ag-context-menu-open .ag-cell.ag-cell-focus:not(.ag-cell-range-selected), */
+/* .ag-cell-range-single-cell,
 .ag-cell-range-single-cell.ag-cell-range-handle,
 .ag-cell-focus:not(.ag-cell-range-selected):focus-within {
   outline: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);
   outline-offset: -2px;
   border-width: 0;
-}
+} */
 
 .ag-cell-wrapper.ag-row-group {
   align-items: center;
 }
 
-/* SLoooow */
+/* SLoooow ? */
 .ag-cell.editable-cell.ag-cell-focus:focus:before,
 .ag-cell.editable-numeric-cell.ag-cell-focus:focus:before,
 .ag-cell.editable-cell.ag-cell-focus:focus-within:before,
@@ -100,7 +115,7 @@
   z-index: 2;
 }
 
-/* SLoooow */
+/* SLoooow ? */
 .editable-numeric-cell input,
 input[class^="ag-"][type="number"] {
   padding: 0 var(--salt-spacing-100);
@@ -164,7 +179,7 @@ input[class^="ag-"][type="number"] {
 
 /* Range selection cross cells "fake" outlines */
 
-/* SLoooow */
+/* SLoooow ? */
 .ag-cell.ag-cell-range-selected:not(.ag-cell-range-single-cell).ag-cell-range-top::after {
   content: "";
   top: 0;
@@ -175,7 +190,7 @@ input[class^="ag-"][type="number"] {
   border-top: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);
 }
 
-/* SLoooow */
+/* SLoooow ? */
 .ag-cell.ag-cell-range-selected:not(.ag-cell-range-single-cell).ag-cell-range-right::after {
   content: "";
   top: 0;
@@ -186,7 +201,7 @@ input[class^="ag-"][type="number"] {
   border-right: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);
 }
 
-/* SLoooow */
+/* SLoooow ? */
 .ag-cell.ag-cell-range-selected:not(.ag-cell-range-single-cell).ag-cell-range-bottom::after {
   content: "";
   top: 0;
@@ -197,7 +212,7 @@ input[class^="ag-"][type="number"] {
   border-bottom: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);
 }
 
-/* SLoooow */
+/* SLoooow ?*/
 .ag-cell.ag-cell-range-selected:not(.ag-cell-range-single-cell).ag-cell-range-left::after {
   content: "";
   top: 0;

--- a/packages/ag-grid-theme/css/parts/ag-body.css
+++ b/packages/ag-grid-theme/css/parts/ag-body.css
@@ -18,14 +18,17 @@
 
 /* CELL */
 
+/* SLoooow */
 .ag-cell.ag-cell-last-left-pinned:not(.ag-cell-range-right):not(.ag-cell-range-single-cell) {
   border-right-color: var(--salt-separable-secondary-borderColor);
 }
 
+/* SLoooow */
 .ag-cell.ag-cell-first-right-pinned:not(.ag-cell-range-left):not(.ag-cell-range-single-cell) {
   border-left-color: var(--salt-separable-secondary-borderColor);
 }
 
+/* SLoooow */
 .ag-cell {
   border: none;
   line-height: calc(var(--ag-line-height) - 1px);
@@ -45,6 +48,7 @@
   border-radius: 0;
 }
 
+/* SLoooow */
 .ag-cell-inline-editing.editable-cell input[class^="ag-"] {
   padding: 0 var(--salt-spacing-100);
 }
@@ -55,6 +59,7 @@
   outline-offset: -1px;
 }
 
+/* SLoooow */
 .ag-cell.numeric-cell,
 .editable-numeric-cell {
   text-align: right;
@@ -65,6 +70,7 @@
   text-align: right;
 }
 
+/* SLoooow */
 .ag-has-focus .ag-cell.ag-cell-focus:not(.ag-cell-range-selected),
 .ag-context-menu-open .ag-cell.ag-cell-focus:not(.ag-cell-range-selected),
 .ag-cell-range-single-cell,
@@ -79,6 +85,7 @@
   align-items: center;
 }
 
+/* SLoooow */
 .ag-cell.editable-cell.ag-cell-focus:focus:before,
 .ag-cell.editable-numeric-cell.ag-cell-focus:focus:before,
 .ag-cell.editable-cell.ag-cell-focus:focus-within:before,
@@ -93,6 +100,7 @@
   z-index: 2;
 }
 
+/* SLoooow */
 .editable-numeric-cell input,
 input[class^="ag-"][type="number"] {
   padding: 0 var(--salt-spacing-100);
@@ -156,6 +164,7 @@ input[class^="ag-"][type="number"] {
 
 /* Range selection cross cells "fake" outlines */
 
+/* SLoooow */
 .ag-cell.ag-cell-range-selected:not(.ag-cell-range-single-cell).ag-cell-range-top::after {
   content: "";
   top: 0;
@@ -166,6 +175,7 @@ input[class^="ag-"][type="number"] {
   border-top: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);
 }
 
+/* SLoooow */
 .ag-cell.ag-cell-range-selected:not(.ag-cell-range-single-cell).ag-cell-range-right::after {
   content: "";
   top: 0;
@@ -176,6 +186,7 @@ input[class^="ag-"][type="number"] {
   border-right: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);
 }
 
+/* SLoooow */
 .ag-cell.ag-cell-range-selected:not(.ag-cell-range-single-cell).ag-cell-range-bottom::after {
   content: "";
   top: 0;
@@ -186,6 +197,7 @@ input[class^="ag-"][type="number"] {
   border-bottom: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);
 }
 
+/* SLoooow */
 .ag-cell.ag-cell-range-selected:not(.ag-cell-range-single-cell).ag-cell-range-left::after {
   content: "";
   top: 0;

--- a/packages/ag-grid-theme/css/parts/ag-buttons.css
+++ b/packages/ag-grid-theme/css/parts/ag-buttons.css
@@ -1,6 +1,6 @@
 /* BUTTON */
 
-div[class*="ag-theme-salt"] .ag-standard-button {
+.ag-standard-button {
   background: var(--salt-actionable-secondary-background);
   border: 0;
   color: var(--salt-actionable-secondary-foreground);
@@ -11,33 +11,33 @@ div[class*="ag-theme-salt"] .ag-standard-button {
   text-transform: uppercase;
 }
 
-div[class*="ag-theme-salt"] .ag-standard-button:hover {
+.ag-standard-button:hover {
   background-color: var(--salt-actionable-secondary-background-hover);
   color: var(--salt-actionable-secondary-foreground-hover);
 }
 
-div[class*="ag-theme-salt"] .ag-ltr .ag-filter-apply-panel-button {
+.ag-ltr .ag-filter-apply-panel-button {
   margin-left: 8px;
 }
 
-div[class*="ag-theme-salt"] .ag-standard-button.ag-filter-apply-panel-button[ref="applyFilterButton"],
-div[class*="ag-theme-salt"] .ag-standard-button.ag-filter-apply-panel-button[data-ref="applyFilterButton"] {
+.ag-standard-button.ag-filter-apply-panel-button[ref="applyFilterButton"],
+.ag-standard-button.ag-filter-apply-panel-button[data-ref="applyFilterButton"] {
   background: var(--salt-actionable-cta-background);
   color: var(--salt-actionable-cta-foreground);
 }
 
-div[class*="ag-theme-salt"] .ag-standard-button.ag-filter-apply-panel-button[ref="applyFilterButton"]:hover,
-div[class*="ag-theme-salt"] .ag-standard-button.ag-filter-apply-panel-button[data-ref="applyFilterButton"]:hover {
+.ag-standard-button.ag-filter-apply-panel-button[ref="applyFilterButton"]:hover,
+.ag-standard-button.ag-filter-apply-panel-button[data-ref="applyFilterButton"]:hover {
   background: var(--salt-actionable-cta-background-hover);
   color: var(--salt-actionable-cta-foreground-hover);
 }
 
-div[class*="ag-theme-salt"] .ag-keyboard-focus .ag-header-cell:focus:after {
+.ag-keyboard-focus .ag-header-cell:focus:after {
   border: 0;
 }
 
-div[class*="ag-theme-salt"] button[class^="ag-"]:focus,
-div[class*="ag-theme-salt"] input[class^="ag-"][type="button"]:focus {
+button[class^="ag-"]:focus,
+input[class^="ag-"][type="button"]:focus {
   box-shadow: none;
   outline-style: var(--salt-focused-outlineStyle);
   outline-width: var(--salt-focused-outlineWidth);
@@ -45,7 +45,7 @@ div[class*="ag-theme-salt"] input[class^="ag-"][type="button"]:focus {
   outline-offset: var(--salt-focused-outlineOffset);
 }
 
-div[class*="ag-theme-salt"] .ag-menu .ag-filter-body-wrapper {
+.ag-menu .ag-filter-body-wrapper {
   display: flex;
   flex-direction: column;
   gap: 0;
@@ -53,27 +53,27 @@ div[class*="ag-theme-salt"] .ag-menu .ag-filter-body-wrapper {
   margin-top: var(--salt-spacing-100);
 }
 
-div[class*="ag-theme-salt"] .ag-menu .ag-menu-column-select-wrapper {
+.ag-menu .ag-menu-column-select-wrapper {
   margin-top: var(--salt-spacing-100);
 }
 
-div[class*="ag-theme-salt"] .ag-simple-filter-body-wrapper > * {
+.ag-simple-filter-body-wrapper > * {
   margin-bottom: var(--salt-spacing-100);
 }
 
-div[class*="ag-theme-salt"] .ag-mini-filter {
+.ag-mini-filter {
   margin: 0;
   padding-left: var(--salt-spacing-50);
   padding-right: var(--salt-spacing-50);
 }
 
-div[class*="ag-theme-salt"] .ag-set-filter-item {
+.ag-set-filter-item {
   margin: 0;
   padding-left: var(--salt-spacing-100);
   padding-right: var(--salt-spacing-100);
 }
 
-div[class*="ag-theme-salt"] .ag-status-bar {
+.ag-status-bar {
   border: none;
   border-top: var(--salt-size-border) var(--salt-separable-borderStyle) var(--salt-container-primary-borderColor);
   color: var(--salt-content-secondary-foreground);
@@ -85,30 +85,30 @@ div[class*="ag-theme-salt"] .ag-status-bar {
   padding: 0 var(--salt-spacing-100);
 }
 
-div[class*="ag-theme-salt"] .ag-status-name-value {
+.ag-status-name-value {
   padding: 0;
   margin: 0 var(--salt-spacing-100);
 }
 
-div[class*="ag-theme-salt"] .ag-status-name-value-value {
+.ag-status-name-value-value {
   font-weight: var(--salt-text-fontWeight-strong);
   color: var(--salt-content-primary-foreground);
 }
 
-div[class*="ag-theme-salt"] .ag-paging-panel {
+.ag-paging-panel {
   border-color: var(--salt-separable-secondary-borderColor);
 }
 
-div[class*="ag-theme-salt"] .ag-floating-bottom {
+.ag-floating-bottom {
   border-color: var(--salt-container-primary-borderColor);
 }
 
-div[class*="ag-theme-salt"] .ag-column-drop-horizontal {
+.ag-column-drop-horizontal {
   border-bottom: var(--salt-size-border) var(--salt-separable-borderStyle) var(--salt-container-primary-borderColor);
   height: calc(var(--salt-size-base) + var(--salt-spacing-100));
 }
 
-div[class*="ag-theme-salt"] .ag-column-drop-cell {
+.ag-column-drop-cell {
   border-radius: 0;
 }
 

--- a/packages/ag-grid-theme/css/parts/ag-buttons.css
+++ b/packages/ag-grid-theme/css/parts/ag-buttons.css
@@ -36,6 +36,7 @@
   border: 0;
 }
 
+/* SLoooow */
 button[class^="ag-"]:focus,
 input[class^="ag-"][type="button"]:focus {
   box-shadow: none;
@@ -57,6 +58,7 @@ input[class^="ag-"][type="button"]:focus {
   margin-top: var(--salt-spacing-100);
 }
 
+/* SLoooow */
 .ag-simple-filter-body-wrapper > * {
   margin-bottom: var(--salt-spacing-100);
 }

--- a/packages/ag-grid-theme/css/parts/ag-buttons.css
+++ b/packages/ag-grid-theme/css/parts/ag-buttons.css
@@ -36,7 +36,7 @@
   border: 0;
 }
 
-/* SLoooow */
+/* SLoooow ? */
 button[class^="ag-"]:focus,
 input[class^="ag-"][type="button"]:focus {
   box-shadow: none;
@@ -58,7 +58,7 @@ input[class^="ag-"][type="button"]:focus {
   margin-top: var(--salt-spacing-100);
 }
 
-/* SLoooow */
+/* SLoooow ? */
 .ag-simple-filter-body-wrapper > * {
   margin-bottom: var(--salt-spacing-100);
 }

--- a/packages/ag-grid-theme/css/parts/ag-checkbox.css
+++ b/packages/ag-grid-theme/css/parts/ag-checkbox.css
@@ -1,6 +1,6 @@
 /* CHECKBOX */
 
-div[class*="ag-theme-salt"] .ag-checkbox-input-wrapper {
+.ag-checkbox-input-wrapper {
   /* border-radius doesn't work given border is part of the font glyph */
   height: var(--salt-size-selectable);
   width: var(--salt-size-selectable);

--- a/packages/ag-grid-theme/css/parts/ag-header.css
+++ b/packages/ag-grid-theme/css/parts/ag-header.css
@@ -152,7 +152,7 @@
   outline-offset: 2px;
 }
 
-/* SLoooow */
+/* SLoooow ? */
 .ag-floating-filter input[class^="ag-"][type="number"],
 .ag-floating-filter input[class^="ag-"][type="text"] {
   /* Avoid floating filter's input clips focus ring */
@@ -163,7 +163,7 @@
   padding: 0 var(--salt-spacing-50);
 }
 
-/* SLoooow */
+/* SLoooow ? */
 .ag-floating-filter-input input[class^="ag-"][type="text"],
 .ag-floating-filter-input input[class^="ag-"][type="number"] {
   border: none;

--- a/packages/ag-grid-theme/css/parts/ag-header.css
+++ b/packages/ag-grid-theme/css/parts/ag-header.css
@@ -1,93 +1,93 @@
 /* HEADER */
 
-div[class*="ag-theme-salt"] .ag-header {
+.ag-header {
   /* Header icon should be the same as text color, aka secondary color */
   --ag-icon-font-color: var(--ag-header-foreground-color);
 }
 
-div[class*="ag-theme-salt"] .ag-advanced-filter-header,
-div[class*="ag-theme-salt"] .ag-header {
+.ag-advanced-filter-header,
+.ag-header {
   border-bottom: var(--salt-size-border) var(--salt-separable-borderStyle) var(--salt-separable-primary-borderColor);
 }
 
-div[class*="ag-theme-salt"] .ag-header-row {
+.ag-header-row {
   font-size: var(--salt-text-label-fontSize);
   font-weight: var(--salt-text-label-fontWeight-strong);
 }
 
-div[class*="ag-theme-salt"] .ag-header-cell:focus-visible::after {
+.ag-header-cell:focus-visible::after {
   /* Remove ag grid default border */
   border: none;
 }
-div[class*="ag-theme-salt"] .ag-header-cell:focus-visible {
+.ag-header-cell:focus-visible {
   outline: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);
   outline-offset: -2px;
   border-width: 0;
 }
 
-div[class*="ag-theme-salt"] .ag-pinned-left-header {
+.ag-pinned-left-header {
   border-right-color: var(--salt-separable-secondary-borderColor);
 }
 
-div[class*="ag-theme-salt"] .ag-pinned-right-header {
+.ag-pinned-right-header {
   border-left-color: var(--salt-separable-secondary-borderColor);
 }
 
-div[class*="ag-theme-salt"] .ag-header-row:not(:first-child) .ag-header-cell:not(.ag-header-span-height.ag-header-span-total) {
+.ag-header-row:not(:first-child) .ag-header-cell:not(.ag-header-span-height.ag-header-span-total) {
   border-top-color: var(--salt-container-primary-borderColor);
 }
 
-div[class*="ag-theme-salt"] .ag-header-row:not(:first-child) .ag-header-cell:not(.ag-header-span-height.ag-header-span-total):focus,
-div[class*="ag-theme-salt"] .ag-header-row:not(:first-child) .ag-header-group-cell.ag-header-group-cell-with-group:focus {
+.ag-header-row:not(:first-child) .ag-header-cell:not(.ag-header-span-height.ag-header-span-total):focus,
+.ag-header-row:not(:first-child) .ag-header-group-cell.ag-header-group-cell-with-group:focus {
   border: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);
 }
 
 /** Move sort arrow towards menu icon */
 /** v32 doesn't have filter icon */
-div[class*="ag-theme-salt"] .ag-ltr .ag-header-cell:not(.ag-right-aligned-header) .ag-header-label-icon.ag-hidden + .ag-sort-indicator-container,
-div[class*="ag-theme-salt"] .ag-ltr .ag-header-cell:not(.ag-right-aligned-header) .ag-header-cell-text + .ag-sort-indicator-container {
+.ag-ltr .ag-header-cell:not(.ag-right-aligned-header) .ag-header-label-icon.ag-hidden + .ag-sort-indicator-container,
+.ag-ltr .ag-header-cell:not(.ag-right-aligned-header) .ag-header-cell-text + .ag-sort-indicator-container {
   margin-left: auto;
 }
 
-div[class*="ag-theme-salt"] .ag-ltr .ag-header-cell.ag-right-aligned-header .ag-header-label-icon.ag-hidden + .ag-sort-indicator-container,
-div[class*="ag-theme-salt"] .ag-ltr .ag-header-cell.ag-right-aligned-header .ag-header-cell-text + .ag-sort-indicator-container {
+.ag-ltr .ag-header-cell.ag-right-aligned-header .ag-header-label-icon.ag-hidden + .ag-sort-indicator-container,
+.ag-ltr .ag-header-cell.ag-right-aligned-header .ag-header-cell-text + .ag-sort-indicator-container {
   margin-right: auto;
 }
 
-div[class*="ag-theme-salt"] .ag-sort-indicator-container {
+.ag-sort-indicator-container {
   align-items: center;
 }
 
-div[class*="ag-theme-salt"] .ag-ltr .ag-header-cell.ag-right-aligned-header .ag-sort-indicator-icon {
+.ag-ltr .ag-header-cell.ag-right-aligned-header .ag-sort-indicator-icon {
   padding-left: var(--salt-spacing-100);
 }
 
-div[class*="ag-theme-salt"] .ag-ltr .ag-header-cell:not(.ag-right-aligned-header) .ag-sort-indicator-icon {
+.ag-ltr .ag-header-cell:not(.ag-right-aligned-header) .ag-sort-indicator-icon {
   padding-right: var(--salt-spacing-100);
 }
 
-div[class*="ag-theme-salt"] .ag-ltr .ag-header-cell:not(.ag-right-aligned-header) .ag-header-label-icon {
+.ag-ltr .ag-header-cell:not(.ag-right-aligned-header) .ag-header-label-icon {
   margin-left: auto;
   padding-right: var(--salt-spacing-100);
 }
 
-div[class*="ag-theme-salt"] .ag-ltr .ag-header-cell.ag-right-aligned-header .ag-header-label-icon {
+.ag-ltr .ag-header-cell.ag-right-aligned-header .ag-header-label-icon {
   margin-right: auto;
   padding-left: var(--salt-spacing-100);
 }
 
 /* Floating filter */
 
-div[class*="ag-theme-salt"] .ag-header-cell.ag-floating-filter::before {
+.ag-header-cell.ag-floating-filter::before {
   /* Remove half height border in most header cells */
   background-color: transparent;
 }
 
-div[class*="ag-theme-salt"] .ag-floating-filter {
+.ag-floating-filter {
   border: var(--salt-size-border) var(--salt-editable-borderStyle) var(--salt-separable-tertiary-borderColor);
 }
 
-div[class*="ag-theme-salt"] .ag-header-cell.ag-floating-filter {
+.ag-header-cell.ag-floating-filter {
   padding-left: 0;
 }
 
@@ -95,27 +95,27 @@ div[class*="ag-theme-salt"] .ag-header-cell.ag-floating-filter {
   From v31, there's a "active" state of floating filter button next to the input. So we want to put the focus ring
   not around the whole header cell, but around the input container.
 */
-div[class*="ag-theme-salt"] .ag-floating-filter .ag-floating-filter-body:focus-within {
+.ag-floating-filter .ag-floating-filter-body:focus-within {
   outline: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);
   outline-offset: -2px;
 }
 
-div[class*="ag-theme-salt"] .ag-header-cell-menu-button:hover,
-div[class*="ag-theme-salt"] .ag-header-cell-filter-button:hover,
-div[class*="ag-theme-salt"] .ag-panel-title-bar-button:hover,
-div[class*="ag-theme-salt"] .ag-header-expand-icon:hover,
-div[class*="ag-theme-salt"] .ag-column-group-icons:hover,
-div[class*="ag-theme-salt"] .ag-set-filter-group-icons:hover,
-div[class*="ag-theme-salt"] .ag-group-expanded .ag-icon:hover,
-div[class*="ag-theme-salt"] .ag-group-contracted .ag-icon:hover,
-div[class*="ag-theme-salt"] .ag-chart-settings-prev:hover,
-div[class*="ag-theme-salt"] .ag-chart-settings-next:hover,
-div[class*="ag-theme-salt"] .ag-group-title-bar-icon:hover,
-div[class*="ag-theme-salt"] .ag-column-select-header-icon:hover,
-div[class*="ag-theme-salt"] .ag-floating-filter-button-button:hover,
-div[class*="ag-theme-salt"] .ag-filter-toolpanel-expand:hover,
-div[class*="ag-theme-salt"] .ag-panel-title-bar-button-icon:hover,
-div[class*="ag-theme-salt"] .ag-chart-menu-icon:hover {
+.ag-header-cell-menu-button:hover,
+.ag-header-cell-filter-button:hover,
+.ag-panel-title-bar-button:hover,
+.ag-header-expand-icon:hover,
+.ag-column-group-icons:hover,
+.ag-set-filter-group-icons:hover,
+.ag-group-expanded .ag-icon:hover,
+.ag-group-contracted .ag-icon:hover,
+.ag-chart-settings-prev:hover,
+.ag-chart-settings-next:hover,
+.ag-group-title-bar-icon:hover,
+.ag-column-select-header-icon:hover,
+.ag-floating-filter-button-button:hover,
+.ag-filter-toolpanel-expand:hover,
+.ag-panel-title-bar-button-icon:hover,
+.ag-chart-menu-icon:hover {
   /* Button is the same size of icon, we're copying what ag quartz theme is doing */
   box-shadow: 0 0 0 var(--salt-spacing-50) var(--salt-actionable-subtle-background-hover);
   background-color: var(--salt-actionable-subtle-background-hover);
@@ -134,26 +134,26 @@ div[class*="ag-theme-salt"] .ag-chart-menu-icon:hover {
   When filter is active, swap out filter icon with filled version.
   This is new in ag grid v32.
 */
-div[class*="ag-theme-salt"] .ag-filter-active {
+.ag-filter-active {
   --ag-icon-font-code-filter: var(--ag-icon-font-code-filter-filled);
 }
 
-div[class*="ag-theme-salt"] .ag-floating-filter:after {
+.ag-floating-filter:after {
   width: 0;
 }
 
-div[class*="ag-theme-salt"] .ag-ltr .ag-floating-filter-button {
+.ag-ltr .ag-floating-filter-button {
   margin-left: var(--salt-spacing-100);
 }
 
-div[class*="ag-theme-salt"] .ag-ltr .ag-floating-filter-button .ag-button:focus {
+.ag-ltr .ag-floating-filter-button .ag-button:focus {
   border: none;
   outline: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);
   outline-offset: 2px;
 }
 
-div[class*="ag-theme-salt"] .ag-floating-filter input[class^="ag-"][type="number"],
-div[class*="ag-theme-salt"] .ag-floating-filter input[class^="ag-"][type="text"] {
+.ag-floating-filter input[class^="ag-"][type="number"],
+.ag-floating-filter input[class^="ag-"][type="text"] {
   /* Avoid floating filter's input clips focus ring */
   height: calc(var(--salt-size-base) + var(--salt-spacing-100) - 6px);
   /* Give internal <input> space for the outline */
@@ -162,14 +162,14 @@ div[class*="ag-theme-salt"] .ag-floating-filter input[class^="ag-"][type="text"]
   padding: 0 var(--salt-spacing-50);
 }
 
-div[class*="ag-theme-salt"] .ag-floating-filter-input input[class^="ag-"][type="text"],
-div[class*="ag-theme-salt"] .ag-floating-filter-input input[class^="ag-"][type="number"] {
+.ag-floating-filter-input input[class^="ag-"][type="text"],
+.ag-floating-filter-input input[class^="ag-"][type="number"] {
   border: none;
 }
 
-div[class*="ag-theme-salt"] .ag-header-cell:not(.ag-column-resizing) + .ag-header-cell.ag-column-menu-visible:not(.ag-column-hover):not(.ag-header-cell-moving):hover,
-div[class*="ag-theme-salt"] .ag-header-cell:not(.ag-column-hover):first-of-type:not(.ag-header-cell-moving).ag-column-menu-visible:hover,
-div[class*="ag-theme-salt"] .ag-header-cell.ag-column-menu-visible {
+.ag-header-cell:not(.ag-column-resizing) + .ag-header-cell.ag-column-menu-visible:not(.ag-column-hover):not(.ag-header-cell-moving):hover,
+.ag-header-cell:not(.ag-column-hover):first-of-type:not(.ag-header-cell-moving).ag-column-menu-visible:hover,
+.ag-header-cell.ag-column-menu-visible {
   /*
     When menu is visible, change bg and fg. 
     From ag grid v32, a new `.ag-has-popup-positioned-under` can be potentially used, however `.ag-column-menu-visible` will still be applied 
@@ -184,22 +184,22 @@ div[class*="ag-theme-salt"] .ag-header-cell.ag-column-menu-visible {
   --salt-actionable-subtle-background-hover: var(--salt-actionable-subtle-background-active);
 }
 
-div[class*="ag-theme-salt"] .ag-header-cell.ag-column-menu-visible .ag-icon {
+.ag-header-cell.ag-column-menu-visible .ag-icon {
   color: var(--salt-actionable-secondary-foreground-active);
 }
 
-div[class*="ag-theme-salt"] .ag-cell-label-container {
+.ag-cell-label-container {
   /* row height is base size + 50 spacing on top/bottom */
   padding: var(--salt-spacing-50) 0;
 }
 
-div[class*="ag-theme-salt"] .ag-list-item:hover,
-div[class*="ag-theme-salt"] .ag-virtual-list-item:hover {
+.ag-list-item:hover,
+.ag-virtual-list-item:hover {
   background-color: var(--salt-selectable-background-hover);
   cursor: pointer;
 }
 
-div[class*="ag-theme-salt"] .ag-label-align-right .ag-label {
+.ag-label-align-right .ag-label {
   margin-inline-start: var(--salt-spacing-100);
   margin-inline-end: 0;
 }

--- a/packages/ag-grid-theme/css/parts/ag-header.css
+++ b/packages/ag-grid-theme/css/parts/ag-header.css
@@ -152,6 +152,7 @@
   outline-offset: 2px;
 }
 
+/* SLoooow */
 .ag-floating-filter input[class^="ag-"][type="number"],
 .ag-floating-filter input[class^="ag-"][type="text"] {
   /* Avoid floating filter's input clips focus ring */
@@ -162,6 +163,7 @@
   padding: 0 var(--salt-spacing-50);
 }
 
+/* SLoooow */
 .ag-floating-filter-input input[class^="ag-"][type="text"],
 .ag-floating-filter-input input[class^="ag-"][type="number"] {
   border: none;

--- a/packages/ag-grid-theme/css/parts/ag-input.css
+++ b/packages/ag-grid-theme/css/parts/ag-input.css
@@ -1,46 +1,46 @@
 /* INPUT */
 
-div[class*="ag-theme-salt"] .ag-filter input[class^="ag-"][type="text"],
-div[class*="ag-theme-salt"] .ag-filter input[class^="ag-"][type="number"],
-div[class*="ag-theme-salt"] .ag-column-select input[class^="ag-"][type="text"],
-div[class*="ag-theme-salt"] .ag-column-select input[class^="ag-"][type="number"] {
+.ag-filter input[class^="ag-"][type="text"],
+.ag-filter input[class^="ag-"][type="number"],
+.ag-column-select input[class^="ag-"][type="text"],
+.ag-column-select input[class^="ag-"][type="number"] {
   border: none;
   border-bottom: var(--salt-size-border) var(--salt-editable-borderStyle) var(--salt-editable-borderColor);
   height: calc(var(--salt-size-base) + var(--salt-spacing-100));
   padding: 0 var(--salt-spacing-100);
 }
 
-div[class*="ag-theme-salt"] .ag-filter input[class^="ag-"][type="text"]::placeholder,
-div[class*="ag-theme-salt"] .ag-filter input[class^="ag-"][type="number"]::placeholder,
-div[class*="ag-theme-salt"] .ag-column-select input[class^="ag-"][type="text"]::placeholder,
-div[class*="ag-theme-salt"] .ag-column-select input[class^="ag-"][type="number"]::placeholder {
+.ag-filter input[class^="ag-"][type="text"]::placeholder,
+.ag-filter input[class^="ag-"][type="number"]::placeholder,
+.ag-column-select input[class^="ag-"][type="text"]::placeholder,
+.ag-column-select input[class^="ag-"][type="number"]::placeholder {
   color: var(--salt-content-secondary-foreground);
   opacity: 1;
 }
 
-div[class*="ag-theme-salt"] .ag-filter input[class^="ag-"][type="text"]:focus,
-div[class*="ag-theme-salt"] .ag-filter input[class^="ag-"][type="number"]:focus,
-div[class*="ag-theme-salt"] .ag-column-select input[class^="ag-"][type="text"]:focus,
-div[class*="ag-theme-salt"] .ag-column-select input[class^="ag-"][type="number"]:focus {
+.ag-filter input[class^="ag-"][type="text"]:focus,
+.ag-filter input[class^="ag-"][type="number"]:focus,
+.ag-column-select input[class^="ag-"][type="text"]:focus,
+.ag-column-select input[class^="ag-"][type="number"]:focus {
   outline: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);
   outline-offset: -2px;
 }
 /* Large text editor, matching multiline input */
-div[class*="ag-theme-salt"] .ag-popup-editor .ag-large-text textarea[class^="ag-"] {
+.ag-popup-editor .ag-large-text textarea[class^="ag-"] {
   border-radius: var(--salt-palette-corner-weak, 0);
   padding: var(--salt-spacing-100) var(--salt-spacing-100);
 }
 
-div[class*="ag-theme-salt"] .ag-popup-editor .ag-large-text,
-div[class*="ag-theme-salt"] .ag-autocomplete-list-popup {
+.ag-popup-editor .ag-large-text,
+.ag-autocomplete-list-popup {
   /* Don't apply a border, but rather textarea border below is used, otherwise focus ring position could be a problem. */
   border: none;
 }
-div[class*="ag-theme-salt"] .ag-popup-editor .ag-large-text textarea[class^="ag-"] {
+.ag-popup-editor .ag-large-text textarea[class^="ag-"] {
   /* When textarea is not in focus, simulating a popup list (OptionList) border color */
   border-color: var(--salt-selectable-borderColor-selected);
 }
 
-div[class*="ag-theme-salt"] .ag-popup-editor .ag-large-text textarea[class^="ag-"]:focus {
+.ag-popup-editor .ag-large-text textarea[class^="ag-"]:focus {
   outline: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);
 }

--- a/packages/ag-grid-theme/css/parts/ag-input.css
+++ b/packages/ag-grid-theme/css/parts/ag-input.css
@@ -1,6 +1,6 @@
 /* INPUT */
 
-/* SLoooow */
+/* SLoooow ? */
 .ag-filter input[class^="ag-"][type="text"],
 .ag-filter input[class^="ag-"][type="number"],
 .ag-column-select input[class^="ag-"][type="text"],
@@ -11,16 +11,16 @@
   padding: 0 var(--salt-spacing-100);
 }
 
-/* SLoooow */
-.ag-filter input[class^="ag-"][type="text"]::placeholder,
+/* SLoooow yes !!! `[class^="ag-"]` is slow */
+/* .ag-filter input[class^="ag-"][type="text"]::placeholder,
 .ag-filter input[class^="ag-"][type="number"]::placeholder,
 .ag-column-select input[class^="ag-"][type="text"]::placeholder,
 .ag-column-select input[class^="ag-"][type="number"]::placeholder {
   color: var(--salt-content-secondary-foreground);
   opacity: 1;
-}
+} */
 
-/* SLoooow */
+/* SLoooow ? */
 .ag-filter input[class^="ag-"][type="text"]:focus,
 .ag-filter input[class^="ag-"][type="number"]:focus,
 .ag-column-select input[class^="ag-"][type="text"]:focus,
@@ -28,7 +28,7 @@
   outline: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);
   outline-offset: -2px;
 }
-/* SLoooow */
+/* SLoooow ? */
 /* Large text editor, matching multiline input */
 .ag-popup-editor .ag-large-text textarea[class^="ag-"] {
   border-radius: var(--salt-palette-corner-weak, 0);
@@ -40,12 +40,12 @@
   /* Don't apply a border, but rather textarea border below is used, otherwise focus ring position could be a problem. */
   border: none;
 }
-/* SLoooow */
+/* SLoooow ? */
 .ag-popup-editor .ag-large-text textarea[class^="ag-"] {
   /* When textarea is not in focus, simulating a popup list (OptionList) border color */
   border-color: var(--salt-selectable-borderColor-selected);
 }
-/* SLoooow */
+/* SLoooow ? */
 
 .ag-popup-editor .ag-large-text textarea[class^="ag-"]:focus {
   outline: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);

--- a/packages/ag-grid-theme/css/parts/ag-input.css
+++ b/packages/ag-grid-theme/css/parts/ag-input.css
@@ -1,5 +1,6 @@
 /* INPUT */
 
+/* SLoooow */
 .ag-filter input[class^="ag-"][type="text"],
 .ag-filter input[class^="ag-"][type="number"],
 .ag-column-select input[class^="ag-"][type="text"],
@@ -10,6 +11,7 @@
   padding: 0 var(--salt-spacing-100);
 }
 
+/* SLoooow */
 .ag-filter input[class^="ag-"][type="text"]::placeholder,
 .ag-filter input[class^="ag-"][type="number"]::placeholder,
 .ag-column-select input[class^="ag-"][type="text"]::placeholder,
@@ -18,6 +20,7 @@
   opacity: 1;
 }
 
+/* SLoooow */
 .ag-filter input[class^="ag-"][type="text"]:focus,
 .ag-filter input[class^="ag-"][type="number"]:focus,
 .ag-column-select input[class^="ag-"][type="text"]:focus,
@@ -25,6 +28,7 @@
   outline: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);
   outline-offset: -2px;
 }
+/* SLoooow */
 /* Large text editor, matching multiline input */
 .ag-popup-editor .ag-large-text textarea[class^="ag-"] {
   border-radius: var(--salt-palette-corner-weak, 0);
@@ -36,10 +40,12 @@
   /* Don't apply a border, but rather textarea border below is used, otherwise focus ring position could be a problem. */
   border: none;
 }
+/* SLoooow */
 .ag-popup-editor .ag-large-text textarea[class^="ag-"] {
   /* When textarea is not in focus, simulating a popup list (OptionList) border color */
   border-color: var(--salt-selectable-borderColor-selected);
 }
+/* SLoooow */
 
 .ag-popup-editor .ag-large-text textarea[class^="ag-"]:focus {
   outline: var(--salt-focused-outlineWidth) var(--salt-focused-outlineStyle) var(--salt-focused-outlineColor);

--- a/packages/ag-grid-theme/css/parts/ag-menus.css
+++ b/packages/ag-grid-theme/css/parts/ag-menus.css
@@ -1,50 +1,50 @@
 /* MENU */
 
-div[class*="ag-theme-salt"] .ag-menu {
+.ag-menu {
   padding: var(--salt-spacing-100);
   border: var(--salt-size-border) var(--salt-container-borderStyle) var(--salt-selectable-borderColor-selected);
 }
 
-div[class*="ag-theme-salt"] .ag-tabs {
+.ag-tabs {
   padding: var(--salt-spacing-100);
 }
 
-div[class*="ag-theme-salt"] .ag-popup-child:not(.ag-tooltip-custom) {
+.ag-popup-child:not(.ag-tooltip-custom) {
   box-shadow: var(--salt-overlayable-shadow-popout);
 }
 
-div[class*="ag-theme-salt"] .ag-menu-header {
+.ag-menu-header {
   border-bottom: var(--salt-size-border) var(--salt-separable-borderStyle) var(--salt-container-primary-borderColor);
   background-color: var(--salt-container-primary-background);
 }
 
-div[class*="ag-theme-salt"] .ag-menu-body {
+.ag-menu-body {
   padding: 0;
 }
 
-div[class*="ag-theme-salt"] .ag-menu-separator {
+.ag-menu-separator {
   height: var(--salt-size-border);
 }
 
-div[class*="ag-theme-salt"] .ag-menu-list {
+.ag-menu-list {
   padding: 0;
 }
 
-div[class*="ag-theme-salt"] .ag-menu-option {
+.ag-menu-option {
   height: calc(var(--salt-size-base) + var(--salt-spacing-100));
 }
 
-div[class*="ag-theme-salt"] .ag-menu-option-icon,
-div[class*="ag-theme-salt"] .ag-compact-menu-option-icon {
+.ag-menu-option-icon,
+.ag-compact-menu-option-icon {
   padding-inline-start: var(--salt-spacing-100);
 }
 
-div[class*="ag-theme-salt"] .ag-tab {
+.ag-tab {
   height: calc(var(--salt-size-base) + var(--salt-spacing-100));
   flex: 1 1 auto;
 }
 
-div[class*="ag-theme-salt"] .ag-column-select-header {
+.ag-column-select-header {
   height: calc(var(--salt-size-base) + var(--salt-spacing-100));
   border: 0;
 }

--- a/packages/ag-grid-theme/css/parts/ag-tool-panel.css
+++ b/packages/ag-grid-theme/css/parts/ag-tool-panel.css
@@ -1,21 +1,21 @@
 /* Tool Panel */
 
-div[class*="ag-theme-salt"] .ag-tool-panel-wrapper > .ag-react-container {
+.ag-tool-panel-wrapper > .ag-react-container {
   width: inherit;
 }
 
-div[class*="ag-theme-salt"] .ag-side-buttons {
+.ag-side-buttons {
   min-width: calc(var(--salt-size-base) + var(--salt-spacing-100));
 }
 
-div[class*="ag-theme-salt"] button.ag-side-button-button {
+button.ag-side-button-button {
   padding: var(--salt-spacing-100) var(--salt-spacing-50);
 }
 
-div[class*="ag-theme-salt"] .ag-column-drop-vertical-empty-message {
+.ag-column-drop-vertical-empty-message {
   padding: var(--salt-spacing-100);
 }
 
-div[class*="ag-theme-salt"] .ag-side-button-icon-wrapper {
+.ag-side-button-icon-wrapper {
   margin-bottom: var(--salt-spacing-100);
 }

--- a/packages/ag-grid-theme/scripts/build.mjs
+++ b/packages/ag-grid-theme/scripts/build.mjs
@@ -18,7 +18,9 @@ const packageName = packageJson.name;
 
 console.log(`Building ${packageName}`);
 
-deleteSync([buildFolder], { force: true });
+if (!argv.includes("--watch")) {
+  deleteSync([buildFolder], { force: true });
+}
 
 const context = await esbuild.context({
   absWorkingDir: cwd,


### PR DESCRIPTION
Use PR storybook to compare CSS selector performance and pin point exactly which selectors are problematic, during ag grid context menu launch.

[#4790](https://github.com/jpmorganchase/salt-ds/issues/4790)

## Apr 1

First iteration, when removing all `div[class*="ag-theme-salt"]` (except in `ag-root-var.css`), below rules significantly slows down MTK blotter when launching a context menu

- Potentially due to `:not` selector, can change to ag grid's css selectors, https://github.com/jpmorganchase/salt-ds/blob/faa03341e324df097257f39b31ad17459da51f59/packages/ag-grid-theme/css/parts/ag-body.css#L68-L69
    ```
    .ag-ltr.ag-cell-focus:not(.ag-cell-range-selected):focus-within,
    .ag-ltr.ag-context-menu-open .ag-cell-focus:not(.ag-cell-range-selected),
    .ag-ltr.ag-full-width-row.ag-row-focus:focus .ag-cell-wrapper.ag-row-group,
    .ag-ltr.ag-cell-range-single-cell,
    .ag-ltr.ag-cell-range-single-cell.ag-cell-range-handle,
    ```
- `[class^="ag-"]` is slow: https://github.com/jpmorganchase/salt-ds/blob/faa03341e324df097257f39b31ad17459da51f59/packages/ag-grid-theme/css/parts/ag-input.css#L13-L19