### PR TITLE
Fix component page tabs shrink

### DIFF
--- a/site/src/css/base.css
+++ b/site/src/css/base.css
@@ -1,7 +1,7 @@
 :root {
   box-sizing: border-box;
 
-  --site-content-max-width: 85ch;
+  --site-content-max-width: 100ch;
 }
 
 *,

--- a/site/src/css/base.css
+++ b/site/src/css/base.css
@@ -1,5 +1,7 @@
 :root {
   box-sizing: border-box;
+
+  --site-content-max-width: 85ch;
 }
 
 *,

--- a/site/src/layouts/Base/Base.module.css
+++ b/site/src/layouts/Base/Base.module.css
@@ -40,5 +40,5 @@
 }
 
 .middle :global(.wrapper) {
-  max-width: 100ch;
+  max-width: var(--site-content-max-width);
 }

--- a/site/src/layouts/Base/PageHeading.module.css
+++ b/site/src/layouts/Base/PageHeading.module.css
@@ -9,7 +9,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--salt-spacing-100);
-  max-width: 100ch;
+  max-width: var(--site-content-max-width);
   width: 100%;
 }
 

--- a/site/src/layouts/DetailComponent/ComponentPageHeading.module.css
+++ b/site/src/layouts/DetailComponent/ComponentPageHeading.module.css
@@ -9,7 +9,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--salt-spacing-100);
-  max-width: 100ch;
+  max-width: var(--site-content-max-width);
   width: 100%;
 }
 

--- a/site/src/layouts/DetailComponent/DetailComponent.module.css
+++ b/site/src/layouts/DetailComponent/DetailComponent.module.css
@@ -22,4 +22,5 @@
 
 .content {
   min-width: 1px;
+  flex-basis: var(--site-content-max-width);
 }


### PR DESCRIPTION
Test on [`/salt/components/ag-grid-theme/accessibility`](https://saltdesignsystem-git-4908-fix-tabs-shrinking-fed-team.vercel.app/salt/components/ag-grid-theme/accessibility), which shouldn't have narrow tabs.

Extract content max width to a global variable to prepare for update in the future. Not including max-width update to 85ch, before font size can be updated to 16px (#4977)

Closes #4908