### PR TITLE
Update glossary to clarify read-only validation support

### DIFF
--- a/site/docs/about/glossary.mdx
+++ b/site/docs/about/glossary.mdx
@@ -43,4 +43,4 @@ A component in a disabled state is completely non-interactive as it isn’t cons
 
 ## Read-only state
 
-A component in a read-only state is considered relevant to the user’s workflow, allowing users to view and interact with the content without modifying it. It must meet accessibility requirements, including minimum contrast. The system supports validation states (error, warning or success) for read-only components. While disabled states are usually not detected by screen readers, read-only elements are accessible by screen readers.
+A component in a read-only state is considered relevant to the user’s workflow, allowing users to view and interact with the content without modifying it. It must meet accessibility requirements, including minimum contrast. The system supports validation states (error, warning, or success) for read-only components, except for radio buttons and checkboxes. While disabled states are usually not detected by screen readers, read-only elements are accessible by screen readers.


### PR DESCRIPTION
Based on the read-only blurb in the glossary, we needed to adjust the language to exclude radio and checkbox as we don't support this in our components.