### PR TITLE
fix: correct 'Alart' to 'Alert' in Progression section (fixes #5480)

### DIFF
--- a/site/docs/patterns/indication.mdx
+++ b/site/docs/patterns/indication.mdx
@@ -70,7 +70,7 @@ There are 5 main stages of progression with associated colors and icons:
 - **In Progress**: 
     - On hold – An item is temporarily not being dealt with and is paused
     - In progress – An item is actively being worked on/addressed, with no blockers
-- **Alart**: 
+- **Alert**: 
     - Pending – An item is being worked on but may be waiting for another process or input
 - **At Risk**: 
     - Canceled – An item has been deliberately closed or removed, likely due to a negative circumstance


### PR DESCRIPTION
## Summary
Fixes a typo in the indication pattern documentation where "Alart" was incorrectly spelled instead of "Alert" in the Progression section.

## What was changed
- Corrected the spelling from "Alart" to "Alert" in `site/docs/patterns/indication.mdx`
- This affects the Progression section where the status was incorrectly labeled

## Issue
Closes #5480

## Testing
- Verified the spelling correction was applied correctly
- No other content was modified