### PR TITLE
Fix Navigation Item label left padding

### DIFF
--- a/.changeset/famous-feet-cry.md
+++ b/.changeset/famous-feet-cry.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Fixed extra left padding of NavigationItem label without an icon.

--- a/packages/core/src/navigation-item/NavigationItem.css
+++ b/packages/core/src/navigation-item/NavigationItem.css
@@ -35,7 +35,6 @@
 
 /* Styles applied to NavigationItem label */
 .saltNavigationItem-label {
-  padding-left: calc(var(--saltNavigationItem-level, 0) * var(--salt-spacing-100));
   flex: 1;
   text-align: left;
   display: flex;
@@ -56,8 +55,14 @@
   padding-top: 0;
   padding-bottom: 0;
   padding-right: var(--salt-spacing-100);
-  padding-left: calc(var(--salt-spacing-300) * (min(var(--saltNavigationItem-level, 0) + 1, 2)));
+  /* Lvl 1 and above - spacing 300 + size-icon + spacing 100 * (level + 1) */
+  padding-left: calc(var(--salt-spacing-300) + max(var(--salt-size-icon), 12px) + var(--salt-spacing-100) * calc(var(--saltNavigationItem-level, 0) + 1));
   width: 100%;
+}
+
+.saltNavigationItem[data-level="0"] .saltNavigationItem-vertical {
+  /* Lvl 0 - spacing 300, icon and gap is managed within item internals */
+  padding-left: var(--salt-spacing-300);
 }
 
 /* Styles applied to NavigationItem Badge */

--- a/packages/core/src/navigation-item/NavigationItem.css
+++ b/packages/core/src/navigation-item/NavigationItem.css
@@ -50,16 +50,6 @@
   width: 100%;
 }
 
-/* Styles applied to NavigationItem label */
-.saltNavigationItem-label {
-  padding-left: calc(var(--saltNavigationItem-level, 0) * var(--salt-spacing-100));
-  flex: 1;
-  text-align: left;
-  display: flex;
-  align-items: baseline;
-  gap: var(--salt-spacing-100);
-}
-
 /* Styles applied when orientation = "horizontal" */
 .saltNavigationItem-horizontal {
   min-height: calc(var(--salt-size-base) + var(--salt-spacing-100) * 2);
@@ -85,6 +75,11 @@
   display: flex;
   align-items: baseline;
   gap: var(--salt-spacing-100);
+}
+
+.saltNavigationItem-label:not(:first-child) {
+  /* Only applies when an icon is used before */
+  padding-left: calc(var(--saltNavigationItem-level, 0) * var(--salt-spacing-100));
 }
 
 /* Styles applied to NavigationItem Badge */

--- a/packages/core/src/navigation-item/NavigationItem.css
+++ b/packages/core/src/navigation-item/NavigationItem.css
@@ -69,7 +69,6 @@
 
 /* Styles applied to NavigationItem label */
 .saltNavigationItem-label {
-  padding-left: calc(var(--saltNavigationItem-level, 0) * var(--salt-spacing-100));
   flex: 1;
   text-align: left;
   display: flex;

--- a/packages/core/src/navigation-item/NavigationItem.css
+++ b/packages/core/src/navigation-item/NavigationItem.css
@@ -76,11 +76,6 @@
   gap: var(--salt-spacing-100);
 }
 
-.saltNavigationItem-label:not(:first-child) {
-  /* Only applies when an icon is used before */
-  padding-left: calc(var(--saltNavigationItem-level, 0) * var(--salt-spacing-100));
-}
-
 /* Styles applied to NavigationItem Badge */
 .saltNavigationItem-label .saltBadge {
   margin-left: auto;

--- a/packages/core/src/navigation-item/NavigationItem.css
+++ b/packages/core/src/navigation-item/NavigationItem.css
@@ -33,6 +33,16 @@
   top: var(--salt-spacing-25);
 }
 
