### PR TITLE
Fix: Use bullet chart type

### DIFF
--- a/packages/highcharts-theme/src/examples/dependencies/bulletOptions.ts
+++ b/packages/highcharts-theme/src/examples/dependencies/bulletOptions.ts
@@ -2,7 +2,8 @@ import type { Options } from "highcharts";
 
 export const bulletOptions: Options = {
   chart: {
-    type: "bar",
+    type: "bullet",
+    inverted: true,
     height: 180,
   },
   title: {

--- a/site/src/examples/highcharts-theme/BulletChart.tsx
+++ b/site/src/examples/highcharts-theme/BulletChart.tsx
@@ -14,7 +14,8 @@ accessibility(Highcharts);
 
 const options: Options = {
   chart: {
-    type: "bar",
+    type: "bullet",
+    inverted: true,
     height: 180,
   },
   title: {


### PR DESCRIPTION
In Highcharts, using the bullet() module sets the chart to be a "bullet" which means you can put anything into the type field and it'll still look like a bullet chart (which is why this was missed...)

inverted: true inverts the axes so that the x axis is vertical and y axis is horizontal (giving the left to right bar effect).