### PR TITLE
Deprecate selectable blur selected tokens

### DIFF
--- a/.changeset/forty-dingos-reply.md
+++ b/.changeset/forty-dingos-reply.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/theme": minor
+---
+
+Deprecated `--salt-selectable-background-blurSelected` and `--salt-palette-interact-background-blurSelected`.

--- a/.changeset/young-flies-wonder.md
+++ b/.changeset/young-flies-wonder.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/lab": patch
+---
+
+Fixed CascadingMenu and refactored the styles to not use any deprecated tokens.

--- a/packages/core/src/menu/MenuItem.css
+++ b/packages/core/src/menu/MenuItem.css
@@ -47,7 +47,6 @@
   z-index: var(--salt-zIndex-default);
   background: var(--salt-selectable-background-selected);
   box-shadow: 0 calc(var(--salt-size-fixed-100) * -1) 0 0 var(--salt-selectable-borderColor-selected), 0 var(--salt-size-fixed-100) 0 0 var(--salt-selectable-borderColor-selected);
-  box-shadow: 0 calc(var(--salt-size-fixed-100) * -1) 0 0 var(--salt-selectable-borderColor-selected), 0 var(--salt-size-fixed-100) 0 0 var(--salt-selectable-borderColor-selected);
 }
 
 /* TODO: Find a better way of doing this */

--- a/packages/lab/src/cascading-menu/CascadingMenuItem.css
+++ b/packages/lab/src/cascading-menu/CascadingMenuItem.css
@@ -12,6 +12,9 @@
   user-select: none;
   white-space: nowrap;
   text-overflow: ellipsis;
+  border-top: var(--salt-size-fixed-100) var(--salt-selectable-borderStyle-selected) transparent;
+  border-bottom: var(--salt-size-fixed-100) var(--salt-selectable-borderStyle-selected) transparent;
+  box-sizing: border-box;
 }
 
 .saltCascadingMenuItem-menuItemText {
@@ -42,5 +45,7 @@
 
 /* extra specificity requred to override ListItem selected */
 .saltCascadingMenuItem.saltCascadingMenuItem-menuItemBlurSelected {
-  background: var(--salt-selectable-background-blurSelected) !important;
+  background: var(--salt-selectable-background-selected);
+  border-top-color: var(--salt-selectable-borderColor-selected);
+  border-bottom-color: var(--salt-selectable-borderColor-selected);
 }

--- a/packages/lab/src/list-deprecated/List.tsx
+++ b/packages/lab/src/list-deprecated/List.tsx
@@ -30,7 +30,7 @@ const ListWithDescendants = forwardRef(function ListWithDescendants<
   const { items } = useContext(DescendantContext);
 
   const { focusedRef, state, helpers, listProps } = useList({
-    source: items.current.length ? items.current : [],
+    source: (items?.current.length ? items.current : []) as Item[],
     ...props,
   });
 

--- a/packages/theme/css/characteristics/selectable-next.css
+++ b/packages/theme/css/characteristics/selectable-next.css
@@ -14,7 +14,6 @@
   --salt-selectable-background: var(--salt-palette-alpha-none);
   --salt-selectable-background-hover: var(--salt-palette-accent-weakest);
   --salt-selectable-background-selected: var(--salt-palette-accent-weaker);
-  --salt-selectable-background-blurSelected: var(--salt-palette-neutral-weakest);
   --salt-selectable-background-disabled: var(--salt-palette-alpha-none);
   --salt-selectable-background-selectedDisabled: var(--salt-palette-accent-weaker-disabled);
 }

--- a/packages/theme/css/characteristics/selectable.css
+++ b/packages/theme/css/characteristics/selectable.css
@@ -19,7 +19,6 @@
   --salt-selectable-background: var(--salt-palette-alpha-none);
   --salt-selectable-background-hover: var(--salt-palette-interact-background-hover);
   --salt-selectable-background-selected: var(--salt-palette-interact-background-active);
-  --salt-selectable-background-blurSelected: var(--salt-palette-interact-background-blurSelected);
   --salt-selectable-background-disabled: var(--salt-palette-alpha-none);
   --salt-selectable-background-selectedDisabled: var(--salt-palette-interact-background-activeDisabled);
 }

