### PR TITLE
Fix AG theme zebra variant selection border colors

### DIFF
--- a/.changeset/dirty-deers-hope.md
+++ b/.changeset/dirty-deers-hope.md
@@ -1,0 +1,7 @@
+---
+"@salt-ds/ag-grid-theme": patch
+---
+
+- Fixed [zebra variant](https://www.saltdesignsystem.com/salt/components/ag-grid-theme/examples#variants) row selection border color.
+- Fixed row selection border hover color, if `ag-grid.css` is loaded after `salt-ag-theme.css`.
+- Updated code for [HD compact example](https://www.saltdesignsystem.com/salt/components/ag-grid-theme/examples#hd-compact), which caused some styling not correctly applied (#5056).

--- a/packages/ag-grid-theme/css/parts/ag-buttons.css
+++ b/packages/ag-grid-theme/css/parts/ag-buttons.css
@@ -176,20 +176,3 @@
 .ag-theme-salt-compact-dark .ag-column-drop-cell {
   border-radius: 0;
 }
-
-.ag-theme-salt-variant-secondary .ag-header {
-  background-color: var(--salt-container-secondary-background);
-}
-
-.ag-theme-salt-variant-secondary .ag-row {
-  background-color: var(--salt-container-secondary-background);
-  border-color: var(--salt-separable-tertiary-borderColor);
-}
-
-.ag-theme-salt-variant-zebra .ag-row-even:not(.ag-row-hover, .ag-row-selected) {
-  background-color: var(--salt-container-secondary-background);
-}
-
-.ag-theme-salt-variant-zebra .ag-row {
-  border-color: var(--salt-separable-tertiary-borderColor);
-}

--- a/packages/ag-grid-theme/css/parts/ag-root-var.css
+++ b/packages/ag-grid-theme/css/parts/ag-root-var.css
@@ -18,7 +18,8 @@ div[class*="ag-theme-salt"] {
   --ag-foreground-color: var(--salt-content-primary-foreground);
   --ag-grid-size: var(--salt-spacing-50);
   --ag-header-background-color: var(--salt-container-primary-background);
-  --ag-header-cell-hover-background-color: var(--salt-container-primary-background);
+  /* Set to same header bg, so secondary variant would work */
+  --ag-header-cell-hover-background-color: var(--ag-header-background-color);
   --ag-header-column-separator-color: var(--salt-separable-tertiary-borderColor);
   --ag-header-column-separator-display: block;
   --ag-header-column-separator-height: calc(var(--salt-size-base) / 2 - 2 * var(--salt-size-border));
@@ -71,6 +72,19 @@ div[class*="ag-theme-salt-compact"] {
   --salt-size-base: 16px;
   /** Checkbox size */
   --salt-size-selectable: 12px;
+}
+
+div[class*="ag-theme-salt"].ag-theme-salt-variant-secondary {
+  --ag-header-background-color: var(--salt-container-secondary-background);
+  --ag-secondary-border-color: var(--salt-separable-tertiary-borderColor);
+  --ag-background-color: var(--salt-container-secondary-background);
+}
+
+div[class*="ag-theme-salt"].ag-theme-salt-variant-zebra {
+  --ag-background-color: var(--salt-container-secondary-background);
+  --ag-odd-row-background-color: var(--salt-container-primary-background);
+  --ag-header-background-color: var(--salt-container-primary-background);
+  --ag-secondary-border-color: var(--salt-separable-tertiary-borderColor);
 }
 
 .ag-theme-salt-light .ag-root-wrapper,

--- a/packages/ag-grid-theme/css/salt-ag-grid-theme.css
+++ b/packages/ag-grid-theme/css/salt-ag-grid-theme.css
@@ -1,19 +1,10 @@
-@import url(parts/ag-root-var.css);
-/* Sloooow */
-@import url(parts/ag-header.css);
-/* Sloooow */
-@import url(parts/ag-menus.css);
-/* Sloooow */
 @import url(parts/ag-body.css);
-/* Sloooow */
-@import url(parts/ag-input.css);
-/* OK Below */
-@import url(parts/ag-checkbox.css);
-/* Sloooow */
 @import url(parts/ag-buttons.css);
-/* OK Below */
-@import url(parts/ag-tool-panel.css);
-/* OK Below */
-@import url(parts/ag-toggle-button.css);
-/* OK Below */
+@import url(parts/ag-checkbox.css);
 @import url(parts/ag-column-drop-list.css);
+@import url(parts/ag-header.css);
+@import url(parts/ag-input.css);
+@import url(parts/ag-menus.css);
+@import url(parts/ag-root-var.css);
+@import url(parts/ag-toggle-button.css);
+@import url(parts/ag-tool-panel.css);

--- a/site/src/examples/ag-grid-theme/HDCompact.tsx
+++ b/site/src/examples/ag-grid-theme/HDCompact.tsx
@@ -2,6 +2,7 @@ import {
   Banner,
   BannerContent,
   SaltProvider,
+  SaltProviderNext,
   StackLayout,
   useTheme,
 } from "@salt-ds/core";
@@ -36,7 +37,7 @@ const HDCompactGrid = () => {
           Compact only works in high density, which is enforced here.
         </BannerContent>
       </Banner>
-      <div {...containerProps} className={className}>
+      <div {...containerProps}>
         <AgGridReact
           columnDefs={defaultColumns}
           rowData={defaultData}
@@ -50,10 +51,12 @@ const HDCompactGrid = () => {
   );
 };
 export const HDCompact = () => {
+  const { themeNext } = useTheme();
+  const Provider = themeNext ? SaltProviderNext : SaltProvider;
   // Enforce a high density
   return (
-    <SaltProvider density="high" applyClassesTo="scope">
+    <Provider density="high" applyClassesTo="scope">
       <HDCompactGrid />
-    </SaltProvider>
+    </Provider>
   );
 };


### PR DESCRIPTION
Extract fixes out from #5054. Test ag grid site example ([Preview](https://saltdesignsystem-git-5056-ag-theme-zebra-border-color-fed-team.vercel.app/salt/components/ag-grid-theme/examples)):

- Variants example: zebra variant selection border color
- HD compact example, row selection color

#5056