### PR TITLE
Fix build scripts

### DIFF
--- a/packages/ag-grid-theme/scripts/build.mjs
+++ b/packages/ag-grid-theme/scripts/build.mjs
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { argv } from "node:process";
+import url from "node:url";
 import { deleteSync } from "del";
 import esbuild from "esbuild";
 import fs from "fs-extra";
@@ -9,7 +10,7 @@ const FILES_TO_COPY = ["README.md", "LICENSE", "CHANGELOG.md"];
 
 const cwd = process.cwd();
 const packageJson = (
-  await import(path.join("file://", cwd, "package.json"), {
+  await import(url.pathToFileURL(path.join(cwd, "package.json")), {
     with: { type: "json" },
   })
 ).default;

--- a/packages/date-adapters/scripts/build.mjs
+++ b/packages/date-adapters/scripts/build.mjs
@@ -1,4 +1,5 @@
 import path from "node:path";
+import url from "node:url";
 import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
@@ -13,7 +14,7 @@ import { distinct } from "./../../../scripts/utils.mjs";
 const cwd = process.cwd();
 
 const packageJson = (
-  await import(path.join("file://", cwd, "package.json"), {
+  await import(url.pathToFileURL(path.join(cwd, "package.json")), {
     with: { type: "json" },
   })
 ).default;

--- a/packages/react-resizable-panels-theme/scripts/build.mjs
+++ b/packages/react-resizable-panels-theme/scripts/build.mjs
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { argv } from "node:process";
+import url from "node:url";
 import { deleteSync } from "del";
 import esbuild from "esbuild";
 import fs from "fs-extra";
@@ -9,7 +10,7 @@ const FILES_TO_COPY = ["README.md", "LICENSE", "CHANGELOG.md"];
 
 const cwd = process.cwd();
 const packageJson = (
-  await import(path.join("file://", cwd, "package.json"), {
+  await import(url.pathToFileURL(path.join(cwd, "package.json")), {
     with: { type: "json" },
   })
 ).default;

--- a/packages/theme/scripts/build.mjs
+++ b/packages/theme/scripts/build.mjs
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { argv } from "node:process";
+import url from "node:url";
 import { deleteSync } from "del";
 import esbuild from "esbuild";
 import fs from "fs-extra";
@@ -8,7 +9,7 @@ const FILES_TO_COPY = ["README.md", "LICENSE", "CHANGELOG.md", "package.json"];
 
 const cwd = process.cwd();
 const packageJson = (
-  await import(path.join("file://", cwd, "package.json"), {
+  await import(url.pathToFileURL(path.join(cwd, "package.json")), {
     with: { type: "json" },
   })
 ).default;

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,4 +1,5 @@
 import path from "node:path";
+import url from "node:url";
 import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
@@ -14,7 +15,7 @@ import { distinct } from "./utils.mjs";
 const cwd = process.cwd();
 
 const packageJson = (
-  await import(path.join("file://", cwd, "package.json"), {
+  await import(url.pathToFileURL(path.join(cwd, "package.json")), {
     with: { type: "json" },
   })
 ).default;


### PR DESCRIPTION
Node 22 breaks the old scripts. Node changed the way path functions work, which means they don't work with URLs e.g. file://. Apparently this was never supported