### PR TITLE
Hide Tooltip if Content is null

### DIFF
--- a/packages/core/src/tooltip/Tooltip.tsx
+++ b/packages/core/src/tooltip/Tooltip.tsx
@@ -124,7 +124,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     const triggerRef = useForkRef(getRefFromChildren(children), reference);
 
     const floatingRef = useForkRef<HTMLDivElement>(floating, ref);
-    const hasContent = content !== undefined && content !== "";
+    const hasContent = !!content;
 
     return (
       <>


### PR DESCRIPTION
The tooltip currently doesn't show if you pass `undefined` or an empty string. However if you pass `null` it shows a weird error state on the UI, where it looks like a tiny empty tooltip with a gap between the arrow and the container. I suspect this behaviour is unexpected, at least it was for me.

This PR changes the Tooltip so that it also doesn't show if `null` is passed. I was going to add `&& !== null`, but I think that's functionally the same as just doing `!!content` so went with that as was a bit cleaner.