+/* Styles applied to NavigationItem label */
+.saltNavigationItem-label {
+  padding-left: calc(var(--saltNavigationItem-level, 0) * var(--salt-spacing-100));
+  flex: 1;
+  text-align: left;
+  display: flex;
+  align-items: baseline;
+  gap: var(--salt-spacing-100);
+}
+
 /* Styles applied when orientation = "horizontal" */
 .saltNavigationItem-horizontal {
   min-height: calc(var(--salt-size-base) + var(--salt-spacing-100) * 2);
@@ -48,32 +58,6 @@
   padding-right: var(--salt-spacing-100);
   padding-left: calc(var(--salt-spacing-300) * (min(var(--saltNavigationItem-level, 0) + 1, 2)));
   width: 100%;
-}
-
-/* Styles applied when orientation = "horizontal" */
-.saltNavigationItem-horizontal {
-  min-height: calc(var(--salt-size-base) + var(--salt-spacing-100) * 2);
-  padding: 0 var(--salt-spacing-100);
-  width: fit-content;
-}
-
-/* Styles applied when orientation = "vertical" */
-.saltNavigationItem-vertical {
-  --saltButton-margin: var(--salt-spacing-50) 0;
-
-  min-height: calc(var(--salt-size-base) + var(--salt-spacing-50) * 2);
-  padding-right: var(--salt-spacing-100);
-  padding-left: calc(var(--salt-spacing-300) * (min(var(--saltNavigationItem-level, 0) + 1, 2)));
-  width: 100%;
-}
-
-/* Styles applied to NavigationItem label */
-.saltNavigationItem-label {
-  flex: 1;
-  text-align: left;
-  display: flex;
-  align-items: baseline;
-  gap: var(--salt-spacing-100);
 }
 
 /* Styles applied to NavigationItem Badge */

--- a/packages/core/src/navigation-item/NavigationItem.tsx
+++ b/packages/core/src/navigation-item/NavigationItem.tsx
@@ -97,6 +97,7 @@ export const NavigationItem = forwardRef<HTMLDivElement, NavigationItemProps>(
         ref={ref}
         className={clsx(withBaseName(), className)}
         style={style}
+        data-level={level}
         {...rest}
       >
         <NavigationItemAction

--- a/packages/core/stories/navigation-item/navigation-item.qa.stories.tsx
+++ b/packages/core/stories/navigation-item/navigation-item.qa.stories.tsx
@@ -70,6 +70,22 @@ export const AllExamples: StoryFn<QAContainerProps> = () => (
             Level 3
           </NavigationItem>
         </StackLayout>
+        <StackLayout gap="var(--salt-size-border">
+          <NavigationItem orientation="vertical" level={0} parent expanded>
+            <NotificationIcon />
+            Level 0 with icon
+          </NavigationItem>
+          <NavigationItem orientation="vertical" level={1}>
+            Level 1
+          </NavigationItem>
+          <NavigationItem orientation="vertical" level={2}>
+            Level 2
+          </NavigationItem>
+          <NavigationItem orientation="vertical" level={0} parent blurActive>
+            <NotificationIcon />
+            Level 0 with icon
+          </NavigationItem>
+        </StackLayout>
       </FlowLayout>
     </QAContainer>
   </>


### PR DESCRIPTION
Closes #3423

Temporay fix in response to Pepper report of Figma component library doesn't align with code. Although [Figma Spec](https://www.figma.com/design/iXMqNur2JdAxSXgHYFx6h1/Navigation-item?node-id=2287-5096&m=dev) doesn't specify how to deal with child items with icons...

The strategy would be:
- For level 0, use `spacing-300` left padding, rely on children of `NavigationItem` to contribute to icon & gap
- For other levels, use `spacing-300` + `size-icon` + `spacing-100` * level, for padding. This would mean more spacing if using icon in these levels, however, sticking to Figma spec when used without icon

#4838 will contain further design changes 
