### PR TITLE
[DNM] Compare with ag theme Quartz

### DIFF
--- a/packages/ag-grid-theme/src/examples/HDCompactQuartz.tsx
+++ b/packages/ag-grid-theme/src/examples/HDCompactQuartz.tsx
@@ -5,9 +5,6 @@ import dataGridExampleColumnsHdCompact from "../dependencies/dataGridExampleColu
 import dataGridExampleData from "../dependencies/dataGridExampleData";
 import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
 
-import "ag-grid-community/styles/ag-grid.css";
-import "../../salt-ag-theme.css";
-
 const statusBar = {
   statusPanels: [
     {
@@ -23,7 +20,7 @@ const statusBar = {
 const repeat = (arr, n) => Array(n).fill(arr).flat();
 const data = repeat(dataGridExampleData, 50);
 
-const HDCompact = (props: AgGridReactProps) => {
+const HDCompactAlt = (props: AgGridReactProps) => {
   const { themeNext } = useTheme();
   const { agGridProps, containerProps } = useAgGridHelpers({
     compact: true,
@@ -32,9 +29,17 @@ const HDCompact = (props: AgGridReactProps) => {
 
   const Provider = themeNext ? SaltProviderNext : SaltProvider;
 
+  const { className, ...restContainerProps } = containerProps;
+
   return (
     <Provider density="high">
-      <div {...containerProps}>
+      <div
+        {...restContainerProps}
+        className={className?.replace(
+          "ag-theme-salt-compact-light",
+          "ag-theme-quartz",
+        )}
+      >
         <AgGridReact
           columnDefs={dataGridExampleColumnsHdCompact}
           rowData={data}
@@ -59,4 +64,4 @@ const HDCompact = (props: AgGridReactProps) => {
   );
 };
 
-export default HDCompact;
+export default HDCompactAlt;

--- a/packages/ag-grid-theme/src/examples/index.ts
+++ b/packages/ag-grid-theme/src/examples/index.ts
@@ -9,6 +9,7 @@ export { default as Coloration } from "./Coloration";
 export { default as Icons } from "./Icons";
 export { default as FloatingFilter } from "./FloatingFilter";
 export { default as HDCompact } from "./HDCompact";
+export { default as HDCompactQuartz } from "./HDCompactQuartz";
 export { default as LoadingOverlay } from "./LoadingOverlay";
 export { default as MasterDetail } from "./MasterDetail";
 export { default as NoDataOverlay } from "./NoDataOverlay";

--- a/packages/ag-grid-theme/stories/ag-grid-theme-quartz.stories.tsx
+++ b/packages/ag-grid-theme/stories/ag-grid-theme-quartz.stories.tsx
@@ -1,0 +1,24 @@
+import { AgGridReact } from "ag-grid-react";
+
+import "ag-grid-community/styles/ag-grid.css";
+import "ag-grid-community/styles/ag-theme-quartz.min.css";
+
+import "@salt-ds/countries/saltSharpCountries.css";
+
+export default {
+  title: "Ag Grid/Ag Grid Theme Quartz",
+  component: AgGridReact,
+  parameters: {
+    // Make all ag grid examples go through chromatic
+    chromatic: {
+      disableSnapshot: false,
+      delay: 200,
+      // double default width from `useAgGridHelpers` given we're using side-by-side mode, + panel wrapper padding
+      modes: {
+        dual: { mode: "side-by-side", viewport: { width: 800 * 2 + 24 * 4 } },
+      },
+    },
+  },
+};
+
+export { HDCompactQuartz } from "../src/examples";


### PR DESCRIPTION
Compare theme performance around scroll. 

## Summary

Assuming comparison set up is correct

- Salt theme is not slow, but marginally better than ag theme quartz during pure scroll test
- `.salt-theme ::selection`  contributes up to 50% of the rendering time (from https://github.com/jpmorganchase/salt-ds/blob/05d4263ac62056b84c7e8ac65ce130dcb39884da/packages/theme/css/global.css#L13-L16)

## Set up

Storybook links:
- [HD compact long scroll with salt theme](https://jpmorganchase-ag-grid-theme.saltdesignsystem-storybook.pages.dev/iframe?globals=&args=&id=ag-grid-ag-grid-theme--hd-compact&viewMode=story)

```js
import "ag-grid-community/styles/ag-grid.css";
import "../../salt-ag-theme.css";
``` 
- [HD compact long scroll with ag quartz theme](https://jpmorganchase-ag-grid-theme.saltdesignsystem-storybook.pages.dev/iframe.html?globals=&args=&id=ag-grid-ag-grid-theme-quartz--hd-compact-quartz)
```js
import "ag-grid-community/styles/ag-grid.css";
import "ag-grid-community/styles/ag-theme-quartz.min.css";
```

Ag grid theme doc: https://www.ag-grid.com/archive/32.2.0/javascript-data-grid/themes/. Note that 2 CSS files are needed.

## Test Details

Use script to scroll `.ag-body-viewport.ag-row-animation.ag-layout-normal` element five times. Use Chrome dev tools Performance Tab with "Enable CSS selector stats (slow)" **checked**. 

Note: Salt theme grid has 3 more visible rows compared to quartz theme

Rendering time is what's shown in the result Summary break down

| Theme | Rendering | 
| --- | --- |
| Salt theme |  1,640ms |
| Ag Quartz | 1,921ms |

Given `.salt-theme ::selection` are top few selectors shown in the Selector stats tab, remove below using Source tab after a full tab reload, then run the same performance test above

```css
.salt-theme ::selection {
    background: var(--salt-content-foreground-highlight)
}
```

| Theme | Rendering | 
| --- | --- |
| Salt theme |  868ms |
| Ag Quartz | 1,125ms |

