### PR TITLE
Fix bad indentation of a mapping entry in Stepper examples site doc

### DIFF
--- a/site/docs/components/stepper/examples.mdx
+++ b/site/docs/components/stepper/examples.mdx
@@ -1,11 +1,11 @@
 ---
-  title:
-    $ref: ./#/title
-  layout: DetailComponent
-  sidebar:
-    exclude: true
-  data:
-    $ref: ./#/data
+title:
+  $ref: ./#/title
+layout: DetailComponent
+sidebar:
+  exclude: true
+data:
+  $ref: ./#/data
 ---
 
 ## Orientation


### PR DESCRIPTION
I am trying to parse the docs but yaml parser throw the error:

`bad indentation of a mapping entry (3:3)`

```bash
 1 | title:
 2 |     $ref: ./#/title
 3 |   layout: DetailComponent
-------^
 4 |   sidebar:
 5 |     exclude: true
Stack: YAMLException: bad indentation of a mapping entry (3:3)
```