### PR TITLE
Update A11y Docs For Tooltip

### DIFF
--- a/site/docs/components/index.mdx
+++ b/site/docs/components/index.mdx
@@ -18,6 +18,10 @@ in Figma when logged in to the JPMC network.
 They include accessibility and design specifications for each component,
 with designs for light and dark modes in all four densities.
 
+Please note: Digital accessibility is a shared responsibility and while our components include standard accessibility
+behavior and attributes, product teams are responsible for implementing components
+correctly and ensuring their digital products meet all current accessibility requirements.
+
 ## Lab components
 
 Stable components do not feature an accompanying symbol in their navigation link titles. You can find them in the `@salt-ds/core` package.

--- a/site/docs/components/tooltip/accessibility.mdx
+++ b/site/docs/components/tooltip/accessibility.mdx
@@ -10,4 +10,45 @@ data:
 
 ## Best practices
 
-The tooltip doesn't receive focus, so we recommend that you don't include interactive elements as the user can't access them.
+- Keep the use of tooltips to a minimum and use only when providing extra (non-essential) information for the user.
+- Focus does not move to the tooltip. Since a tooltip does not receive focus, do not include interactive elements in the tooltip as the user cannot access them.
+- Only one tooltip should be displayed at a time.
+- Keep the text for a tooltip short and concise.
+- Avoid rich content such as bold text, italics, headings, icons, etc. as these will not be conveyed through `aria-describedby`.
+- Do not use a timeout to hide the tooltip.
+
+## Anti-Pattern
+
+Avoid applying a tooltip to non-interactive elements. As a rule, non-operable elements should not receive keyboard focus to avoid confusion and unnecessary navigation steps.
+A common anti-pattern is to use an (i) icon (or another non-interative element) as the tooltip anchor however this is not recommended for the following reasons:
+
+- Icons (and other non-interative elements) do not receive focus by default.
+- Adding `tabindex` to make the icon focusable introduces an additional tab stop.
+- An (i) icon or non-interative element will not provide an appropriate programmatic association to what the tooltip is visually associated with. These tooltips become an orphaned note that screen readers announce out of context.
+- Screen readers are designed to announce tooltips when a user focuses on an interactive element. When a tooltip is attached to a static element (even using `tabindex`) Screen readers may not reliably announce its content as it is not part of the expected interaction model.
+
+Note: When the content of a tooltip is not about an interactive UI element, consider adding the message directly on the page or use an [`Overlay`](../overlay), [`Dialog`](../dialog), or [`Banner`](../banner) instead.
+
+## Mobile Consideration
+
+Standard tooltips do not display on touch-only devices when attached to [`Links`](../link), [`Buttons`](../button) or non-interative elements and there is currently no workaround. That said, tooltips should display when attached to a [`Form Field`](../form-field).
+
+## Keyboard interactions
+
+<KeyboardControls>
+  <KeyboardControl keyOrCombos="Tab">
+
+    - Tooltips do not receive focus, so Tab does not move focus to the tooltip. Instead, Tab moves focus to the tooltip trigger element to display the tooltip.
+
+  </KeyboardControl>
+  <KeyboardControl keyOrCombos="Escape">
+
+    - If the tooltip is displayed, pressing Escape dismisses the tooltip.
+
+  </KeyboardControl>
+</KeyboardControls>
+
+## Resources
+
+- [ARIA Tooltip Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/)
+- [WCAG 1.4.13 Content on Hover or Focus](https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus)

--- a/site/docs/components/tooltip/examples.mdx
+++ b/site/docs/components/tooltip/examples.mdx
@@ -10,9 +10,13 @@ data:
 
 ## Default
 
-By default, `Tooltip` displays a message and an arrow pointing to the relevant UI element. Its default placement is "right," and appears after 300 milliseconds.
+By default, `Tooltip` displays a message and an arrow pointing to the relevant UI element. Its default placement is "right," and appears after 300 milliseconds. Use the `content` prop to pass a simple string to display in the tooltip.
 
-Use the `content` prop to pass a simple string to display in the tooltip.
+Tooltips are triggered by both focus and hover events and remain visible and persistent until:
+
+- Hover or focus is removed from the trigger element
+- The user manually dismisses it (e.g.`Esc` key)
+- The content is no longer valid
 
 <LivePreview componentName="tooltip" exampleName="Default" />
 

--- a/site/docs/components/tooltip/index.mdx
+++ b/site/docs/components/tooltip/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tooltip
 data:
-  description: "`Tooltip` displays a brief message to the user that provides additional information about a UI element. The tooltip appears after the user’s mouse pointer hovers over the target element for a certain time.  It can communicate new or supporting information, errors, warnings or successful completion of a process or task."
+  description: "`Tooltip` is a non-modal overlay, initially hidden, that appears on hover or focus. It provides concise, text-only content related to the associated interactive element, typically offering supplementary (non-essential) information without disturbing the users workflow."
   sourceCodeUrl: "https://github.com/jpmorganchase/salt-ds/tree/main/packages/core/src/tooltip"
   package:
     name: "@salt-ds/core"

--- a/site/docs/components/tooltip/usage.mdx
+++ b/site/docs/components/tooltip/usage.mdx
@@ -12,7 +12,7 @@ data:
 
 ### When to use
 
-- When you want to display a brief message to the user that provides additional information about a UI element.
+- When you want to display a brief message to the user that provides additional information about an interactive UI element.
 
 ### When not to use
 


### PR DESCRIPTION
We need to update our tooltip documentation to provide guidance on the interactivity of the Tooltip's anchor to address questions and use cases where devs are trying to add a tooltip to an non-interactive element.

Information that needs to be added:
Clarification on a Tooltip's anchor and when to use
Alternatives

Closes: https://github.com/jpmorganchase/salt-ds/issues/5216