### PR TITLE
Parallel cypress test on GitHub action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,7 @@ jobs:
           cache: "yarn"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT    
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -146,7 +146,7 @@ jobs:
           cache: "yarn"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT    
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,11 +90,39 @@ jobs:
       - name: Install dependencies
         run: yarn
       - run: yarn run test
-  cypress-tests:
+  cypress-tests-prebuild:
     strategy:
       fail-fast: false
       matrix:
         react: [16, 17, 18]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "yarn"
+      - name: Install dependencies
+        run: yarn
+      - name: Setup react
+        run: yarn up react@${{ matrix.react }} react-dom@${{ matrix.react }}
+      - name: Build packages
+        run: yarn run build
+      - uses: actions/cache/save@v4
+        with:
+          path: |
+            dist
+          key: cache-${{ github.sha }}-${{ matrix.react }}
+
+  cypress-tests:
+    needs: cypress-tests-prebuild
+    strategy:
+      fail-fast: false
+      matrix:
+        react: [16, 17, 18]
+        testSpecs: [core, others]
     runs-on: ubuntu-latest
     container:
       image: cypress/browsers:node-22.14.0-chrome-133.0.6943.126-1-ff-135.0.1-edge-133.0.3065.82-1
@@ -111,16 +139,30 @@ jobs:
         run: yarn
       - name: Setup react
         run: yarn up react@${{ matrix.react }} react-dom@${{ matrix.react }}
-      - name: Build packages
-        run: yarn run build
-      - name: Cypress Components
+      - name: Restore cached build dist
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            dist
+          key: cache-${{ github.sha }}-${{ matrix.react }}
+      - name: Cypress Components (core)
         uses: cypress-io/github-action@v6
+        if: matrix.testSpecs == 'core'
         with:
           install: false
           component: true
           browser: chrome
+          spec: "packages/core/src/**/*.cy.{js,ts,jsx,tsx}"
+      - name: Cypress Components (others)
+        uses: cypress-io/github-action@v6
+        if: matrix.testSpecs == 'others'
+        with:
+          install: false
+          component: true
+          browser: chrome
+          spec: "packages/!(core)/src/**/*.cy.{js,ts,jsx,tsx}"
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: cypress-screenshots-${{ matrix.react }}
+          name: cypress-screenshots-${{ matrix.react }}-${{ matrix.testSpecs }}
           path: cypress/screenshots

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,9 +106,8 @@ jobs:
           cache: "yarn"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT    
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT    
       - uses: actions/cache@v4
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ matrix.react }}-${{ hashFiles('**/yarn.lock') }}
@@ -147,9 +146,8 @@ jobs:
           cache: "yarn"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT    
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT    
       - uses: actions/cache@v4
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ matrix.react }}-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,16 @@ jobs:
         with:
           node-version: "20"
           cache: "yarn"
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT    
+      - uses: actions/cache@v4
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ matrix.react }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-${{ matrix.react }}-
       - name: Install dependencies
         run: yarn
       - name: Setup react
@@ -135,6 +145,16 @@ jobs:
         with:
           node-version: "20"
           cache: "yarn"
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT    
+      - uses: actions/cache@v4
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ matrix.react }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-${{ matrix.react }}-
       - name: Install dependencies
         run: yarn
       - name: Setup react

--- a/yarn.lock
+++ b/yarn.lock
@@ -6867,9 +6867,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001579, caniuse-lite@npm:^1.0.30001629":
-  version: 1.0.30001632
-  resolution: "caniuse-lite@npm:1.0.30001632"
-  checksum: 10/80b8b75007e525c30ec204adff4a16797a83ac9faeec33ed20ad14b55239c2721693f248389ee3bc9a76f8fd0182870872af7a9c80d48484a3eab7c5e8af173f
+  version: 1.0.30001713
+  resolution: "caniuse-lite@npm:1.0.30001713"
+  checksum: 10/0c1b97320d08cf87c73883fe9a7b9d8037b7c24aa027641e75cce3dee74c9ad538cf17725fdcb46e6ec86be8efedf6edd0848db07c5f8110936ccf0185e2ff68
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Split step to 2
    - first to build packages and cache `dist`
    - second to run tests only, and split core and lab tests to run at the same time

```mermaid
flowchart LR
    prebuild["`cypress-test-prebuild (16)
cypress-test-prebuild (17)
cypress-test-prebuild (18)`"]
    tests["`cypress-tests (16, core)
cypress-tests (16, others)
cypress-tests (17, core)
cypress-tests (17, others)
cypress-tests (18, core)
cypress-tests (18, others)
`"]
    prebuild --> tests
```

Example run: https://github.com/origami-z/salt-ds/actions/runs/14399440198