### PR TITLE
Fix snapshot success comment

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -113,7 +113,7 @@ jobs:
             await exec.exec('yarn changeset publish --no-git-tag --snapshot --tag snapshot', [], options);
 
             const { COMMENT_ID } = process.env
-            const [_, packagesStdin] = output.split("success packages published successfully:\n")
+            const [_, packagesStdin] = output.split("packages published successfully:\n")
 
             const newTags = packagesStdin ? packagesStdin.split("\n").flatMap(package => Array.from(package.matchAll(/\s+(.*)/g),m => m[1])) : [];
 


### PR DESCRIPTION
Try to fix snapshot release not adding success comment back to PR

Output [example here](https://productionresultssa8.blob.core.windows.net/actions-results/0a6385f7-2d0d-4f35-99a7-fa2bf2657026/workflow-job-run-b1f201b7-a245-58a5-e067-7696c2487ba9/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-04-02T07%3A41%3A13Z&sig=vlW64uHFucuB7gnuQkhqrmuR%2Fsxds9C9Gg8TQwLIxbw%3D&ske=2025-04-02T16%3A52%3A15Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-04-02T04%3A52%3A15Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-01-05&sp=r&spr=https&sr=b&st=2025-04-02T07%3A31%3A08Z&sv=2025-01-05) shows: `[32msuccess[39m packages published successfully:`