### PR TITLE
Fix checked indeterminate Checkbox styling 

### DIFF
--- a/.changeset/rich-walls-chew.md
+++ b/.changeset/rich-walls-chew.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Fix `CheckboxIcon` checked color styles applying when checkbox is `indeterminate`

--- a/.changeset/rich-walls-chew.md
+++ b/.changeset/rich-walls-chew.md
@@ -2,4 +2,4 @@
 "@salt-ds/core": patch
 ---
 
-Fix `CheckboxIcon` checked color styles applying when checkbox is `indeterminate`
+Fixed `Checkbox`'s checked color styles applying when `Checkbox` is indeterminate.

--- a/packages/core/src/checkbox/CheckboxIcon.css
+++ b/packages/core/src/checkbox/CheckboxIcon.css
@@ -22,8 +22,8 @@
   color: var(--salt-selectable-foreground-hover);
 }
 
-.saltCheckboxIcon-checked,
-.saltCheckbox:hover .saltCheckboxIcon-checked {
+.saltCheckboxIcon-checked:not(.saltCheckboxIcon-indeterminate),
+.saltCheckbox:hover .saltCheckboxIcon-checked:not(.saltCheckboxIcon-indeterminate) {
   border-color: var(--salt-selectable-borderColor-selected);
   color: var(--salt-selectable-foreground-selected);
 }

--- a/packages/core/src/checkbox/CheckboxIcon.css
+++ b/packages/core/src/checkbox/CheckboxIcon.css
@@ -16,16 +16,21 @@
   box-sizing: border-box;
 }
 
+.saltCheckboxIcon-checked,
+.saltCheckbox:hover .saltCheckboxIcon-checked {
+  border-color: var(--salt-selectable-borderColor-selected);
+  color: var(--salt-selectable-foreground-selected);
+}
+
 .saltCheckbox:hover .saltCheckboxIcon,
 .saltCheckbox:hover .saltCheckboxIcon-indeterminate {
   border-color: var(--salt-selectable-borderColor-hover);
   color: var(--salt-selectable-foreground-hover);
 }
 
-.saltCheckboxIcon-checked:not(.saltCheckboxIcon-indeterminate),
-.saltCheckbox:hover .saltCheckboxIcon-checked:not(.saltCheckboxIcon-indeterminate) {
-  border-color: var(--salt-selectable-borderColor-selected);
-  color: var(--salt-selectable-foreground-selected);
+.saltCheckboxIcon-checked.saltCheckboxIcon-indeterminate {
+  border-color: var(--salt-selectable-borderColor);
+  color: var(--salt-selectable-foreground);
 }
 
 .saltCheckboxIcon-disabled,

--- a/packages/core/src/checkbox/CheckboxIcon.tsx
+++ b/packages/core/src/checkbox/CheckboxIcon.tsx
@@ -68,7 +68,7 @@ export const CheckboxIcon = ({
       className={clsx(
         withBaseName(),
         {
-          [withBaseName("checked")]: checked,
+          [withBaseName("checked")]: checked && !indeterminate,
           [withBaseName("disabled")]: disabled,
           [withBaseName("error")]: error,
           [withBaseName(validationStatus || "")]: validationStatus,

--- a/packages/core/src/checkbox/CheckboxIcon.tsx
+++ b/packages/core/src/checkbox/CheckboxIcon.tsx
@@ -68,7 +68,7 @@ export const CheckboxIcon = ({
       className={clsx(
         withBaseName(),
         {
-          [withBaseName("checked")]: checked && !indeterminate,
+          [withBaseName("checked")]: checked,
           [withBaseName("disabled")]: disabled,
           [withBaseName("error")]: error,
           [withBaseName(validationStatus || "")]: validationStatus,


### PR DESCRIPTION
When a checkbox has checked/defaultChecked set to true but is indeterminate, blue color styles are overriding the what should be gray (according to Figma spec) styles for an indeterminate checkbox as noticed here by @origami-z  https://storybook.saltdesignsystem.com/?path=/story/core-salt-provider--toggle-theme&globals=density:low 

Before

![image](https://github.com/user-attachments/assets/bfbef31b-9868-4ae8-a617-e062f3863e96)

After

![image](https://github.com/user-attachments/assets/1b934a0e-fa85-4aa2-8a45-40109a664e60)
