### PR TITLE
[Test] Corner radius support for ag grid theme

### DIFF
--- a/.changeset/ag-theme-rounded-corner.md
+++ b/.changeset/ag-theme-rounded-corner.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/ag-grid-theme": minor
+---
+
+Added corner radius support for `.editable-cell` and floating filter when used in brand theme.

--- a/packages/ag-grid-theme/css/parts/ag-body.css
+++ b/packages/ag-grid-theme/css/parts/ag-body.css
@@ -65,8 +65,6 @@
 .ag-theme-salt-compact-light .ag-ltr .ag-cell-inline-editing,
 .ag-theme-salt-compact-dark .ag-ltr .ag-cell-inline-editing {
   padding: 0;
-  /* When styling option corner='rounded', we don't want this to be flipped between rounded and not between editing and normal state */
-  border-radius: 0;
 }
 
 .ag-theme-salt-light .ag-cell-inline-editing.editable-cell input[class^="ag-"],
@@ -86,6 +84,7 @@
 .ag-theme-salt-compact-dark .editable-numeric-cell {
   outline: var(--salt-size-border) var(--salt-container-borderStyle) var(--salt-editable-borderColor);
   outline-offset: -1px;
+  border-radius: var(--salt-palette-corner-weak);
 }
 
 .ag-theme-salt-light .ag-cell.numeric-cell,
@@ -213,7 +212,6 @@
 .ag-theme-salt-compact-light .ag-select .ag-picker-field-wrapper,
 .ag-theme-salt-compact-dark .ag-select .ag-picker-field-wrapper {
   border: var(--salt-size-border) var(--salt-separable-borderStyle) var(--salt-editable-borderColor);
-  border-radius: 0;
 }
 
 .ag-theme-salt-light .ag-ltr .editable-cell .ag-select .ag-picker-field-wrapper,
@@ -225,7 +223,6 @@
 .ag-theme-salt-compact-dark .ag-ltr .editable-cell .ag-select .ag-picker-field-wrapper,
 .ag-theme-salt-compact-dark .ag-ltr .editable-cell .ag-rich-select .ag-picker-field-wrapper {
   padding: 0 var(--salt-spacing-100);
-  border-radius: 0;
 }
 
 .ag-theme-salt-light .ag-ltr .editable-cell .ag-select .ag-icon-small-down::before,

--- a/packages/ag-grid-theme/css/parts/ag-checkbox.css
+++ b/packages/ag-grid-theme/css/parts/ag-checkbox.css
@@ -3,7 +3,7 @@
 .ag-theme-salt-dark .ag-checkbox-input-wrapper,
 .ag-theme-salt-compact-light .ag-checkbox-input-wrapper,
 .ag-theme-salt-compact-dark .ag-checkbox-input-wrapper {
-  /* border-radius doesn't work given border is part of the font glyph */
+  /* border-radius doesn't work given border is part of the font glyph, v33 new theme approach will support this. */
   height: var(--salt-size-selectable);
   width: var(--salt-size-selectable);
   font-size: var(--salt-size-selectable);

--- a/packages/ag-grid-theme/css/parts/ag-header.css
+++ b/packages/ag-grid-theme/css/parts/ag-header.css
@@ -369,3 +369,10 @@
   margin-inline-start: var(--salt-spacing-100);
   margin-inline-end: 0;
 }
+
+.ag-theme-salt-light .ag-header-cell.ag-floating-filter,
+.ag-theme-salt-dark .ag-header-cell.ag-floating-filter,
+.ag-theme-salt-compact-light .ag-header-cell.ag-floating-filter,
+.ag-theme-salt-compact-dark .ag-header-cell.ag-floating-filter {
+  border-radius: var(--salt-palette-corner-weak);
+}


### PR DESCRIPTION
- Corner support for floating filter cells and `.editable-cell` cells
- Checkbox doesn't work given it's part of font glyph

Check on [`/?path=/story/ag-grid-ag-grid-theme--provided-cell-editors&globals=themeNext:enable;corner:rounded`](/?path=/story/ag-grid-ag-grid-theme--provided-cell-editors&globals=themeNext:enable;corner:rounded)