--- a/packages/theme/css/deprecated/characteristics-next.css
+++ b/packages/theme/css/deprecated/characteristics-next.css
@@ -1,0 +1,3 @@
+.salt-theme.salt-theme-next {
+  --salt-selectable-background-blurSelected: var(--salt-palette-neutral-weakest);
+}

--- a/packages/theme/css/deprecated/characteristics.css
+++ b/packages/theme/css/deprecated/characteristics.css
@@ -56,6 +56,8 @@
   --salt-selectable-foreground-partial: var(--salt-palette-interact-foreground-partial);
   --salt-selectable-foreground-partialDisabled: var(--salt-palette-interact-foreground-partialDisabled);
 
+  --salt-selectable-background-blurSelected: var(--salt-palette-interact-background-blurSelected);
+
   --salt-selectable-cta-foreground: var(--salt-palette-interact-foreground);
   --salt-selectable-cta-foreground-disabled: var(--salt-palette-interact-foreground-disabled);
   --salt-selectable-cta-foreground-hover: var(--salt-palette-interact-cta-foreground-hover);

--- a/packages/theme/css/deprecated/palette.css
+++ b/packages/theme/css/deprecated/palette.css
@@ -41,6 +41,7 @@
   --salt-palette-interact-secondary-foreground-activeDisabled: var(--salt-color-white-fade-foreground);
   --salt-palette-interact-secondary-background-activeDisabled: var(--salt-color-gray-200-fade-background);
   --salt-palette-interact-background: transparent;
+  --salt-palette-interact-background-blurSelected: var(--salt-color-gray-30);
   --salt-palette-interact-background-disabled: transparent;
   --salt-palette-interact-border-none: transparent;
   --salt-palette-interact-secondary-background: transparent;
@@ -133,6 +134,7 @@
   --salt-palette-interact-secondary-foreground-activeDisabled: var(--salt-color-gray-900-fade-foreground);
   --salt-palette-interact-secondary-background-activeDisabled: var(--salt-color-gray-70-fade-background);
   --salt-palette-interact-background: transparent;
+  --salt-palette-interact-background-blurSelected: var(--salt-color-gray-600);
   --salt-palette-interact-background-disabled: transparent;
   --salt-palette-interact-border-none: transparent;
   --salt-palette-interact-secondary-background: transparent;

--- a/packages/theme/css/palette/interact.css
+++ b/packages/theme/css/palette/interact.css
@@ -1,5 +1,4 @@
 .salt-theme[data-mode="light"] {
-  --salt-palette-interact-background-blurSelected: var(--salt-color-gray-30);
   --salt-palette-interact-background-hover: var(--salt-color-blue-10);
   --salt-palette-interact-background-active: var(--salt-color-blue-30);
   --salt-palette-interact-background-activeDisabled: var(--salt-color-blue-30-40a);
@@ -42,7 +41,6 @@
 
 .salt-theme[data-mode="dark"] {
   --salt-palette-interact-background-active: var(--salt-color-blue-700);
-  --salt-palette-interact-background-blurSelected: var(--salt-color-gray-600);
   --salt-palette-interact-background-hover: var(--salt-color-blue-800);
   --salt-palette-interact-background-activeDisabled: var(--salt-color-blue-700-40a);
   --salt-palette-interact-border: var(--salt-color-gray-90);

--- a/packages/theme/css/theme-next.css
+++ b/packages/theme/css/theme-next.css
@@ -29,5 +29,6 @@
 @import url(characteristics/track-next.css);
 
 /* Deprecated */
+@import url(deprecated/characteristics-next.css);
 @import url(deprecated/foundations-next.css);
 @import url(deprecated/palette-next.css);


### PR DESCRIPTION
This includes a change to CascadingMenu (a legacy component).
After:
![image](https://github.com/user-attachments/assets/8bb58070-79c3-4bc9-9138-6950ca4eb9cd)
