### PR TITLE
`AriaAnnouncer` improvements, previously `delay` was used to queue an…

### DIFF
--- a/.changeset/nasty-planes-sell.md
+++ b/.changeset/nasty-planes-sell.md
@@ -1,0 +1,19 @@
+---
+"@salt-ds/core": minor
+---
+
+- `AriaAnnouncer` improvements, previously `delay` was used to queue announcements, but it could create overlapping announcements. We have deprecated `delay`, although it is still supported. Instead, we have added a new options API.
+- `duration`: provides a sequential delay between announcements, ensuring they do not overlap.
+- `ariaLive` determines the importance and urgency of the announcement.
+
+The default duration is 500 msecs, unless specified.
+
+```diff
+import { useAriaAnnouncer } from "./useAriaAnnouncer";
+
+const { announce } = useuseAriaAnnouncer();
+
+- const delayMsec = 1000;
+- announce("my announcement", delayMsec);
++ announce("my announcement", { duration: 1000, ariaLive: "polite"});
+```

--- a/packages/core/src/aria-announcer/AriaAnnounce.tsx
+++ b/packages/core/src/aria-announcer/AriaAnnounce.tsx
@@ -1,24 +1,36 @@
 import { type ComponentType, useEffect } from "react";
-
+import type { AnnounceFnOptions } from "./AriaAnnouncerContext";
 import { useAriaAnnouncer } from "./useAriaAnnouncer";
 
-export interface AriaAnnounceProps {
+export interface AriaAnnounceProps extends AnnounceFnOptions {
   /**
-   * String which will be announced by screen readers on change
+   * String to be announced by screenreader.
    */
   announcement?: string;
+  /**
+   * Legacy option, precede the announcement with a delay.
+   * @deprecated
+   * useAriaAnnouncer `delay` arg is deprecated, use your own `setTimeout` or consider using `duration` through `AnnounceFnOptions` instead.
+   */
+  delay?: number;
 }
 
 export const AriaAnnounce: ComponentType<AriaAnnounceProps> = ({
   announcement,
+  delay,
+  ...rest
 }) => {
   const { announce } = useAriaAnnouncer();
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: ignore rest
   useEffect(() => {
     if (announcement) {
-      announce(announcement);
+      if (delay !== undefined) {
+        announce(announcement, delay);
+      }
+      announce(announcement, rest);
     }
-  }, [announce, announcement]);
+  }, [announce, announcement, delay]);
 
   // biome-ignore lint/complexity/noUselessFragments: If we return null here, react-docgen wouldn't be able to locate the component.
   return <></>;

--- a/packages/core/src/aria-announcer/AriaAnnouncerContext.ts
+++ b/packages/core/src/aria-announcer/AriaAnnouncerContext.ts
@@ -1,9 +1,23 @@
 import { createContext } from "react";
 
