### PR TITLE
Highcharts | Add PieChart

### DIFF
--- a/.changeset/quiet-hairs-try.md
+++ b/.changeset/quiet-hairs-try.md
@@ -1,0 +1,8 @@
+---
+"@salt-ds/highcharts-theme": minor
+---
+
+- Added PieChart
+- Since DonutChart is a variant of PieChart,the plotOptions.pie.innerSize setting is moved out of the global options; otherwise, a default PieChart would automatically become a DonutChart
+- Consumers are instructed to supply the innerSize setting themselves in documentation.
+- Documentation reordered to show PieChart first due to the above.

--- a/.changeset/tasty-snakes-clean.md
+++ b/.changeset/tasty-snakes-clean.md
@@ -1,5 +1,5 @@
 ---
-"@salt-ds/highcharts-theme": patch
+"@salt-ds/highcharts-theme": minor
 ---
 
 - `useChart` hook is density-aware. When Salt density changes, it triggers a `chart.redraw()` and returns a `legendIconSize` mapped to Salt size tokens, enabling responsive legend symbol sizing.

--- a/packages/highcharts-theme/src/examples/DonutChart.tsx
+++ b/packages/highcharts-theme/src/examples/DonutChart.tsx
@@ -28,6 +28,11 @@ const DonutChart: FC<DonutChartProps> = ({ patterns = false }) => {
     tooltip: {
       enabled: false,
     },
+    plotOptions: {
+      pie: {
+        innerSize: "80%",
+      },
+    },
     series: [
       {
         type: "pie",

--- a/packages/highcharts-theme/src/examples/PieChart.tsx
+++ b/packages/highcharts-theme/src/examples/PieChart.tsx
@@ -1,21 +1,19 @@
-import { Switch } from "@salt-ds/core";
 import { useChart } from "@salt-ds/highcharts-theme";
 import { clsx } from "clsx";
 import Highcharts, { type Options } from "highcharts";
-import accessibility from "highcharts/modules/accessibility";
 import HighchartsReact from "highcharts-react-official";
-import { useRef, useState } from "react";
-import styles from "./index.module.css";
+import { type FC, useRef } from "react";
 
-accessibility(Highcharts);
+export interface PieChartProps {
+  patterns?: boolean;
+}
 
-export const DonutChart = () => {
-  const DonutRef = useRef<HighchartsReact.RefObject>(null);
-  const [patterns, setPatterns] = useState(false);
+const PieChart: FC<PieChartProps> = ({ patterns = false }) => {
+  const PieRef = useRef<HighchartsReact.RefObject>(null);
 
-  useChart({ chartRef: DonutRef });
+  useChart({ chartRef: PieRef });
 
-  const donutChartOptions: Options = {
+  const pieChartOptions: Options = {
     chart: {
       type: "pie",
     },
@@ -23,17 +21,12 @@ export const DonutChart = () => {
       text: "Bank revenue mix",
       align: "center",
     },
-    tooltip: {
-      enabled: false,
-    },
     accessibility: {
       description:
-        "A donut chart showing a breakdown of bank revenue by product line. There are 20 categories, each shown with equal share (5%) for demonstration purposes.",
+        "A pie chart showing a breakdown of bank revenue by product line. There are 20 categories, each shown with equal share (5%) for demonstration purposes.",
     },
-    plotOptions: {
-      pie: {
-        innerSize: "80%",
-      },
+    tooltip: {
+      enabled: false,
     },
     series: [
       {
@@ -66,26 +59,19 @@ export const DonutChart = () => {
   };
 
   return (
-    <div className={styles.chartContainer}>
-      <div className={styles.controlsRow}>
-        <Switch
-          label="Show patterns"
-          checked={patterns}
-          onChange={(e) => setPatterns(e.target.checked)}
-        />
-      </div>
-      <div
-        className={clsx("highcharts-theme-salt", {
-          "salt-fill-patterns": patterns,
-        })}
-      >
-        <HighchartsReact
-          className={styles.chart}
-          highcharts={Highcharts}
-          options={donutChartOptions}
-          ref={DonutRef}
-        />
-      </div>
+    <div
+      className={clsx("highcharts-theme-salt", {
+        "salt-fill-patterns": patterns,
+      })}
+      style={{ maxWidth: 700, width: "100%" }}
+    >
+      <HighchartsReact
+        highcharts={Highcharts}
+        options={pieChartOptions}
+        ref={PieRef}
+      />
     </div>
   );
 };
+
+export default PieChart;

--- a/packages/highcharts-theme/src/examples/index.ts
+++ b/packages/highcharts-theme/src/examples/index.ts
@@ -1,2 +1,3 @@
 export { default as DonutChart } from "./DonutChart";
 export { default as LineChart } from "./LineChart";
+export { default as PieChart } from "./PieChart";

--- a/packages/highcharts-theme/src/highcharts-options-salt.ts
+++ b/packages/highcharts-theme/src/highcharts-options-salt.ts
@@ -21,6 +21,7 @@ export const saltThemeDefaults: HighchartsOptionsCompat = {
     headerFormat: "<span>{point.key}</span><br/>",
     pointFormat:
       '<span>{series.name}: </span><span class="value">{point.y}</span>',
+    stickOnContact: true,
   },
   legend: {
     layout: "vertical",
@@ -55,7 +56,6 @@ export const saltThemeDefaults: HighchartsOptionsCompat = {
           '{point.name} <span class="value">{point.percentage:.1f}%</span>',
         enabled: true,
       },
-      innerSize: "80%",
     },
   },
   title: {

--- a/packages/highcharts-theme/stories/highcharts-theme.stories.tsx
+++ b/packages/highcharts-theme/stories/highcharts-theme.stories.tsx
@@ -6,6 +6,7 @@ import HighchartsReact from "highcharts-react-official";
 import {
   DonutChart as DonutChartComponent,
   LineChart as LineChartComponent,
+  PieChart as PieChartComponent,
 } from "../src/examples";
 
 accessibility(Highcharts);
@@ -42,6 +43,13 @@ export const LineChart = {
 
 export const DonutChart = {
   render: (args: { patterns?: boolean }) => <DonutChartComponent {...args} />,
+  args: {
+    patterns: false,
+  },
+};
+
+export const PieChart = {
+  render: (args: { patterns?: boolean }) => <PieChartComponent {...args} />,
   args: {
     patterns: false,
   },

--- a/site/docs/components/highcharts-theme/examples.mdx
+++ b/site/docs/components/highcharts-theme/examples.mdx
@@ -21,9 +21,21 @@ Use a line chart to show changes in data over time. To ensure accessible present
 
 <LivePreview componentName="highcharts-theme" exampleName="LineChart" />
 
+## Pie Chart
+
+Use a pie chart to show proportions of a whole. To ensure accessible presentation, fill patterns can be applied to the chart (see [Patterns and Fills](./usage#patterns-and-fills) for details).
+
+<LivePreview componentName="highcharts-theme" exampleName="PieChart" />
+
 ## Donut Chart
 
-Use a donut chart to show proportions of a whole. To ensure accessible presentation, fill patterns can be applied to the chart (see [Patterns and Fills](./usage#patterns-and-fills) for details).
+Use a donut chart to show proportions of a whole, with space in the center to highlight key values or additional information. To ensure accessible presentation, fill patterns can be applied to the chart (see [Patterns and Fills](./usage#patterns-and-fills) for details).
+
+A donut chart is a variation of the pie chart, with the `plotOptions.pie.innerSize` set to less than `100%` within the `Options` object.
+
+### Best practices
+
+- An `innerSize` value of `80%` is recommended for a good default visual balance.
 
 <LivePreview componentName="highcharts-theme" exampleName="DonutChart" />
 

--- a/site/src/examples/highcharts-theme/PieChart.tsx
+++ b/site/src/examples/highcharts-theme/PieChart.tsx
@@ -9,13 +9,13 @@ import styles from "./index.module.css";
 
 accessibility(Highcharts);
 
-export const DonutChart = () => {
-  const DonutRef = useRef<HighchartsReact.RefObject>(null);
+export const PieChart = () => {
+  const PieRef = useRef<HighchartsReact.RefObject>(null);
   const [patterns, setPatterns] = useState(false);
 
-  useChart({ chartRef: DonutRef });
+  useChart({ chartRef: PieRef });
 
-  const donutChartOptions: Options = {
+  const pieChartOptions: Options = {
     chart: {
       type: "pie",
     },
@@ -28,12 +28,7 @@ export const DonutChart = () => {
     },
     accessibility: {
       description:
-        "A donut chart showing a breakdown of bank revenue by product line. There are 20 categories, each shown with equal share (5%) for demonstration purposes.",
-    },
-    plotOptions: {
-      pie: {
-        innerSize: "80%",
-      },
+        "A pie chart showing a breakdown of bank revenue by product line. There are 20 categories, each shown with equal share (5%) for demonstration purposes.",
     },
     series: [
       {
@@ -82,8 +77,8 @@ export const DonutChart = () => {
         <HighchartsReact
           className={styles.chart}
           highcharts={Highcharts}
-          options={donutChartOptions}
-          ref={DonutRef}
+          options={pieChartOptions}
+          ref={PieRef}
         />
       </div>
     </div>

--- a/site/src/examples/highcharts-theme/index.ts
+++ b/site/src/examples/highcharts-theme/index.ts
@@ -1,2 +1,3 @@
 export * from "./DonutChart";
 export * from "./LineChart";
+export * from "./PieChart";


### PR DESCRIPTION
- DonutChart is a variant of PieChart, so the `plotOptions.pie.innerSize` setting is moved out of the global options; otherwise, a default PieChart would automatically become a DonutChart. Consumers are instructed to supply the `innerSize` setting themselves in documentation.

- Documentation reordered to show PieChart first due to the above.