### PR TITLE
Country Symbols Usage Text Fix (UIE-7026)

### DIFF
--- a/site/docs/components/country-symbol/usage.mdx
+++ b/site/docs/components/country-symbol/usage.mdx
@@ -16,11 +16,9 @@ To reduce the core package's bundle size, country symbols are in a separate pack
 
 ### When to use
 
-When you need to display an icon that represents the flag of a country or intergovernmental organization.
+To display an icon that represents the flag of a country or territory.
 
 ### When not to use
-
-When representing languages, national currencies or telephone country codes.
 
 While the ISO country codes do correlate with top-level domains (TLD) on the internet, for example, they don't always map perfectly to languages, national currencies or telephone country codes. So, sometimes they may not be the best corresponding visuals, given cultural, historical and political sensitivities. Regardless, since the symbols are decorative, there must be correct labels and accessible text to convey the information.
 


### PR DESCRIPTION
Removed: "When representing languages, national currencies or telephone country codes" so as not to conflict with "they don't always map perfectly to languages, national currencies or telephone country codes"