### PR TITLE
code review minor polish

### DIFF
--- a/.changeset/silent-carrots-greet.md
+++ b/.changeset/silent-carrots-greet.md
@@ -5,9 +5,10 @@
 Updated the `NumberInput`:
 
 1. Added support for `format` and `parse` callbacks for formatting capabilities.
-2. Added `clampValue` prop to allow enforcement of values within the min and max range.
+2. Added `clamp` prop to restrict entry within the min and max range.
 3. Refactored `stepBlock` prop to be `stepMultiplier` to be consistent with `Slider` and `RangeSlider` components and to ensure that valid values remain reachable.
 4. Refactored `decimalPlaces` to be `decimalScale`.
+5. Added caret handling to preserve the caret position, during change.
 
 Example:
 
@@ -21,7 +22,7 @@ Example:
 + stepMultiplier={4}
   min={0}
   max={100}
-+ clampValue={true}
++ clamp
   defaultValue={20}
 />
 ```

--- a/packages/lab/src/__tests__/__e2e__/number-input/NumberInput.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/number-input/NumberInput.cy.tsx
@@ -356,7 +356,7 @@ describe("Number Input", () => {
     cy.findByRole("spinbutton").should("have.value", "10");
   });
 
-  it("allows out of range input when clampValue is false", () => {
+  it("allows out of range input when clamp is false", () => {
     cy.mount(<MinAndMaxValue />);
     cy.findByRole("spinbutton").focus();
     cy.realType("2");
@@ -367,10 +367,8 @@ describe("Number Input", () => {
     cy.findByTestId("ErrorSolidIcon").should("exist");
   });
 
-  it("clamps out of range values on blur when clampValue is set to true", () => {
-    cy.mount(
-      <Default max={100} decimalScale={2} clampValue defaultValue={""} />,
-    );
+  it("clamps out of range values on blur when clamp is set to true", () => {
+    cy.mount(<Default max={100} decimalScale={2} clamp defaultValue={""} />);
 
     cy.findByRole("spinbutton").focus();
     cy.realType("10000000");
@@ -384,7 +382,7 @@ describe("Number Input", () => {
   });
 
   it("increments and decrements from the correct value when value gets clamped", () => {
-    cy.mount(<Default max={100} min={10} clampValue defaultValue={""} />);
+    cy.mount(<Default max={100} min={10} clamp defaultValue={""} />);
 
     cy.findByRole("spinbutton").focus();
     cy.realType("10000000");

--- a/packages/lab/src/number-input/internal/utils.ts
+++ b/packages/lab/src/number-input/internal/utils.ts
@@ -1,6 +1,4 @@
 // The input should only accept numbers, decimal points, and plus/minus symbols
-export const ACCEPTED_INPUT = /^[-+]?[0-9]*\.?[0-9]*$/;
-
 export const isAllowedNonNumeric = (inputCharacter: number | string) => {
   if (typeof inputCharacter === "number") return;
   return (
@@ -62,7 +60,7 @@ export const isOutOfRange = (
   return floatValue > max || floatValue < min;
 };
 
-export const clamp = (max: number, min: number, value: number) => {
+export const clampToRange = (min: number, max: number, value: number) => {
   if (value < min) return min;
   if (value > max) return max;
   return value;

--- a/packages/lab/src/number-input/useNumberInput.ts
+++ b/packages/lab/src/number-input/useNumberInput.ts
@@ -10,6 +10,28 @@ import type { NumberInputProps } from "./NumberInput";
 import { useActivateWhileMouseDown } from "./internal/useActivateWhileMouseDown";
 import { toFloat } from "./internal/utils";
 
+export interface UseNumberInputProps
+  extends Pick<
+    NumberInputProps,
+    | "decimalScale"
+    | "disabled"
+    | "format"
+    | "inputRef"
+    | "max"
+    | "min"
+    | "onChange"
+    | "parse"
+    | "readOnly"
+    | "step"
+    | "stepMultiplier"
+  > {
+  inputRef: MutableRefObject<HTMLInputElement | null>;
+  isAdjustingRef: MutableRefObject<boolean>;
+  setIsEditing: Dispatch<SetStateAction<boolean>>;
+  setValue: Dispatch<SetStateAction<string | number>>;
+  value: string | number;
+}
+
 /**
  * Manages increment / decrement logic
  */
@@ -29,26 +51,7 @@ export const useNumberInput = ({
   step = 1,
   stepMultiplier = 2,
   value,
-}: Pick<
-  NumberInputProps,
-  | "decimalScale"
-  | "disabled"
-  | "format"
-  | "inputRef"
-  | "max"
-  | "min"
-  | "onChange"
-  | "parse"
-  | "readOnly"
-  | "step"
-  | "stepMultiplier"
-> & {
-  inputRef: MutableRefObject<HTMLInputElement | null>;
-  isAdjustingRef: MutableRefObject<boolean>;
-  setIsEditing: Dispatch<SetStateAction<boolean>>;
-  setValue: Dispatch<SetStateAction<string | number>>;
-  value: string | number;
-}) => {
+}: UseNumberInputProps) => {
   // biome-ignore lint/correctness/useExhaustiveDependencies: Refs cannot be added to dependency arrays
   const updateValue = useCallback(
     (event: SyntheticEvent | undefined, nextValue: number) => {

--- a/packages/lab/stories/number-input/number-input.stories.tsx
+++ b/packages/lab/stories/number-input/number-input.stories.tsx
@@ -109,7 +109,7 @@ export const Controlled: StoryFn<NumberInputProps> = (args) => {
       <NumberInput
         {...args}
         decimalScale={2}
-        clampValue
+        clamp
         max={2}
         value={value}
         onChange={(_event, value) => {
@@ -227,7 +227,7 @@ export const Clamping: StoryFn<NumberInputProps> = (args) => {
         <NumberInput
           {...args}
           defaultValue={2}
-          clampValue
+          clamp
           max={max}
           min={min}
           style={{ width: "250px" }}
@@ -446,7 +446,7 @@ export const UncontrolledFormatting: StoryFn<NumberInputProps> = (args) => {
           defaultValue={12}
           format={(value) => `${value}%`}
           max={100}
-          clampValue
+          clamp
           parse={(value) => {
             return String(value).replace(/%/g, "");
           }}

--- a/site/docs/components/input/examples.mdx
+++ b/site/docs/components/input/examples.mdx
@@ -34,7 +34,7 @@ You can disable the input, resulting in no action when the user interacts with i
 
 You can set `Input` to a read-only state. The user can't edit the value text in this state, but they can highlight and copy it.
 
-By default, the marker is an em dash. If your application requires a different marker, you can set it via the `emptyReadOnlyMarker` prop.
+By default, a dash ('-') serves as the empty marker. You can customize this marker by using the `emptyReadOnlyMarker` prop if your application needs a different symbol.
 
 - Use the read-only state when the user needs the value for their flow or current task but cannot edit it, for example, because of user permissions.
 

--- a/site/docs/components/number-input/accessibility.mdx
+++ b/site/docs/components/number-input/accessibility.mdx
@@ -16,7 +16,7 @@ Wrap `NumberInput` in [`FormField`](/salt/components/form-field) to provide the 
 
 Number input inherits keyboard interactions from [`Input`](/salt/components/input/accessibility).
 
-The following interactions are specific to Number Input.
+The following interactions are specific to `NumberInput`.
 
 <KeyboardControls>
 <KeyboardControl keyOrCombos="Up arrow">

--- a/site/docs/components/number-input/examples.mdx
+++ b/site/docs/components/number-input/examples.mdx
@@ -36,13 +36,13 @@ To limit the range of accepted values, you can specify a minimum, maximum, or bo
 
 - Clearly communicate the accepted value range by utilizing the `FormField`'s helper text to guide users.
 - Use the `FormField` error state to alert users when they manually enter a value outside the permitted range, indicating that the input is invalid.
-- Use the `clampValue` prop to enforce the value to be within range.
+- Use the `clamp` prop to enforce the value to be within range.
 
 <LivePreview componentName="number-input" exampleName="Limits" />
 
 ## Clamp behaviour
 
-By default, even when minimum and maximum values are specified, they are not strictly enforced, allowing users to type values outside this range. However, by setting the prop `clampValue` to true, the
+By default, even when minimum and maximum values are specified, they are not strictly enforced, allowing users to type values outside this range. However, by setting the prop `clamp` to true, the
 input will automatically adjust to the nearest minimum or maximum value when the input field loses focus.
 
 <LivePreview componentName="number-input" exampleName="ClampBehaviour" />
@@ -60,7 +60,8 @@ The `NumberInput` can display validation states, `error`, `warning`, and `succes
 
 ## Decimal scale
 