-export type AnnounceFn = (announcement: string, delay?: number) => void;
+export type AnnounceFnOptions = {
+  duration?: number;
+  ariaLive?: Exclude<React.AriaAttributes["aria-live"], "off">;
+};
 
 export type AriaAnnouncer = {
-  announce: AnnounceFn;
+  /**
+   * TODO remove legacy `delay` arg (number) in favour of `options` (AnnounceFnOptions) as a breaking change
+   */
+  /**
+   * Announcer function
+   * @param announcement - announcement to queue for screenreader.
+   * @param legacyDelayOrOptions, deprecated `delay` or `options` for announcement
+   */
+  announce: (
+    announcement: string,
+    legacyDelayOrOptions?: number | AnnounceFnOptions,
+  ) => void;
 };
 
 export const AriaAnnouncerContext = createContext<AriaAnnouncer | undefined>(

--- a/packages/core/src/aria-announcer/useAriaAnnouncer.ts
+++ b/packages/core/src/aria-announcer/useAriaAnnouncer.ts
@@ -1,6 +1,7 @@
 import { useCallback, useContext, useEffect, useMemo, useRef } from "react";
 import { debounce } from "../utils/debounce";
 import {
+  type AnnounceFnOptions,
   type AriaAnnouncer,
   AriaAnnouncerContext,
 } from "./AriaAnnouncerContext";
@@ -13,6 +14,7 @@ export type useAriaAnnouncerHook = (
 ) => AriaAnnouncer;
 
 let warnedOnce = false;
+let warnedLegacyOnce = false;
 
 export const useAriaAnnouncer: useAriaAnnouncerHook = ({
   debounce: debounceInterval = 0,
@@ -20,11 +22,26 @@ export const useAriaAnnouncer: useAriaAnnouncerHook = ({
   const context = useContext(AriaAnnouncerContext);
   const mountedRef = useRef(true);
   const baseAnnounce = useCallback(
-    (announcement: string, delay?: number) => {
+    (announcement: string, delayOrOptions: number | AnnounceFnOptions = {}) => {
+      const isLegacy = typeof delayOrOptions === "number";
+      let legacyDelay: number | undefined;
+      let options: AnnounceFnOptions = {};
+      /** TODO remove legacy `delay` arg (number) in favour of `options` (AnnounceFnOptions) as a breaking change */
+      if (isLegacy) {
+        legacyDelay = delayOrOptions as number;
+      } else {
+        options = delayOrOptions;
+      }
       const isReactAnnouncerInstalled = context?.announce;
 
       if (process.env.NODE_ENV !== "production") {
-        if (isReactAnnouncerInstalled && warnedOnce) {
+        if (legacyDelay !== undefined && !warnedLegacyOnce) {
+          console.warn(
+            "useAriaAnnouncer `delay` prop is deprecated, use `duration` through `AnnounceFnOptions` instead.",
+          );
+          warnedLegacyOnce = true;
+        }
+        if (!isReactAnnouncerInstalled && !warnedOnce) {
           console.warn(
             "useAriaAnnouncer is being used without an AriaAnnouncerProvider. Your application should be wrapped in an AriaAnnouncerProvider",
           );
@@ -35,13 +52,13 @@ export const useAriaAnnouncer: useAriaAnnouncerHook = ({
       function makeAnnouncement() {
         if (mountedRef.current) {
           if (isReactAnnouncerInstalled) {
-            context.announce(announcement);
+            context.announce(announcement, isLegacy ? legacyDelay : options);
           }
         }
       }
 
-      if (delay) {
-        setTimeout(makeAnnouncement, delay);
+      if (legacyDelay) {
+        setTimeout(makeAnnouncement, legacyDelay);
       } else {
         makeAnnouncement();
       }

--- a/packages/core/stories/aria-announcer/aria-announcer.stories.tsx
+++ b/packages/core/stories/aria-announcer/aria-announcer.stories.tsx
@@ -1,11 +1,12 @@
-import { AriaAnnouncerProvider, useAriaAnnouncer, useId } from "@salt-ds/core";
-import type { Meta, StoryFn } from "@storybook/react-vite";
 import {
-  type ChangeEvent,
-  type CSSProperties,
-  useCallback,
-  useState,
-} from "react";
+  AriaAnnouncerProvider,
+  RadioButton,
+  RadioButtonGroup,
+  useAriaAnnouncer,
+  useId,
+} from "@salt-ds/core";
+import type { Meta, StoryFn } from "@storybook/react-vite";
+import { type ChangeEvent, type CSSProperties, useState } from "react";
 
 export default {
   title: "Core/Aria Announcer Provider",
@@ -16,73 +17,110 @@ export default {
   argTypes: { onClick: { action: "clicked" } },
 } as Meta<typeof AriaAnnouncerProvider>;
 
-type changeEvt = ChangeEvent<HTMLInputElement>;
-type interval = "delay" | "debounce";
+type Interval = "delay" | "debounce" | "duration";
+type AriaLive = "assertive" | "polite" | undefined;
 /**
  * Do not apply visible style in a production app. This is for debug purposes only.
  */
 const visibleStyle: CSSProperties = {
+  display: "block",
   clip: "auto",
   clipPath: "none",
   height: "auto",
-
   width: "auto",
   margin: 0,
   overflow: "visible",
   padding: 0,
-  position: "relative",
+  position: "absolute",
 };
 
 const Content = () => {
   const [count, setCount] = useState(0);
   const [delay, setDelay] = useState("");
+  const [ariaLive, setAriaLive] = useState<AriaLive>("assertive");
   const [debounce, setDebounce] = useState("");
+  const [duration, setDuration] = useState("");
 
-  const getMilliseconds = useCallback(
-    (type: interval) => {
-      const value = type === "delay" ? delay : debounce;
-      const maybeNumber = Number.parseInt(value, 10);
-      return Number.isNaN(maybeNumber) ? undefined : maybeNumber;
-    },
-    [debounce, delay],
-  );
+  const getMilliseconds = (type: Interval) => {
+    let value;
+    if (type === "delay") {
+      value = delay;
+    } else if (type === "debounce") {
+      value = debounce;
+    } else {
+      value = duration;
+    }
+    const maybeNumber = Number.parseInt(value, 10);
+    return Number.isNaN(maybeNumber) ? undefined : maybeNumber;
+  };
 
   const { announce } = useAriaAnnouncer({
     debounce: getMilliseconds("debounce"),
   });
 
-  const handleClick = useCallback(() => {
+  const handleClick = () => {
     setCount((currentValue) => {
       const newValue = currentValue + 1;
-      announce(`count = ${newValue}`, getMilliseconds("delay"));
+      const delay = getMilliseconds("delay");
+      const duration = getMilliseconds("duration");
+      announce(
+        `count = ${newValue}`,
+        delay !== undefined ? delay : { ariaLive, duration },
+      );
       return newValue;
     });
-  }, [announce, getMilliseconds]);
+  };
 
-  const handleDelay = (e: changeEvt) => {
+  const handleDelay = (e: ChangeEvent<HTMLInputElement>) => {
     setDelay(e.target.value);
     setDebounce("");
+    setDuration("");
   };
-  const handleDebounce = (e: changeEvt) => {
+
+  const handleDebounce = (e: ChangeEvent<HTMLInputElement>) => {
     setDebounce(e.target.value);
     setDelay("");
+    setDuration("");
+  };
+
+  const handleDuration = (e: ChangeEvent<HTMLInputElement>) => {
+    setDuration(e.target.value);
+    setDelay("");
+    setDebounce("");
+  };
+
+  const handleAriaLive = (e: ChangeEvent<HTMLInputElement>) => {
+    setAriaLive(e.target.value as AriaLive);
   };
 
   const getButtonLabel = () => {
     if (delay) {
-      return `Increment count with ${delay}ms delay`;
+      return `Increment count with ${delay}ms delay ${getMilliseconds("debounce") !== undefined ? ` and debounce=${debounce}ms` : ""}`;
+    }
+    if (duration) {
+      return `Increment count with ${duration}ms duration ${getMilliseconds("debounce") !== undefined ? ` and debounce=${debounce}ms` : ""}`;
     }
     if (debounce) {
-      return `Increment count with ${debounce}ms debounce`;
+      return `Increment count with debounce=${debounce}ms only`;
     }
     return "Increment count, nothing fancy";
   };
 
   const delayInputId = useId();
   const debounceInputId = useId();
+  const durationInputId = useId();
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <RadioButtonGroup
+        name="ariaLive"
+        direction="horizontal"
+        onChange={handleAriaLive}
+        value={ariaLive}
+      >
+        <RadioButton label="Assertive" value="assertive" />
+        <RadioButton label="Polite" value="polite" />
+      </RadioButtonGroup>
       <div style={{ display: "flex" }}>
         <label htmlFor={delayInputId} style={{ width: 160 }}>
           Delay (ms):{" "}
@@ -105,11 +143,21 @@ const Content = () => {
           value={debounce}
         />
       </div>
-
-      <div style={{ display: "flex", gap: 12 }}>
-        <button onClick={handleClick}>{getButtonLabel()}</button>
-        <span>{count}</span>
+      <div style={{ display: "flex" }}>
+        <label htmlFor={durationInputId} style={{ width: 160 }}>
+          Duration (ms):{" "}
+        </label>
+        <input
+          id={durationInputId}
+          onChange={handleDuration}
+          style={{ width: 80 }}
+          value={duration}
+        />
       </div>
+      <span aria-hidden="true" style={{ display: "flex", width: 160 }}>
+        Count: {count}
+      </span>
+      <button onClick={handleClick}>{getButtonLabel()}</button>
     </div>
   );
 };


### PR DESCRIPTION
…nouncements, but it could create overlapping announcements. We have deprecated `delay`, although it is still supported. Instead, we have added a new options API.

- `duration`: provides a sequential delay between announcements, ensuring they do not overlap.
- `ariaLive` determines the importance and urgency of the announcement.