### PR TITLE
Fix site code block copy button not working

### DIFF
--- a/site/src/components/components/LivePreview.tsx
+++ b/site/src/components/components/LivePreview.tsx
@@ -85,7 +85,8 @@ export const LivePreview: FC<LivePreviewProps> = ({
                 </ChosenSaltProvider>
               </div>
             </ChosenSaltProvider>
-            <SaltProviderNext density="medium" applyClassesTo="child">
+            {/* Unset theme, font size override would cause switch misalignment */}
+            <SaltProviderNext density="low" applyClassesTo="child" theme="">
               <div className={styles.toolbar}>
                 <Switch
                   checked={showCode}

--- a/site/src/components/mdx/pre/Pre.tsx
+++ b/site/src/components/mdx/pre/Pre.tsx
@@ -32,7 +32,9 @@ export const Pre = forwardRef<HTMLDivElement, PreProps>(function Pre(
   const divRef = useRef<HTMLDivElement>(null);
   const handleClickCopy = () => {
     if (divRef.current?.textContent) {
-      navigator.clipboard.writeText(divRef.current.textContent).catch(() => {});
+      navigator.clipboard
+        .writeText(divRef.current.textContent)
+        .catch(console.error);
     }
   };
 
@@ -75,6 +77,7 @@ export const Pre = forwardRef<HTMLDivElement, PreProps>(function Pre(
         className={styles.codeblock}
         // biome-ignore lint/security/noDangerouslySetInnerHtml: Needed for Shiki.
         dangerouslySetInnerHTML={{ __html: html }}
+        ref={divRef}
       />
     </div>
   );


### PR DESCRIPTION
Try any code block, e.g., `/salt/getting-started/developing`, was not copying...