### PR TITLE
Add corner radius to Site Diagram

### DIFF
--- a/site/src/components/diagrams/Diagrams.module.css
+++ b/site/src/components/diagrams/Diagrams.module.css
@@ -79,6 +79,7 @@
 .image {
   justify-content: center;
   display: flex;
+  border-radius: var(--salt-palette-corner);
 }
 
 .diagramsContainer .image img {


### PR DESCRIPTION
Try to align with component preview.

See [`/salt/patterns/search`](https://saltdesignsystem-git-site-diagram-image-radius-fed-team.vercel.app/salt/patterns/search)