### PR TITLE
Fix interactive background with open Dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
   },
   "resolutions": {
     "@changesets/assemble-release-plan@npm:^6.0.5": "patch:@changesets/assemble-release-plan@npm%3A6.0.5#~/.yarn/patches/@changesets-assemble-release-plan-npm-6.0.5-3055b7bcad.patch",
+    "@floating-ui/react": "0.27.0",
     "@salt-ds/lab": "workspace:*",
     "next": "^14.0.0",
     "whatwg-url": "^14.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "*.css"
   ],
   "dependencies": {
-    "@floating-ui/react": "^0.26.28",
+    "@floating-ui/react": "0.27.0",
     "@salt-ds/icons": "workspace:^",
     "@salt-ds/styles": "workspace:*",
     "@salt-ds/window": "workspace:*",

--- a/packages/core/src/dialog/Dialog.tsx
+++ b/packages/core/src/dialog/Dialog.tsx
@@ -115,7 +115,7 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>(
 
     const { getFloatingProps } = useInteractions([
       useClick(context),
-      useDismiss(context, { enabled: !disableDismiss }),
+      useDismiss(context, { outsidePress: !disableDismiss }),
     ]);
 
     const { Component: FloatingComponent } = useFloatingComponent();

--- a/packages/core/src/utils/useFloatingUI/useFloatingUI.tsx
+++ b/packages/core/src/utils/useFloatingUI/useFloatingUI.tsx
@@ -82,7 +82,7 @@ const DefaultFloatingComponent = forwardRef<
     return (
       <FloatingPortal>
         <ChosenSaltProvider applyClassesTo="scope">
-          <FloatingFocusManager {...focusManagerProps}>
+          <FloatingFocusManager outsideElementsInert {...focusManagerProps}>
             <div style={style} {...rest} ref={ref} />
           </FloatingFocusManager>
         </ChosenSaltProvider>

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -16,7 +16,7 @@
     "*.css"
   ],
   "dependencies": {
-    "@floating-ui/react": "^0.26.28",
+    "@floating-ui/react": "0.27.0",
     "@salt-ds/core": "workspace:^",
     "@salt-ds/date-adapters": "workspace:*",
     "@salt-ds/icons": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,55 +1725,55 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/core@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "@floating-ui/core@npm:1.6.0"
+"@floating-ui/core@npm:^1.7.2":
+  version: 1.7.2
+  resolution: "@floating-ui/core@npm:1.7.2"
   dependencies:
-    "@floating-ui/utils": "npm:^0.2.1"
-  checksum: 10/d6a47cacde193cd8ccb4c268b91ccc4ca254dffaec6242b07fd9bcde526044cc976d27933a7917f9a671de0a0e27f8d358f46400677dbd0c8199de293e9746e1
+    "@floating-ui/utils": "npm:^0.2.10"
+  checksum: 10/2885a4c824f8d148222714cf2650c29bf3b30b70f465b990734766aafb1366ba23b4a285918c4f3ee67161096e7b9e4fbe0b3ca31e0f78800338cb4e6292912d
   languageName: node
   linkType: hard
 
-"@floating-ui/dom@npm:^1.0.0":
-  version: 1.6.12
-  resolution: "@floating-ui/dom@npm:1.6.12"
+"@floating-ui/dom@npm:^1.7.2":
+  version: 1.7.2
+  resolution: "@floating-ui/dom@npm:1.7.2"
   dependencies:
-    "@floating-ui/core": "npm:^1.6.0"
-    "@floating-ui/utils": "npm:^0.2.8"
-  checksum: 10/5c8e5fdcd3843140a606ab6dc6c12ad740f44e66b898966ef877393faaede0bbe14586e1049e2c2f08856437da8847e884a2762e78275fefa65a5a9cd71e580d
+    "@floating-ui/core": "npm:^1.7.2"
+    "@floating-ui/utils": "npm:^0.2.10"
+  checksum: 10/2d581459973b66024c47f039cabdc059b39c72abca93a4a0a8110e0a90b79d3fb84e49099afb73e13b3e7f17096070422220d996b206a5f0120c92bd7c48b98b
   languageName: node
   linkType: hard
 
 "@floating-ui/react-dom@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "@floating-ui/react-dom@npm:2.1.2"
+  version: 2.1.4
+  resolution: "@floating-ui/react-dom@npm:2.1.4"
   dependencies:
-    "@floating-ui/dom": "npm:^1.0.0"
+    "@floating-ui/dom": "npm:^1.7.2"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
-  checksum: 10/2a67dc8499674e42ff32c7246bded185bb0fdd492150067caf9568569557ac4756a67787421d8604b0f241e5337de10762aee270d9aeef106d078a0ff13596c4
+  checksum: 10/8fad23bd7a94b50bbd715109a272528978511b793b8954098c8e99dd0b63557a8641b315ce09301ef014eada560fd8638e4dea4c21cf7ce8d93f0038a59cd442
   languageName: node
   linkType: hard
 
-"@floating-ui/react@npm:^0.26.28, @floating-ui/react@npm:^0.26.6":
-  version: 0.26.28
-  resolution: "@floating-ui/react@npm:0.26.28"
+"@floating-ui/react@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@floating-ui/react@npm:0.27.0"
   dependencies:
     "@floating-ui/react-dom": "npm:^2.1.2"
     "@floating-ui/utils": "npm:^0.2.8"
     tabbable: "npm:^6.0.0"
   peerDependencies:
-    react: ">=16.8.0"
-    react-dom: ">=16.8.0"
-  checksum: 10/7f8e6b27db48b68ca94756687af21857be04e7360ac922d7c8e22411f2895df6384af7bd40f4b48663d3cc5809bb5c6574cd9c9ea15543ec747b9a8e1c8c3008
+    react: ">=17.0.0"
+    react-dom: ">=17.0.0"
+  checksum: 10/b04e8b356c6ffebbd7033cfb0ba7c08e83b3c0314b28e860ff1502595ca6eb245ef8b935b8879af044edca38a27335fefff15eddaabe3a7d39bcfd255b7fcd86
   languageName: node
   linkType: hard
 
-"@floating-ui/utils@npm:^0.2.1, @floating-ui/utils@npm:^0.2.8":
-  version: 0.2.8
-  resolution: "@floating-ui/utils@npm:0.2.8"
-  checksum: 10/3e3ea3b2de06badc4baebdf358b3dbd77ccd9474a257a6ef237277895943db2acbae756477ec64de65a2a1436d94aea3107129a1feeef6370675bf2b161c1abc
+"@floating-ui/utils@npm:^0.2.10, @floating-ui/utils@npm:^0.2.8":
+  version: 0.2.10
+  resolution: "@floating-ui/utils@npm:0.2.10"
+  checksum: 10/b635ea865a8be2484b608b7157f5abf9ed439f351011a74b7e988439e2898199a9a8b790f52291e05bdcf119088160dc782d98cff45cc98c5a271bc6f51327ae
   languageName: node
   linkType: hard
 
@@ -3143,7 +3143,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@salt-ds/core@workspace:packages/core"
   dependencies:
-    "@floating-ui/react": "npm:^0.26.28"
+    "@floating-ui/react": "npm:0.27.0"
     "@salt-ds/icons": "workspace:^"
     "@salt-ds/styles": "workspace:*"
     "@salt-ds/window": "workspace:*"
@@ -3273,7 +3273,7 @@ __metadata:
   resolution: "@salt-ds/lab@workspace:packages/lab"
   dependencies:
     "@date-fns/tz": "npm:^1.2.0"
-    "@floating-ui/react": "npm:^0.26.28"
+    "@floating-ui/react": "npm:0.27.0"
     "@salt-ds/core": "workspace:^"
     "@salt-ds/date-adapters": "workspace:*"
     "@salt-ds/icons": "workspace:^"


### PR DESCRIPTION
This PR bumps floating-ui to 0.27.0. 0.27.0 dropped support for React 16 however it doesn't make any code changes. It's peer dependencies have been updated which will cause a message to be shown when installing 