### PR TITLE
Update icon and country symbol site search

### DIFF
--- a/site/src/components/country-symbol-preview/CountrySymbolPreview.tsx
+++ b/site/src/components/country-symbol-preview/CountrySymbolPreview.tsx
@@ -1,8 +1,8 @@
 import {
   Button,
-  FlexItem,
-  FlexLayout,
   FlowLayout,
+  FormField,
+  FormFieldLabel,
   Input,
   StackLayout,
   StatusIndicator,
@@ -84,39 +84,41 @@ export const CountrySymbolPreview = () => {
     );
   }, [filteredSymbols, deferredSearch]);
 
+  const totalCount = Object.values(countryMetaMap).length;
+
   return (
     <Suspense fallback="Loading...">
       <StackLayout className={styles.root} gap={1}>
-        <FlexLayout direction="row">
-          <FlexItem>
-            <Input
-              placeholder="Search country symbols"
-              aria-label="Search country symbols"
-              value={search}
-              onChange={handleSearch}
-              className={styles.search}
-              startAdornment={<SearchIcon />}
-              endAdornment={
-                search ? (
-                  <Button
-                    onClick={handleClear}
-                    appearance="transparent"
-                    sentiment="neutral"
-                    aria-label="Clear search"
-                  >
-                    <CloseIcon aria-hidden />
-                  </Button>
-                ) : null
-              }
-            />
-          </FlexItem>
-          <FlexItem className={styles.formfield}>
-            <Text className={styles.symbolCount}>
-              Symbol Count: {filteredSymbols.length}
-            </Text>
-          </FlexItem>
-        </FlexLayout>
+        <FormField>
+          <FormFieldLabel>Search country symbols</FormFieldLabel>
+          <Input
+            value={search}
+            onChange={handleSearch}
+            className={styles.search}
+            startAdornment={<SearchIcon />}
+            endAdornment={
+              search ? (
+                <Button
+                  onClick={handleClear}
+                  appearance="transparent"
+                  sentiment="neutral"
+                  aria-label="Clear search"
+                >
+                  <CloseIcon aria-hidden />
+                </Button>
+              ) : null
+            }
+          />
+        </FormField>
+
         <div className={styles.symbolsContainer}>{renderSymbols}</div>
+
+        <Text styleAs="label" color="secondary">
+          Total symbols: {totalCount}.
+          {totalCount > filteredSymbols.length
+            ? ` Filtered: ${filteredSymbols.length}.`
+            : null}
+        </Text>
       </StackLayout>
     </Suspense>
   );

--- a/site/src/components/icon-preview/IconPreview.module.css
+++ b/site/src/components/icon-preview/IconPreview.module.css
@@ -22,10 +22,16 @@
 }
 
 .iconCard {
-  padding-top: var(--salt-spacing-300);
-  padding-inline: var(--salt-spacing-25);
-  height: calc(var(--salt-size-base) * 4);
-  aspect-ratio: 1.1;
+  padding-block: var(--salt-spacing-200);
+  height: calc(var(--salt-size-base) * 3);
+  aspect-ratio: 1.05;
+}
+
+@media not screen and (min-width: 960px) {
+  .iconCard {
+    padding-block: var(--salt-spacing-100);
+    height: calc(var(--salt-size-base) * 2.5);
+  }
 }
 
 .iconContainer {
@@ -35,12 +41,8 @@
   min-height: calc(var(--salt-size-icon) * 2);
 }
 
+.resultContainer,
 .notFound {
   flex: 1;
   justify-content: center;
-}
-
-.iconCount {
-  display: flex;
-  align-items: center;
 }

--- a/site/src/components/icon-preview/IconPreview.tsx
+++ b/site/src/components/icon-preview/IconPreview.tsx
@@ -3,12 +3,10 @@ import {
   Checkbox,
   CheckboxGroup,
   FlexItem,
-  FlexLayout,
   FlowLayout,
   FormField,
   FormFieldLabel,
   Input,
-  SaltProvider,
   StackLayout,
   StatusIndicator,
   Text,
@@ -31,7 +29,9 @@ export function IconPreview() {
   }, []);
 
   const [search, setSearch] = useState("");
