### PR TITLE
doc: Add Category and Content group to characteristics page

### DIFF
--- a/site/docs/themes/characteristics/index.mdx
+++ b/site/docs/themes/characteristics/index.mdx
@@ -18,11 +18,23 @@ Components with the ability to action something, action is performed immediately
 
 <CharacteristicsTokenTable themeNext={true} group="actionable" />
 
+## Category
+
+Colors support data visualization and the grouping of related content.
+
+<CharacteristicsTokenTable themeNext={true} group="category" />
+
 ## Container
 
 Group of components used to contain and separate different types of content and allow hierarchical organization.
 
 <CharacteristicsTokenTable themeNext={true} group="container" />
+
+## Content
+
+Styling of container content in the foreground, primarily text and icons.
+
+<CharacteristicsTokenTable themeNext={true} group="content" />
 
 ## Draggable
 

--- a/site/docs/themes/characteristics/legacy.mdx
+++ b/site/docs/themes/characteristics/legacy.mdx
@@ -17,11 +17,23 @@ Components with the ability to action something, action is performed immediately
 
 <CharacteristicsTokenTable themeNext={false} group="actionable" />
 
+## Category
+
+Colors support data visualization and the grouping of related content.
+
+<CharacteristicsTokenTable themeNext={true} group="category" />
+
 ## Container
 
 Group of components used to contain and separate different types of content and allow hierarchical organization.
 
 <CharacteristicsTokenTable themeNext={false} group="container" />
+
+## Content
+
+Styling of container content in the foreground, primarily text and icons.
+
+<CharacteristicsTokenTable themeNext={true} group="content" />
 
 ## Draggable
 

--- a/site/docs/themes/characteristics/legacy.mdx
+++ b/site/docs/themes/characteristics/legacy.mdx
@@ -21,7 +21,7 @@ Components with the ability to action something, action is performed immediately
 
 Colors support data visualization and the grouping of related content.
 
-<CharacteristicsTokenTable themeNext={true} group="category" />
+<CharacteristicsTokenTable themeNext={false} group="category" />
 
 ## Container
 
@@ -33,7 +33,7 @@ Group of components used to contain and separate different types of content and 
 
 Styling of container content in the foreground, primarily text and icons.
 
-<CharacteristicsTokenTable themeNext={true} group="content" />
+<CharacteristicsTokenTable themeNext={false} group="content" />
 
 ## Draggable
 


### PR DESCRIPTION
Missing 2 groups from the doc

Category and content was missing on [`/salt/themes/characteristics/index`](https://saltdesignsystem-git-4769-add-content-category-243389-fed-team.vercel.app/salt/themes/characteristics/index)