-By default, the decimal scale is auto-calculated using the number of decimal places in the `step` or `defaultValue` or `value` prop, whichever is greater. However, you can set it to any value of your choice using the `decimalScale` prop and that will have priority.
+By default, the decimal scale is derived from the highest number of decimal places found in the `step` prop, or if not defined, in either the `defaultValue` or `value` prop.
+However, you can set it to any value of your choice using the `decimalScale` prop and that will have priority.
 
 ### Best practices
 
@@ -78,7 +79,7 @@ Users will be able to see the formatted value in the input, e.g. "5K". When the 
 
 The `format` callback has been designed to work with most formatting libraries, e.g. Intl.NumberFormat. However, it is highly recommended to provide a `parse` callback alongside `format` to determine the correct numerical value so the precision of the value can be maintained.
 
-**Note**: When a `format` callback is provided, it will override `decimalScale` to allow managing decimal place rules within your formatting function as well.
+**Note**: If a `format` callback is provided, it will override the `decimalScale`, enabling you to handle decimal place rules directly within your formatting function.
 
 <LivePreview componentName="number-input" exampleName="Formatting" />
 
@@ -104,7 +105,7 @@ Use a reset button to return the `NumberInput` to its default value.
 
 **Synchronize adornment**:
 
-Synchronize the `NumberInput` with a live value from a constantly changing source, such as live stock prices. The `NumberInput`'s value does not automatically update with changes in the live value. In this scenario, the synchronize button appears when the displayed value and live value differ.
+Synchronize the `NumberInput` with a live value from a constantly changing source, such as ticking stock values. The `NumberInput`'s value does not automatically update with changes in the live value. In this scenario, the synchronize button appears when the displayed value and live value differ.
 
 **Custom buttons**:
 