-  const deferredSearch = useDeferredValue(search.toLowerCase());
+  const deferredSearch = useDeferredValue(
+    search.toLowerCase().replaceAll(/\s/g, ""),
+  );
   const [variants, setVariants] = useState<("solid" | "outline")[]>([
     "solid",
     "outline",
@@ -57,7 +57,8 @@ export function IconPreview() {
 
   const filteredIcons = useMemo(() => {
     return Object.entries(allIcons).filter(([name]) => {
-      const matchesSearch = name.toLowerCase().includes(deferredSearch);
+      const iconNameToMatch = name.toLowerCase(); // add acronym when available
+      const matchesSearch = iconNameToMatch.includes(deferredSearch);
       const isOutlineIcon = !name.endsWith("SolidIcon");
       const isSolidIcon = name.endsWith("SolidIcon");
       return (
@@ -112,33 +113,37 @@ export function IconPreview() {
     );
   }, [filteredIcons, deferredSearch]);
 
+  const totalCount = Object.entries(allIcons).length;
+
   return (
     <StackLayout className={styles.root} gap={1}>
-      <FlexLayout wrap>
+      <FlowLayout justify="space-between">
         <FlexItem>
-          <Input
-            placeholder="Search icons"
-            aria-label="Search icons"
-            value={search}
-            onChange={handleSearch}
-            className={styles.search}
-            startAdornment={<SearchIcon />}
-            endAdornment={
-              search ? (
-                <Button
-                  onClick={handleClear}
-                  appearance="transparent"
-                  sentiment="neutral"
-                  aria-label="Clear search"
-                >
-                  <CloseIcon aria-hidden />
-                </Button>
-              ) : null
-            }
-          />
+          <FormField>
+            <FormFieldLabel>Search icons</FormFieldLabel>
+            <Input
+              value={search}
+              onChange={handleSearch}
+              className={styles.search}
+              startAdornment={<SearchIcon />}
+              endAdornment={
+                search ? (
+                  <Button
+                    onClick={handleClear}
+                    appearance="transparent"
+                    sentiment="neutral"
+                    aria-label="Clear search"
+                  >
+                    <CloseIcon aria-hidden />
+                  </Button>
+                ) : null
+              }
+            />
+          </FormField>
         </FlexItem>
+
         <FlexItem>
-          <FormField labelPlacement="left" className={styles.formfield}>
+          <FormField>
             <FormFieldLabel>Show variant</FormFieldLabel>
             <CheckboxGroup
               checkedValues={variants}
@@ -150,13 +155,16 @@ export function IconPreview() {
             </CheckboxGroup>
           </FormField>
         </FlexItem>
-        <FlexItem className={styles.formfield}>
-          <Text className={styles.iconCount}>
-            Icon Count: {filteredIcons.length}
-          </Text>
-        </FlexItem>
-      </FlexLayout>
-      <SaltProvider density="medium">{renderIcons}</SaltProvider>
+      </FlowLayout>
+
+      <div className={styles.resultContainer}>{renderIcons}</div>
+
+      <Text styleAs="label" color="secondary">
+        Total icons:{totalCount}.
+        {totalCount > filteredIcons.length
+          ? ` Filtered: ${filteredIcons.length}.`
+          : null}
+      </Text>
     </StackLayout>
   );
 }


### PR DESCRIPTION
- fix icon search doesn't support 2 words, e.g. "man woman" wasn't result anything
- move total / filter count to the bottom, to be more aligned with [ag grid status bar](https://www.saltdesignsystem.com/salt/components/ag-grid-theme/examples#status-bar)
- use visible form field label to be more accessible on the search field
- use top aligned form field on the checkbox group, given left aligned has problem due to 16px font-size override.