### PR TITLE
Toggle button appearance example and jsdoc comments

### DIFF
--- a/.changeset/thirty-camels-tell.md
+++ b/.changeset/thirty-camels-tell.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Updated `ToggleButton` `appearance` JSDoc to be more clear around selected state.

--- a/packages/core/src/toggle-button/ToggleButton.tsx
+++ b/packages/core/src/toggle-button/ToggleButton.tsx
@@ -16,7 +16,7 @@ import toggleButtonCss from "./ToggleButton.css";
 
 export interface ToggleButtonProps extends ComponentPropsWithoutRef<"button"> {
   /**
-   * The appearance of the toggle button.
+   * The appearance of the toggle button when `selected` is true.
    * @default solid
    */
   appearance?: Extract<ButtonAppearance, "bordered" | "solid">;

--- a/site/src/examples/toggle-button/Appearance.tsx
+++ b/site/src/examples/toggle-button/Appearance.tsx
@@ -3,8 +3,10 @@ import type { ReactElement } from "react";
 
 export const Appearance = (): ReactElement => (
   <FlowLayout>
-    <ToggleButton value="solid">Solid</ToggleButton>
-    <ToggleButton value="bordered" appearance="bordered">
+    <ToggleButton defaultChecked value="solid">
+      Solid
+    </ToggleButton>
+    <ToggleButton defaultChecked value="bordered" appearance="bordered">
       Bordered
     </ToggleButton>
   </FlowLayout>


### PR DESCRIPTION
Example is not straightforward obvious 2 example toggle button are different:  
https://www.saltdesignsystem.com/salt/components/toggle-button/examples#selected-appearance