@@ -122,7 +123,7 @@ The `NumberInput` can be disabled to prevent any user interaction or input.
 
 The `NumberInput` can be set to a read-only state using the `readOnly` prop, allowing users to highlight and copy the value without editing it.
 
-By default, an em dash is used as the marker. If your application requires a different marker, you can customize it using the `emptyReadOnlyMarker` prop.
+By default, a dash ('-') serves as the empty marker. You can customize this marker by using the `emptyReadOnlyMarker` prop if your application needs a different symbol.
 
 **Note:** To address browser and screen reader limitations in conveying a read-only state, the `NumberInput`'s role is changed to `textbox` when set to read-only.
 

--- a/site/docs/components/number-input/usage.mdx
+++ b/site/docs/components/number-input/usage.mdx
@@ -29,9 +29,9 @@ To avoid misleading users, set the width to correlate to the length of the value
 
 ### Accepted characters
 
-- The Number Input component accepts numeric digits 0-9, decimal point (.), plus sign (+) and minus sign (-).
+- The `NumberInput` component accepts numeric digits 0-9, decimal point (.), plus sign (+) and minus sign (-).
 - Note it does not accept the character e, which is allowed in native HTML `type="number"` inputs to represent exponential notation. This design choice ensures that all input values remain simple numerical values without exponential formatting.
-- For consistent number input interaction in your application, use Number Input rather than Input with `type="number"`.
+- For consistent number input interaction in your application, use `NumberInput` rather than `Input` with `type="number"`.
 
 ### Controlled/uncontrolled
 

--- a/site/src/examples/number-input/ButtonAdornments.tsx
+++ b/site/src/examples/number-input/ButtonAdornments.tsx
@@ -22,7 +22,7 @@ const ResetAdornment = () => {
   const [value, setValue] = useState<number | string>(defaultValue);
   const [accessibleText, setAccessibleText] = useState("");
 
-  const formFieldLabel = "Number Input with Reset adornment";
+  const formFieldLabel = "Number input with reset adornment";
   const accessibleTextId = useId();
 
   const clearAccessibleText = () =>
@@ -72,7 +72,7 @@ const SyncAdornment = () => {
   const [value, setValue] = useState<number | string>(randomLiveValue);
   const [accessibleText, setAccessibleText] = useState("");
 
-  const formFieldLabel = "Number Input with Sync adornment";
+  const formFieldLabel = "Number input with sync adornment";
   const accessibleTextId = useId();
 
   useEffect(() => {
@@ -140,7 +140,7 @@ const CustomButtons = () => {
 
   return (
     <FormField>
-      <FormFieldLabel>Number Input with Custom buttons</FormFieldLabel>
+      <FormFieldLabel>Number input with custom buttons</FormFieldLabel>
       <NumberInput
         hideButtons
         value={value}

--- a/site/src/examples/number-input/ClampBehaviour.tsx
+++ b/site/src/examples/number-input/ClampBehaviour.tsx
@@ -10,8 +10,8 @@ export const ClampBehaviour = () => {
   return (
     <StackLayout style={{ width: "256px" }}>
       <FormField>
-        <FormFieldLabel>Number input with limited range</FormFieldLabel>
-        <NumberInput defaultValue={2} min={0} max={10} clampValue />
+        <FormFieldLabel>Number input with clamped range</FormFieldLabel>
+        <NumberInput defaultValue={2} min={0} max={10} clamp />
         <FormFieldHelperText>
           Limit value must be between 0 and 10
         </FormFieldHelperText>

--- a/site/src/examples/number-input/Decimals.tsx
+++ b/site/src/examples/number-input/Decimals.tsx
@@ -4,9 +4,7 @@ import { NumberInput } from "@salt-ds/lab";
 export const Decimals = () => (
   <StackLayout>
     <FormField style={{ width: "256px" }}>
-      <FormFieldLabel>
-        Number input with auto-calculated decimal scale
-      </FormFieldLabel>
+      <FormFieldLabel>Number input with derived decimal scale</FormFieldLabel>
       <NumberInput defaultValue={100} step={0.01} endAdornment="USD" />
     </FormField>
     <FormField style={{ width: "256px" }}>


### PR DESCRIPTION
- `clampValue` used a naming convention that implied it was a value and not a boolean.
- minor case changes in docs
- minor grammar improvements in docs
- added `UseNumberInputProps` type
- moved location of decimalScale to simplify code