### PR TITLE
Upgrade date-fns peer dependency to 4.1.0 and add timezone support

### DIFF
--- a/.changeset/eleven-rings-clap.md
+++ b/.changeset/eleven-rings-clap.md
@@ -1,0 +1,46 @@
+---
+"@salt-ds/date-adapters": patch
+---
+
+- Upgrade peer dependencies for `@salt-ds/date-adapters/date-fns` and its type definitions to the version 4.
+
+```diff
+  "peerDependencies": {
+-   "date-fns": "^3.6.0",
++   "date-fns": "^4.1.0",
+  }
+```
+
+This upgrade is a breaking change for `date-fns`, mostly around inner types and ESM support.
+https://github.com/date-fns/date-fns/releases/tag/v4.0.0
+
+Ensure compatibility with your codebase by reviewing any changes in the `date-fns` API and type definitions.
+
+As these are peer dependencies, make sure that the consuming projects are also updated to these versions to avoid potential conflicts.
+
+- Added new `@salt-ds/date-adapters/date-fns-tz` adapter, a`date-fns` adapter with timezone support.
+
+```diff package.json
+  "peerDependencies": {
+-   "date-fns": "^3.6.0",
++   "date-fns": "^4.1.0",
+    }
+```
+
+If you DO NOT require timezone support use `@salt-ds/date-adapters/date-fns`.  
+If you DO require timezone support use `@salt-ds/date-adapters/date-fns-tz`.
+
+To use:
+
+```
+import { AdapterDateFnsTZ } from "../date-fns-tz-adapter";
+import { enUS } from "date-fns/locale";
+
+    <LocalizationProvider
+      DateAdapter={AdapterDateFnsTZ}
+      locale={enUS}
+    >
+    </LocalizationProvider>
+```
+
+Creates a peer dependency on `@date-fns/tz`.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,11 @@ jobs:
         run: yarn
       - name: Setup TypeScript
         run: yarn up typescript@${{ matrix.ts }}
-      - name: Run typecheck
+      - name: Run typecheck for TypeScript 4.6.4
+        if: ${{ matrix.ts == '4.6.4' }}
+        run: yarn run typecheck:v4
+      - name: Run typecheck for TypeScript 5
+        if: ${{ matrix.ts == '5' }}
         run: yarn run typecheck
   jest-tests:
     runs-on: ubuntu-latest

--- a/.storybook/decorators/withLocalization.tsx
+++ b/.storybook/decorators/withLocalization.tsx
@@ -1,6 +1,6 @@
 import type { Decorator } from "@storybook/react-vite";
 import "dayjs/locale/en";
-import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDateFnsTZ } from "@salt-ds/date-adapters/date-fns-tz";
 import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
 import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
 import { AdapterMoment } from "@salt-ds/date-adapters/moment";
@@ -11,7 +11,7 @@ import { enUS as dateFnsEnUs } from "date-fns/locale";
 const dateAdapterMap: Record<string, any> = {
   moment: AdapterMoment,
   dayjs: AdapterDayjs,
-  "date-fns": AdapterDateFns,
+  "date-fns": AdapterDateFnsTZ,
   luxon: AdapterLuxon,
 };
 

