### PR TITLE
add center alignment to menu items

### DIFF
--- a/.changeset/spicy-peas-beam.md
+++ b/.changeset/spicy-peas-beam.md
@@ -2,4 +2,4 @@
 "@salt-ds/core": patch
 ---
 
-Adds center alignment styling to `MenuItem`
+Added center alignment styling to `MenuItem`

--- a/.changeset/spicy-peas-beam.md
+++ b/.changeset/spicy-peas-beam.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Adds center alignment styling to `MenuItem`

--- a/packages/core/src/menu/MenuItem.css
+++ b/packages/core/src/menu/MenuItem.css
@@ -1,4 +1,5 @@
 .saltMenuItem {
+  align-items: center;
   color: var(--salt-content-primary-foreground);
   background: var(--salt-selectable-background);
   font-size: var(--salt-text-fontSize);


### PR DESCRIPTION
If salt-size-base is changed at theme level, menu item text is misaligned