### PR TITLE
Highcharts | Bug Fixes & Doc Enhancements

### DIFF
--- a/packages/highcharts-theme/src/default-options.ts
+++ b/packages/highcharts-theme/src/default-options.ts
@@ -55,6 +55,9 @@ export const getDefaultOptions = (
           enabled: true,
         },
       },
+      bar: {
+        borderRadius: 0,
+      },
     },
   };
 

--- a/site/docs/components/highcharts-theme/accessibility.mdx
+++ b/site/docs/components/highcharts-theme/accessibility.mdx
@@ -12,7 +12,9 @@ data:
 
 Highcharts provides an [accessibility module](https://www.highcharts.com/docs/accessibility/accessibility-module) that enhances the accessibility of charts.
 
-To enable the accessibility module in Highcharts v10, import and initialize the module as shown below:
+### Highcharts v10
+
+To enable the accessibility module in Highcharts v10, import and initialize the module with your Highcharts instance:
 
 ```js
 import accessibility from "highcharts/modules/accessibility";
@@ -20,8 +22,10 @@ import accessibility from "highcharts/modules/accessibility";
 accessibility(Highcharts);
 ```
 
-<Callout title="Note">
+### Highcharts v11+
 
-From Highcharts v11 onwards, you no longer need to call a function to initialize the accessibility module. Ensure you follow the guidance above for Highcharts v10 compatibility.
+From Highcharts v11+ onwards, the accessibility module auto-initializes upon import:
 
-</Callout>
+```js
+import "highcharts/modules/accessibility";
+```

--- a/site/docs/components/highcharts-theme/usage.mdx
+++ b/site/docs/components/highcharts-theme/usage.mdx
@@ -12,12 +12,16 @@ data:
 
 ## Import
 
-To install the Salt Highcharts theme package, ensure you have a supported version of Highcharts installed and add `@salt-ds/highcharts-theme` via your package manager
+Install the following dependencies:
+
+- `highcharts` - version 10.2.0 to v12.
+- `highcharts-react-official`
+- `@salt-ds/highcharts-theme@0.0.0-snapshot-20250915124856`
 
 ```bash
-npm install @salt-ds/highcharts-theme
+npm install highcharts highcharts-react-official @salt-ds/highcharts-theme@0.0.0-snapshot-20250915124856
 # or
-yarn add @salt-ds/highcharts-theme
+yarn add highcharts highcharts-react-official @salt-ds/highcharts-theme@0.0.0-snapshot-20250915124856
 ```
 
 ### Import Highcharts CSS
@@ -51,7 +55,7 @@ Then wrap your Highcharts with `highcharts-theme-salt` class name as shown below
 
 ## useChart hook
 
-Many Highchart stylistic properties can't be configured via CSS alone and are not density sensitive. Wrap your Highcharts options with the `useChart` hook to ensure the theme is applied correctly.
+Wrap your Highcharts options with the `useChart` hook to ensure the theme is applied correctly.
 
 ```jsx
 import { useChart } from "@salt-ds/highcharts-theme";

--- a/site/src/examples/highcharts-theme/DonutChart.tsx
+++ b/site/src/examples/highcharts-theme/DonutChart.tsx
@@ -2,12 +2,9 @@ import { Switch } from "@salt-ds/core";
 import { useChart } from "@salt-ds/highcharts-theme";
 import { clsx } from "clsx";
 import Highcharts, { type Options } from "highcharts";
-import accessibility from "highcharts/modules/accessibility";
 import HighchartsReact from "highcharts-react-official";
 import { useRef, useState } from "react";
 import styles from "./index.module.css";
-
-accessibility(Highcharts);
 
 const options: Options = {
   title: {

--- a/site/src/examples/highcharts-theme/PieChart.tsx
+++ b/site/src/examples/highcharts-theme/PieChart.tsx
@@ -2,12 +2,9 @@ import { Switch } from "@salt-ds/core";
 import { useChart } from "@salt-ds/highcharts-theme";
 import { clsx } from "clsx";
 import Highcharts, { type Options } from "highcharts";
-import accessibility from "highcharts/modules/accessibility";
 import HighchartsReact from "highcharts-react-official";
 import { useRef, useState } from "react";
 import styles from "./index.module.css";
-
-accessibility(Highcharts);
 
 const options: Options = {
   chart: {

--- a/site/src/examples/highcharts-theme/StackedBarChart.tsx
+++ b/site/src/examples/highcharts-theme/StackedBarChart.tsx
@@ -2,12 +2,9 @@ import { Switch } from "@salt-ds/core";
 import { useChart } from "@salt-ds/highcharts-theme";
 import { clsx } from "clsx";
 import Highcharts, { type Options } from "highcharts";
-import accessibility from "highcharts/modules/accessibility";
 import HighchartsReact from "highcharts-react-official";
 import { useRef, useState } from "react";
 import styles from "./index.module.css";
-
-accessibility(Highcharts);
 
 const options: Options = {
   chart: {


### PR DESCRIPTION
- Set bar border radius to 0 for v11+ compatibility
- Remove direct import of accessibility module in examples as this differs between highchart versions and guidance is clarified in the accessibility tab.
- Improve installation guidance with temporary snapshot package.