--- a/cypress/support/commands.tsx
+++ b/cypress/support/commands.tsx
@@ -124,8 +124,7 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   "mount",
-  // biome-ignore lint/suspicious/noExplicitAny: locale type varies between Date frameworks
-  <TDate extends DateFrameworkType, TLocale = any>(
+  (
     children: ReactNode,
     options?: MountOptions,
   ): Cypress.Chainable<MountReturn> => {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "yarn build:ag-grid-theme && yarn bundle:css && storybook build --stats-json",
     "typecheck": "tsc --noEmit",
+    "typecheck:v4": "tsc --noEmit --project tsconfig.v4.json",
     "chromatic": "chromatic"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "workerDirectory": "docs/public"
   },
   "devDependencies": {
+    "@date-fns/tz": "^1.2.0",
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.3.0",

--- a/packages/date-adapters/package.json
+++ b/packages/date-adapters/package.json
@@ -11,15 +11,19 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "peerDependencies": {
+    "@date-fns/tz": "^1.2.0",
     "@types/luxon": "^3.6.2",
     "@types/react": ">=16.14.0",
-    "date-fns": "^3.6.0",
+    "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
     "luxon": "^3.6.1",
     "moment": "^2.30.1",
     "moment-timezone": "^0.5.46"
   },
   "peerDependenciesMeta": {
+    "@date-fns/tz": {
+      "optional": true
+    },
     "date-fns": {
       "optional": true
     },

--- a/packages/date-adapters/scripts/build.mjs
+++ b/packages/date-adapters/scripts/build.mjs
@@ -38,6 +38,7 @@ const entryPoints = {
   luxon: path.join(cwd, "src/luxon-adapter/index.ts"),
   dayjs: path.join(cwd, "src/dayjs-adapter/index.ts"),
   "date-fns": path.join(cwd, "src/date-fns-adapter/index.ts"),
+  "date-fns-tz": path.join(cwd, "src/date-fns-tz-adapter/index.ts"),
 };
 
 for (const [adapterName, inputPath] of Object.entries(entryPoints)) {
@@ -121,6 +122,11 @@ await fs.writeJSON(
         types: "./dist-types/date-fns-adapter/index.d.ts",
         import: "./dist-es/date-fns/index.js",
         require: "./dist-cjs/date-fns/index.js",
+      },
+      "./date-fns-tz": {
+        types: "./dist-types/date-fns-tz-adapter/index.d.ts",
+        import: "./dist-es/date-fns-tz/index.js",
+        require: "./dist-cjs/date-fns-tz/index.js",
       },
       "./dayjs": {
         types: "./dist-types/dayjs-adapter/index.d.ts",

--- a/packages/date-adapters/src/__tests__/date-fns-tz.spec.ts
+++ b/packages/date-adapters/src/__tests__/date-fns-tz.spec.ts
@@ -1,0 +1,64 @@
+import { TZDate } from "@date-fns/tz";
+import { enUS } from "date-fns/locale";
+import { describe, expect, it } from "vitest";
+import { AdapterDateFnsTZ } from "../date-fns-tz-adapter";
+
+describe("GIVEN an AdapterDateFnsTZ", () => {
+  const adapter = new AdapterDateFnsTZ({ locale: enUS });
+
+  it("SHOULD create a valid TZDate from a string", () => {
+    const date = adapter.date("2023-11-01");
+    expect(adapter.isValid(date)).toBe(true);
+    expect(date.getFullYear()).toBe(2023);
+    expect(date.getMonth()).toBe(10); // Months are 0-indexed
+    expect(date.getDate()).toBe(1);
+  });
+
+  it("SHOULD return an invalid TZDate for an invalid string", () => {
+    const date = adapter.date("invalid date");
+    expect(adapter.isValid(date)).toBe(false);
+  });
+
+  it("SHOULD get the current date at the start of the day", () => {
+    const today = adapter.today();
+    const now = new Date();
+    expect(today.getFullYear()).toBe(now.getFullYear());
+    expect(today.getMonth()).toBe(now.getMonth());
+    expect(today.getDate()).toBe(now.getDate());
+    expect(today.getHours()).toBe(0);
+    expect(today.getMinutes()).toBe(0);
+    expect(today.getSeconds()).toBe(0);
+    expect(today.getMilliseconds()).toBe(0);
+  });
+
+  it("SHOULD get the current date and time", () => {
+    const now = adapter.now();
+    const current = new Date();
+    expect(now.getFullYear()).toBe(current.getFullYear());
+    expect(now.getMonth()).toBe(current.getMonth());
+    expect(now.getDate()).toBe(current.getDate());
+  });
+
+  it("SHOULD get the timezone of a TZDate", () => {
+    const date = new TZDate("2023-11-01T00:00:00Z");
+    const timezone = adapter.getTimezone(date);
+    expect(timezone).toBe(Intl.DateTimeFormat().resolvedOptions().timeZone);
+  });
+
+  it("SHOULD set the timezone of a date", () => {
+    const date = new Date(2023, 10, 1);
+    const tzDate = adapter.setTimezone(date, "America/New_York");
+    expect(adapter.getTimezone(tzDate)).toBe("America/New_York");
+    expect(tzDate.getHours()).toBe(0);
+    expect(tzDate.getMinutes()).toBe(0);
+    expect(tzDate.getSeconds()).toBe(0);
+    expect(tzDate.getMilliseconds()).toBe(0);
+  });
+
+  it("SHOULD clone a TZDate", () => {
+    const date = new TZDate("2023-11-01T00:00:00Z");
+    const clonedDate = adapter.clone(date);
+    expect(clonedDate).toEqual(date);
+    expect(clonedDate).not.toBe(date);
+  });
+});

--- a/packages/date-adapters/src/__tests__/date-fns.spec.ts
+++ b/packages/date-adapters/src/__tests__/date-fns.spec.ts
@@ -86,6 +86,8 @@ describe("GIVEN a AdapterDateFns", () => {
     const startOfDay = adapter.startOf(date, "day");
     expect(startOfDay.getHours()).toBe(0);
     expect(startOfDay.getMinutes()).toBe(0);
+    expect(startOfDay.getSeconds()).toBe(0);
+    expect(startOfDay.getMilliseconds()).toBe(0);
   });
 
   it("SHOULD get the end of a day", () => {
@@ -103,6 +105,8 @@ describe("GIVEN a AdapterDateFns", () => {
     expect(today.getDate()).toBe(now.getDate());
     expect(today.getHours()).toBe(0);
     expect(today.getMinutes()).toBe(0);
+    expect(today.getSeconds()).toBe(0);
+    expect(today.getMilliseconds()).toBe(0);
   });
 
   it("SHOULD return the current date and time", () => {

--- a/packages/date-adapters/src/date-fns-adapter/index.ts
+++ b/packages/date-adapters/src/date-fns-adapter/index.ts
@@ -93,7 +93,7 @@ const defaultFormatMap: { [key: string]: string } = {
 
 /**
  * Adapter for date-fns library, implementing the SaltDateAdapter interface.
- * Provides methods for date manipulation and formatting using date-fns.
+ * Provides methods for date manipulation and formatting using date-fns, without timezone support.
  */
 export class AdapterDateFns implements SaltDateAdapter<Date, Locale> {
   /**
@@ -341,9 +341,10 @@ export class AdapterDateFns implements SaltDateAdapter<Date, Locale> {
 
   /**
    * Get the timezone from the Date object (un-supported by v3 date-fns/Date object)
+   * @param date - A Date object
    * @returns "default" as Timezones are not supported by the date-fns/Date object
    */
-  public getTimezone = (): string => {
+  public getTimezone = (_date: Date): string => {
     return "default";
   };
 
@@ -428,7 +429,14 @@ export class AdapterDateFns implements SaltDateAdapter<Date, Locale> {
    * @returns The current date at the start of the day.
    */
   public today(): Date {
-    return startOfDay(new Date());
+    let now = new Date();
+    now = setDateFns(now, {
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+      milliseconds: 0,
+    });
+    return now;
   }
 
   /**

--- a/packages/date-adapters/src/date-fns-tz-adapter/index.ts
+++ b/packages/date-adapters/src/date-fns-tz-adapter/index.ts
@@ -1,0 +1,92 @@
+import { TZDate } from "@date-fns/tz";
+import { startOfDay } from "date-fns";
+import { enUS as dateFnsEnUs } from "date-fns/locale/en-US";
+import { AdapterDateFns } from "../date-fns-adapter";
+import type { Timezone } from "../types";
+
+/**
+ * Adapter for date-fns library, implementing the SaltDateAdapter interface.
+ * Provides methods for date manipulation and formatting using date-fns, without timezone support.
+ */
+export class AdapterDateFnsTZ extends AdapterDateFns {
+  constructor({ locale = dateFnsEnUs }) {
+    super({
+      locale,
+    });
+  }
+
+  /**
+   * Creates a Date object from a string or returns an invalid date.
+   * @param value - The date string to parse.
+   * @returns The parsed Date object or an invalid date object.
+   */
+  public date = <T extends string | undefined>(value?: T): Date => {
+    if (!value || !super.isValidDateString(value)) {
+      return new TZDate(Number.NaN);
+    }
+    return new TZDate(value);
+  };
+
+  /**
+   * Gets the current date with the time set to the start of the day.
+   * @returns The current date at the start of the day.
+   */
+  public today(): TZDate {
+    let now: TZDate = new TZDate();
+    now = this.set(now, {
+      hour: 0,
+      minute: 0,
+      second: 0,
+      millisecond: 0,
+    }) as TZDate;
+    return now;
+  }
+
+  /**
+   * Gets the current date and time.
+   * @returns The current date and time.
+   */
+  public now(): TZDate {
+    return new TZDate();
+  }
+
+  /**
+   * Get the timezone from the Date object
+   * @returns timezone
+   */
+  public getTimezone = (date: Date): string => {
+    return (
+      (date as TZDate).timeZone ??
+      Intl.DateTimeFormat().resolvedOptions().timeZone
+    );
+  };
+
+  /**
+   * Set the timezone for the Date object
+   * @param date - A Date object
+   * @param _timezone - Timezone to set date object to (un-used)
+   * @returns  date object set to the timezone
+   */
+  public setTimezone = (date: Date, timezone: Timezone = "default"): Date => {
+    const newTimezone =
+      timezone === "system" || timezone == "default"
+        ? Intl.DateTimeFormat().resolvedOptions().timeZone
+        : timezone;
+    let tzdate: Date = new TZDate(date, newTimezone);
+    tzdate = this.set(tzdate, {
+      hour: 0,
+      minute: 0,
+      second: 0,
+      millisecond: 0,
+    });
+    return tzdate;
+  };
+
+  /**
+   * Clone the date object
+   * @param date
+   */
+  public clone(date: TZDate): TZDate {
+    return new TZDate(date.getTime());
+  }
+}

--- a/packages/date-adapters/src/date-fns-tz-adapter/index.ts
+++ b/packages/date-adapters/src/date-fns-tz-adapter/index.ts
@@ -1,5 +1,4 @@
 import { TZDate } from "@date-fns/tz";
-import { startOfDay } from "date-fns";
 import { enUS as dateFnsEnUs } from "date-fns/locale/en-US";
 import { AdapterDateFns } from "../date-fns-adapter";
 import type { Timezone } from "../types";
@@ -69,7 +68,7 @@ export class AdapterDateFnsTZ extends AdapterDateFns {
    */
   public setTimezone = (date: Date, timezone: Timezone = "default"): Date => {
     const newTimezone =
-      timezone === "system" || timezone == "default"
+      timezone === "system" || timezone === "default"
         ? Intl.DateTimeFormat().resolvedOptions().timeZone
         : timezone;
     let tzdate: Date = new TZDate(date, newTimezone);

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -37,8 +37,9 @@
     "tinycolor2": "^1.4.2"
   },
   "devDependencies": {
+    "@date-fns/tz": "^1.2.0",
     "@types/luxon": "^3.6.2",
-    "date-fns": "^3.6.0",
+    "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
     "luxon": "^3.6.1",
     "moment": "^2.30.1",

--- a/packages/lab/stories/calendar/calendar.stories.tsx
+++ b/packages/lab/stories/calendar/calendar.stories.tsx
@@ -507,18 +507,15 @@ export const WithLocale: StoryFn<typeof Calendar> = (args) => {
 
 export const SingleWithTimezone: StoryFn<typeof Calendar> = (args) => {
   const { dateAdapter } = useLocalization<DateFrameworkType>();
-  const timezoneOptions =
-    dateAdapter.lib !== "date-fns"
-      ? [
-          "default",
-          "system",
-          "UTC",
-          "America/New_York",
-          "Europe/London",
-          "Asia/Shanghai",
-          "Asia/Kolkata",
-        ]
-      : ["default"];
+  const timezoneOptions = [
+    "default",
+    "system",
+    "UTC",
+    "America/New_York",
+    "Europe/London",
+    "Asia/Shanghai",
+    "Asia/Kolkata",
+  ];
   const [selectedTimezone, setSelectedTimezone] = useState<string>(
     timezoneOptions[0],
   );
@@ -570,7 +567,7 @@ export const SingleWithTimezone: StoryFn<typeof Calendar> = (args) => {
       const jsDate =
         dateAdapter.lib === "luxon"
           ? selection.toJSDate()
-          : dateAdapter.lib === "moment"
+          : dateAdapter.lib === "moment" || dateAdapter.lib === "dayjs"
             ? selection.toDate()
             : selection;
       const formattedDate = formatDate(jsDate);
@@ -650,18 +647,15 @@ export const RangeWithTimezone: StoryFn<
   CalendarRangeProps<DateFrameworkType>
 > = (args) => {
   const { dateAdapter } = useLocalization<DateFrameworkType>();
-  const timezoneOptions =
-    dateAdapter.lib !== "date-fns"
-      ? [
-          "default",
-          "system",
-          "UTC",
-          "America/New_York",
-          "Europe/London",
-          "Asia/Shanghai",
-          "Asia/Kolkata",
-        ]
-      : ["default"];
+  const timezoneOptions = [
+    "default",
+    "system",
+    "UTC",
+    "America/New_York",
+    "Europe/London",
+    "Asia/Shanghai",
+    "Asia/Kolkata",
+  ];
   const [selectedTimezone, setSelectedTimezone] = useState<string>(
     timezoneOptions[0],
   );
@@ -722,7 +716,7 @@ export const RangeWithTimezone: StoryFn<
       const startJSDate =
         dateAdapter.lib === "luxon"
           ? startDate.toJSDate()
-          : dateAdapter.lib === "moment"
+          : dateAdapter.lib === "moment" || dateAdapter.lib === "dayjs"
             ? startDate.toDate()
             : startDate;
       const start = formatDate(startJSDate);
@@ -734,7 +728,7 @@ export const RangeWithTimezone: StoryFn<
         const endJSDate =
           dateAdapter.lib === "luxon"
             ? endDate.toJSDate()
-            : dateAdapter.lib === "moment"
+            : dateAdapter.lib === "moment" || dateAdapter.lib === "dayjs"
               ? endDate.toDate()
               : endDate;
         const end = formatDate(endJSDate);

--- a/packages/lab/stories/date-picker/date-picker.stories.tsx
+++ b/packages/lab/stories/date-picker/date-picker.stories.tsx
@@ -3533,6 +3533,33 @@ export const WithExperimentalTime: StoryFn<
     );
   const previousSelectedDate = useRef<typeof selectedDate>(selectedDate);
 
+  const addTimeToDate = useCallback(
+    (
+      time: typeof selectedTime,
+      date: DateRangeSelection<DateFrameworkType>,
+    ) => {
+      const { startTime, endTime } = time;
+      if (dateAdapter.isValid(date?.startDate) && startTime) {
+        date.startDate = dateAdapter.set(date.startDate, {
+          hour: startTime.hour,
+          minute: startTime.minute,
+          second: startTime.second,
+          millisecond: startTime.millisecond,
+        });
+      }
+      if (dateAdapter.isValid(date?.endDate) && endTime) {
+        date.endDate = dateAdapter.set(date.endDate, {
+          hour: endTime.hour,
+          minute: endTime.minute,
+          second: endTime.second,
+          millisecond: endTime.millisecond,
+        });
+      }
+      return date;
+    },
+    [selectedTime, dateAdapter],
+  );
+
   const handleSelectionChange = useCallback(
     (
       event: SyntheticEvent,
@@ -3587,6 +3614,7 @@ export const WithExperimentalTime: StoryFn<
       selectedTime,
       selectedTime?.startTime,
       selectedTime?.endTime,
+      addTimeToDate,
     ],
   );
 
@@ -3601,32 +3629,8 @@ export const WithExperimentalTime: StoryFn<
         );
       }
     },
-    [dateAdapter, selectedDate],
+    [dateAdapter, selectedDate, addTimeToDate],
   );
-
-  function addTimeToDate(
-    time: typeof selectedTime,
-    date: DateRangeSelection<DateFrameworkType>,
-  ) {
-    const { startTime, endTime } = time;
-    if (dateAdapter.isValid(date?.startDate) && startTime) {
-      date.startDate = dateAdapter.set(date.startDate, {
-        hour: startTime.hour,
-        minute: startTime.minute,
-        second: startTime.second,
-        millisecond: startTime.millisecond,
-      });
-    }
-    if (dateAdapter.isValid(date?.endDate) && endTime) {
-      date.endDate = dateAdapter.set(date.endDate, {
-        hour: endTime.hour,
-        minute: endTime.minute,
-        second: endTime.second,
-        millisecond: endTime.millisecond,
-      });
-    }
-    return date;
-  }
 
   const handleApply = useCallback(
     (

--- a/site/docs/components/date-input/usage.mdx
+++ b/site/docs/components/date-input/usage.mdx
@@ -87,7 +87,7 @@ The default timezone for Salt's components is "default".
 
 Valid values for `timezone` are date framework specific and can be one of the following:
 
-- "default" uses the local timezone of the user's browser.
+- "default" uses the local timezone of the user's browser (un-supported by date-fns).
 - "system" uses the timezone of the system running the code.
 - "UTC" uses the UTC timezone.
 - string uses a specific IANA timezone string, such as "America/New_York" or "Europe/London".

--- a/site/docs/components/date-picker/range-date-picker/usage.mdx
+++ b/site/docs/components/date-picker/range-date-picker/usage.mdx
@@ -77,7 +77,7 @@ The default timezone for Salt's components is "default".
 
 Valid values for `timezone` are date framework specific and can be one of the following:
 
-- "default" uses the local timezone of the user's browser.
+- "default" uses the local timezone of the user's browser (un-supported by date-fns).
 - "system" uses the timezone of the system running the code.
 - "UTC" uses the UTC timezone.
 - string uses a specific IANA timezone string, such as "America/New_York" or "Europe/London".

--- a/site/docs/components/date-picker/usage.mdx
+++ b/site/docs/components/date-picker/usage.mdx
@@ -76,7 +76,7 @@ The default timezone for Salt's components is "default".
 
 Valid values for `timezone` are date framework specific and can be one of the following:
 
-- "default" uses the local timezone of the user's browser.
+- "default" uses the local timezone of the user's browser (unsupported by date-fns).
 - "system" uses the timezone of the system running the code.
 - "UTC" uses the UTC timezone.
 - string uses a specific IANA timezone string, such as "America/New_York" or "Europe/London".

--- a/site/docs/components/localization-provider/examples.mdx
+++ b/site/docs/components/localization-provider/examples.mdx
@@ -13,7 +13,7 @@ data:
 To integrate your date framework with Salt components and enable support for locales or timezones, defining a date adapter is essential. Salt provides date adapters for the most popular date frameworks, which you can extend or use as a foundation to create your own custom adapter.
 
 - **[Day.js](https://day.js.org/)**: Recommended for its small footprint, this library returns immutable Day.js objects.
-- **[date-fns](https://date-fns.org/)**: Ideal for comprehensive date manipulation, it returns native JavaScript `Date` objects but does not support timezones or UTC.
+- **[date-fns](https://date-fns.org/)**: Ideal for comprehensive date manipulation, it returns native JavaScript `Date` objects.
 - **[Luxon](https://moment.github.io/luxon/api-docs/index.html)**: A modern successor to Moment.js, it returns Luxon objects.
 - **[Moment.js](https://momentjs.com/docs/)**: A legacy library that is no longer actively maintained.
 

--- a/site/docs/components/localization-provider/usage.mdx
+++ b/site/docs/components/localization-provider/usage.mdx
@@ -28,42 +28,45 @@ data:
 
 To import `LocalizationProvider` from the core Salt package, use:
 
-```
+```js
 import { LocalizationProvider } from "@salt-ds/lab";
 ```
 
 To import your chosen adapter adapter use one of the following :
 
-Whilst `AdapterDayjs`, `AdapterLuxon` and `AdapterMoment` are compatible with both UTC and timezones, `AdapterDateFns` is not.  
-If you need to use UTC dates or timezones, you should use one of the other adapters.
+## luxon (recommended)
 
-## date-fns
-
-```
-import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+```js
+import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
 ```
 
 ## dayjs
 
-```
+```js
 import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
 ```
 
-## luxon
+## date-fns (without timezone support)
 
+```js
+import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
 ```
-import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
+
+## date-fns (with timezone support)
+
+```js
+import { AdapterDateFnsTZ } from "@salt-ds/date-adapters/date-fns-tz";
 ```
 
 ## moment (legacy)
 
-```
+```js
 import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 ```
 
 # Usage
 
-```
+```js
 const dateAdapter = new AdapterDateFns(locale);
 ```
 
@@ -71,17 +74,17 @@ Each adapter imports the date library defined by your peer dependency but for da
 
 Passing `dayjs` to `AdapterDayjs` enables you to preconfigure defaults.
 
-```
+```js
 import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
 import dayjs from "dayjs";
-dayjs.tz.setDefault('America/New_York');
+dayjs.tz.setDefault("America/New_York");
 
 const dayjsAdapter = new AdapterDayjs(locale, dayjs);
 ```
 
 Passing `moment-timezone` to `AdapterMoment` adapter enables timezone support.
 
-```
+```js
 import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import moment from "moment-timezone";
 
@@ -377,21 +380,21 @@ The following table lists the supported format types for date and time formattin
 
 For example to parse a date you need specify a format string
 
-```
-adapter.parse("25 Dec 2025", "DD MMM YYYY")
+```js
+adapter.parse("25 Dec 2025", "DD MMM YYYY");
 ```
 
 To format a date object you need a format string
 
-```
-adapter.format(date, "DD MMM YYYY") // 25 Dec 2025
+```js
+adapter.format(date, "DD MMM YYYY"); // 25 Dec 2025
 ```
 
 # Providing your own adapter
 
 Not normally necessary, but in order to add a new adapter that is a valid `TDate`, you will need to augment `DateFrameworkTypeMap`.
 
-```
+```js
 /**
  * To add a new adapter, then, add the adapter's date object to `DateFrameworkTypeMap` interface
  */

--- a/site/package.json
+++ b/site/package.json
@@ -22,6 +22,7 @@
     "gen:css": "yarn node './cssGen.mjs'"
   },
   "dependencies": {
+    "@date-fns/tz": "^1.2.0",
     "@jpmorganchase/mosaic-cli": "0.1.0-beta.92",
     "@jpmorganchase/mosaic-layouts": "0.1.0-beta.92",
     "@jpmorganchase/mosaic-plugins": "0.1.0-beta.92",
@@ -32,7 +33,7 @@
     "@jpmorganchase/mosaic-standard-generator": "0.1.0-beta.92",
     "@jpmorganchase/mosaic-store": "0.1.0-beta.92",
     "css-tree": "^3.1.0",
-    "date-fns": "^3.6.0",
+    "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
     "embla-carousel-react": "^8.6.0",
     "lodash-es": "^4.17.21",

--- a/site/src/examples/calendar/TwinCalendars.tsx
+++ b/site/src/examples/calendar/TwinCalendars.tsx
@@ -21,7 +21,7 @@ export const TwinCalendars = (): ReactElement => {
     null,
   );
   const handleHoveredDateChange: CalendarProps<DateFrameworkType>["onHoveredDateChange"] =
-    (event, newHoveredDate) => {
+    (_event, newHoveredDate) => {
       setHoveredDate(newHoveredDate);
     };
   const [startVisibleMonth, setStartVisibleMonth] = useState<
@@ -74,7 +74,7 @@ export const TwinCalendars = (): ReactElement => {
     UseCalendarSelectionRangeProps<DateFrameworkType>["selectedDate"]
   >({ startDate: undefined, endDate: undefined });
   const handleSelectionChange: UseCalendarSelectionRangeProps<DateFrameworkType>["onSelectionChange"] =
-    (event, newSelectedDate) => {
+    (_event, newSelectedDate) => {
       setSelectedDate(newSelectedDate);
     };
 

--- a/site/src/examples/calendar/WithTimezone.tsx
+++ b/site/src/examples/calendar/WithTimezone.tsx
@@ -9,7 +9,7 @@ import {
   StackLayout,
 } from "@salt-ds/core";
 import type { DateFrameworkType, Timezone } from "@salt-ds/date-adapters";
-import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
+import { AdapterDateFnsTZ } from "@salt-ds/date-adapters/date-fns-tz";
 import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
 import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
 import { AdapterMoment } from "@salt-ds/date-adapters/moment";
@@ -29,14 +29,6 @@ import {
   useEffect,
   useState,
 } from "react";
-
-// biome-ignore lint/suspicious/noExplicitAny: Date framework adapter
-const dateAdapterMap: Record<string, any> = {
-  moment: AdapterMoment,
-  dayjs: AdapterDayjs,
-  "date-fns": AdapterDateFns,
-  luxon: AdapterLuxon,
-};
 
 const Single = ({
   selectedTimezone,
@@ -167,25 +159,21 @@ export const WithTimezone = (): ReactElement => {
   const dateAdapterMap: Record<string, any> = {
     moment: AdapterMoment,
     dayjs: AdapterDayjs,
-    "date-fns": AdapterDateFns,
+    "date-fns": AdapterDateFnsTZ,
     luxon: AdapterLuxon,
   };
   const validAdapters = Object.keys(dateAdapterMap);
   const [dateAdapterName, setDateAdapterName] = useState<string>("luxon");
 
-  const timezoneOptions =
-    dateAdapterName !== "date-fns"
-      ? [
-          "default",
-          "system",
-          "UTC",
-          "America/New_York",
-          "Europe/London",
-          "Asia/Shanghai",
-          "Asia/Kolkata",
-        ]
-      : ["default"];
-
+  const timezoneOptions = [
+    "default",
+    "system",
+    "UTC",
+    "America/New_York",
+    "Europe/London",
+    "Asia/Shanghai",
+    "Asia/Kolkata",
+  ];
   const [selectedTimezone, setSelectedTimezone] = useState<string>(
     timezoneOptions[0],
   );

--- a/site/src/examples/calendar/WithTimezone.tsx
+++ b/site/src/examples/calendar/WithTimezone.tsx
@@ -41,7 +41,6 @@ const Single = ({
   const [iso8601String, setIso8601String] = useState<string>("");
   const [localeDateString, setLocaleDateString] = useState<string>("");
   const [dateString, setDateString] = useState<string>("");
-  const [error, setError] = useState<string | undefined>(undefined);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: reset related state when timezone changes
   useEffect(() => {
@@ -49,7 +48,6 @@ const Single = ({
     setIso8601String("");
     setLocaleDateString("");
     setDateString("");
-    setError(undefined);
   }, [selectedTimezone]);
 
   const handleSelectionChange = (
@@ -179,7 +177,7 @@ export const WithTimezone = (): ReactElement => {
   );
 
   const handleAdapterChange: DropdownProps["onSelectionChange"] = (
-    event,
+    _event,
     newSelected,
   ) => {
     setDateAdapterName(newSelected[0] ?? "date-fns");

--- a/site/src/examples/date-input/Range.tsx
+++ b/site/src/examples/date-input/Range.tsx
@@ -11,7 +11,7 @@ export const Range = (): ReactElement => {
   const { dateAdapter } = useLocalization();
   const handleDateChange = useCallback(
     (
-      event: SyntheticEvent,
+      _event: SyntheticEvent,
       date: DateRangeSelection<DateFrameworkType> | null,
       details: DateInputRangeDetails | undefined,
     ) => {

--- a/site/src/examples/date-input/RangeBordered.tsx
+++ b/site/src/examples/date-input/RangeBordered.tsx
@@ -11,7 +11,7 @@ export const RangeBordered = (): ReactElement => {
   const { dateAdapter } = useLocalization();
   const handleDateChange = useCallback(
     (
-      event: SyntheticEvent,
+      _event: SyntheticEvent,
       date: DateRangeSelection<DateFrameworkType> | null,
       details: DateInputRangeDetails | undefined,
     ) => {

--- a/site/src/examples/date-input/RangeControlled.tsx
+++ b/site/src/examples/date-input/RangeControlled.tsx
@@ -21,7 +21,6 @@ export const RangeControlled = (): ReactElement => {
   const { dateAdapter } = useLocalization();
   const defaultHelperText = "Please enter date in DD MMM YYYY format";
   const errorHelperText = "Please enter a valid date in DD MMM YYYY format";
-  const [open, setOpen] = useState<boolean>(false);
   const [helperText, setHelperText] = useState(defaultHelperText);
   const [validationStatus, setValidationStatus] = useState<"error" | undefined>(
     undefined,
@@ -30,7 +29,7 @@ export const RangeControlled = (): ReactElement => {
     useState<DateRangeSelection<DateFrameworkType> | null>(null);
   const handleDateChange = useCallback(
     (
-      event: SyntheticEvent,
+      _event: SyntheticEvent,
       date: DateRangeSelection<DateFrameworkType> | null,
       details: DateInputRangeDetails | undefined,
     ) => {

--- a/site/src/examples/date-input/SingleControlled.tsx
+++ b/site/src/examples/date-input/SingleControlled.tsx
@@ -29,7 +29,7 @@ export const SingleControlled = (): ReactElement => {
   );
   const handleDateChange = useCallback(
     (
-      event: SyntheticEvent,
+      _event: SyntheticEvent,
       date: SingleDateSelection<DateFrameworkType> | null,
       details: DateInputSingleDetails | undefined,
     ) => {

--- a/site/src/examples/date-input/SingleWithTimezone.tsx
+++ b/site/src/examples/date-input/SingleWithTimezone.tsx
@@ -27,14 +27,6 @@ import {
   useState,
 } from "react";
 
-// biome-ignore lint/suspicious/noExplicitAny: Date framework adapter
-const dateAdapterMap: Record<string, any> = {
-  moment: AdapterMoment,
-  dayjs: AdapterDayjs,
-  "date-fns": AdapterDateFns,
-  luxon: AdapterLuxon,
-};
-
 const Single = ({
   selectedTimezone,
 }: {

--- a/site/src/examples/date-picker/RangeControlled.tsx
+++ b/site/src/examples/date-picker/RangeControlled.tsx
@@ -22,7 +22,7 @@ export const RangeControlled = (): ReactElement => {
     useState<DateRangeSelection<DateFrameworkType> | null>(null);
   const handleSelectionChange = useCallback(
     (
-      event: SyntheticEvent,
+      _event: SyntheticEvent,
       date: DateRangeSelection<DateFrameworkType> | null,
       details: DateInputRangeDetails | undefined,
     ) => {

--- a/site/src/examples/date-picker/RangeGridPanel.tsx
+++ b/site/src/examples/date-picker/RangeGridPanel.tsx
@@ -25,7 +25,7 @@ export const RangeGridPanel = () => {
   const [step, setStep] = useState("1");
   const handleSelectionChange = useCallback(
     (
-      event: SyntheticEvent,
+      _event: SyntheticEvent,
       date: DateRangeSelection<DateFrameworkType> | null,
       details: DateInputRangeDetails | undefined,
     ) => {

--- a/site/src/examples/date-picker/RangeWithTimezone.tsx
+++ b/site/src/examples/date-picker/RangeWithTimezone.tsx
@@ -62,7 +62,7 @@ const Range = ({
 
   const handleSelectionChange = useCallback(
     (
-      event: SyntheticEvent,
+      _event: SyntheticEvent,
       selection: DateRangeSelection<DateFrameworkType> | null,
       details: DateInputRangeDetails | undefined,
     ) => {
@@ -301,7 +301,7 @@ export const RangeWithTimezone = (): ReactElement => {
   );
 
   const handleAdapterChange: DropdownProps["onSelectionChange"] = (
-    event,
+    _event,
     newSelected,
   ) => {
     setDateAdapterName(newSelected[0] ?? "date-fns");

--- a/site/src/examples/date-picker/SingleGridPanel.tsx
+++ b/site/src/examples/date-picker/SingleGridPanel.tsx
@@ -26,7 +26,7 @@ export const SingleGridPanel = () => {
 
   const handleSelectionChange = useCallback(
     (
-      event: SyntheticEvent,
+      _event: SyntheticEvent,
       date: SingleDateSelection<DateFrameworkType> | null,
       details: DateInputSingleDetails | undefined,
     ) => {

--- a/site/src/examples/date-picker/SingleWithConfirmation.tsx
+++ b/site/src/examples/date-picker/SingleWithConfirmation.tsx
@@ -50,7 +50,7 @@ export const SingleWithConfirmation = (): ReactElement => {
   });
   const handleSelectionChange = useCallback(
     (
-      event: SyntheticEvent,
+      _event: SyntheticEvent,
       date: SingleDateSelection<DateFrameworkType> | null,
       details: DateInputSingleDetails | undefined,
     ) => {

--- a/site/src/examples/date-picker/SingleWithLocaleZhCN.tsx
+++ b/site/src/examples/date-picker/SingleWithLocaleZhCN.tsx
@@ -44,7 +44,7 @@ export const SingleWithLocaleZhCN = (): ReactElement => {
   );
   const handleSelectionChange = useCallback(
     (
-      event: SyntheticEvent,
+      _event: SyntheticEvent,
       date: SingleDateSelection<DateFrameworkType> | null,
       details: DateInputSingleDetails | undefined,
     ) => {

--- a/site/src/examples/date-picker/SingleWithTimezone.tsx
+++ b/site/src/examples/date-picker/SingleWithTimezone.tsx
@@ -56,7 +56,7 @@ const Single = ({
 
   const handleSelectionChange = useCallback(
     (
-      event: SyntheticEvent,
+      _event: SyntheticEvent,
       selection: SingleDateSelection<DateFrameworkType> | null,
       details: DateInputSingleDetails | undefined,
     ) => {
@@ -224,7 +224,7 @@ export const SingleWithTimezone = (): ReactElement => {
   );
 
   const handleAdapterChange: DropdownProps["onSelectionChange"] = (
-    event,
+    _event,
     newSelected,
   ) => {
     setDateAdapterName(newSelected[0] ?? "date-fns");

--- a/site/src/examples/localization-provider/MinMax.tsx
+++ b/site/src/examples/localization-provider/MinMax.tsx
@@ -39,7 +39,7 @@ export const MinMax = (): ReactElement => {
     });
   const handleDateChange = useCallback(
     (
-      event: SyntheticEvent,
+      _event: SyntheticEvent,
       date: DateRangeSelection<DateFrameworkType> | null,
       details: DateInputRangeDetails | undefined,
     ) => {

--- a/tsconfig.v4.json
+++ b/tsconfig.v4.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules/date-fns/**"],
+  "include": ["types"]
+}

--- a/types/date-fns.d.ts
+++ b/types/date-fns.d.ts
@@ -1,0 +1,2 @@
+declare module 'date-fns' {
+}

--- a/types/date-fns.d.ts
+++ b/types/date-fns.d.ts
@@ -1,2 +1,1 @@
-declare module 'date-fns' {
-}
+declare module "date-fns" {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1446,6 +1446,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@date-fns/tz@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@date-fns/tz@npm:1.2.0"
+  checksum: 10/a9c2d32f98a5a5c655a7d3843046a5a36779b2ef0db803c608291976e6254e594a085777bf738379f50c7e9fc2ffebbf8bb836e9e9759a5ef2b703f91bb785de
+  languageName: node
+  linkType: hard
+
 "@emotion/hash@npm:^0.9.0":
   version: 0.9.0
   resolution: "@emotion/hash@npm:0.9.0"
@@ -3190,14 +3197,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@salt-ds/date-adapters@workspace:packages/date-adapters"
   peerDependencies:
+    "@date-fns/tz": ^1.2.0
     "@types/luxon": ^3.6.2
     "@types/react": ">=16.14.0"
-    date-fns: ^3.6.0
+    date-fns: ^4.1.0
     dayjs: ^1.11.13
     luxon: ^3.6.1
     moment: ^2.30.1
     moment-timezone: ^0.5.46
   peerDependenciesMeta:
+    "@date-fns/tz":
+      optional: true
     date-fns:
       optional: true
     dayjs:
@@ -3255,6 +3265,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@salt-ds/lab@workspace:packages/lab"
   dependencies:
+    "@date-fns/tz": "npm:^1.2.0"
     "@floating-ui/react": "npm:^0.26.28"
     "@salt-ds/core": "workspace:^"
     "@salt-ds/date-adapters": "workspace:*"
@@ -3268,7 +3279,7 @@ __metadata:
     clipboard-copy: "npm:^4.0.1"
     clsx: "npm:^2.0.0"
     compute-scroll-into-view: "npm:^3.0.0"
-    date-fns: "npm:^3.6.0"
+    date-fns: "npm:^4.1.0"
     dayjs: "npm:^1.11.13"
     deepmerge: "npm:^4.2.2"
     luxon: "npm:^3.6.1"
@@ -3310,6 +3321,7 @@ __metadata:
     "@biomejs/wasm-nodejs": "npm:^2.0.0"
     "@changesets/cli": "npm:^2.27.12"
     "@cypress/code-coverage": "npm:^3.13.6"
+    "@date-fns/tz": "npm:^1.2.0"
     "@faker-js/faker": "npm:^8.0.0"
     "@fontsource/open-sans": "npm:^4.5.13"
     "@fontsource/pt-mono": "npm:^5.0.12"
@@ -3374,6 +3386,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@salt-ds/site@workspace:site"
   dependencies:
+    "@date-fns/tz": "npm:^1.2.0"
     "@jpmorganchase/mosaic-cli": "npm:0.1.0-beta.92"
     "@jpmorganchase/mosaic-layouts": "npm:0.1.0-beta.92"
     "@jpmorganchase/mosaic-plugins": "npm:0.1.0-beta.92"
@@ -3389,7 +3402,7 @@ __metadata:
     concurrently: "npm:^9.0.0"
     cross-env: "npm:^7.0.3"
     css-tree: "npm:^3.1.0"
-    date-fns: "npm:^3.6.0"
+    date-fns: "npm:^4.1.0"
     dayjs: "npm:^1.11.13"
     dotenv-load: "npm:^2.0.1"
     embla-carousel-class-names: "npm:^8.6.0"
@@ -7209,10 +7222,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "date-fns@npm:3.6.0"
-  checksum: 10/cac35c58926a3b5d577082ff2b253612ec1c79eb6754fddef46b6a8e826501ea2cb346ecbd211205f1ba382ddd1f9d8c3f00bf433ad63cc3063454d294e3a6b8
+"date-fns@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "date-fns@npm:4.1.0"
+  checksum: 10/d5f6e9de5bbc52310f786099e18609289ed5e30af60a71e0646784c8185ddd1d0eebcf7c96b7faaaefc4a8366f3a3a4244d099b6d0866ee2bec80d1361e64342
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- added `@salt-ds/date-adapters/date-fns-tz` to provide timezone support for `date-fns`