### PR TITLE
Fix intermittent focus ring on hover

### DIFF
--- a/.changeset/clean-mugs-sing.md
+++ b/.changeset/clean-mugs-sing.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Fixed intermittent appearance of MenuItem focus ring during mouse hover

--- a/.changeset/clean-mugs-sing.md
+++ b/.changeset/clean-mugs-sing.md
@@ -2,4 +2,4 @@
 "@salt-ds/core": patch
 ---
 
-Fixed intermittent appearance of MenuItem focus ring during mouse hover
+Fixed intermittent appearance of `MenuItem` focus ring during mouse hover

--- a/packages/core/src/__tests__/__e2e__/menu/Menu.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/menu/Menu.cy.tsx
@@ -187,10 +187,10 @@ describe("Given a Menu", () => {
     cy.get("@alertStub").should("not.have.been.called");
   });
 
-  it("should focus items on hover", () => {
+  it("should not focus items on hover", () => {
     cy.mount(<SingleLevel open />);
     cy.findByRole("menuitem", { name: "Paste" }).realHover();
-    cy.findByRole("menuitem", { name: "Paste" }).should("have.focus");
+    cy.findByRole("menuitem", { name: "Paste" }).should("not.have.focus");
   });
 
   it("should support open being uncontrolled", () => {

--- a/packages/core/src/menu/MenuBase.tsx
+++ b/packages/core/src/menu/MenuBase.tsx
@@ -139,6 +139,7 @@ export function MenuBase(props: MenuBaseProps) {
         activeIndex,
         nested: isNested,
         onNavigate: setActiveIndex,
+        focusItemOnHover: false,
       }),
     ],
   );

--- a/packages/core/src/menu/MenuItem.css
+++ b/packages/core/src/menu/MenuItem.css
@@ -36,7 +36,7 @@
 
 .saltMenuItem-blurActive:not(:hover) {
   z-index: var(--salt-zIndex-default);
-  /* Prevents box-shadow flickering when hovering between menu items  */
+  /* Transitions prevent visual flicker when rapidly moving mouse between menu items */
   transition:
     box-shadow 50ms ease-in-out,
     background 50ms ease-in-out;

--- a/packages/core/src/menu/MenuItem.css
+++ b/packages/core/src/menu/MenuItem.css
@@ -21,10 +21,6 @@
   outline-offset: calc(var(--salt-size-fixed-100) * -2);
 }
 
-.saltMenuItem:hover {
-  outline: none;
-}
-
 .saltMenuItem:hover,
 .saltMenuItem:focus-visible {
   background: var(--salt-selectable-background-hover);

--- a/packages/core/src/menu/MenuItem.css
+++ b/packages/core/src/menu/MenuItem.css
@@ -26,11 +26,27 @@
   background: var(--salt-selectable-background-hover);
 }
 
-.saltMenuItem:active {
+.saltMenuItem:active,
+.saltMenuItem-blurActive:not(:hover) {
   background: var(--salt-selectable-background-selected);
   box-shadow:
     0 calc(var(--salt-size-fixed-100) * -1) 0 0 var(--salt-selectable-borderColor-selected),
     0 var(--salt-size-fixed-100) 0 0 var(--salt-selectable-borderColor-selected);
+}
+
+.saltMenuItem-blurActive:not(:hover) {
+  z-index: var(--salt-zIndex-default);
+  /* Prevents box-shadow flickering when hovering between menu items  */
+  transition:
+    box-shadow 50ms ease-in-out,
+    background 50ms ease-in-out;
+}
+
+.saltMenuItem-blurActive:hover {
+  box-shadow: none;
+  transition:
+    box-shadow var(--salt-duration-instant),
+    background var(--salt-duration-instant);
 }
 
 .saltMenuItem[aria-disabled="true"],
@@ -39,14 +55,6 @@
   color: var(--salt-content-primary-foreground-disabled);
   cursor: var(--salt-cursor-disabled);
   box-shadow: none;
-}
-
-.saltMenuItem-blurActive {
-  z-index: var(--salt-zIndex-default);
-  background: var(--salt-selectable-background-selected);
-  box-shadow:
-    0 calc(var(--salt-size-fixed-100) * -1) 0 0 var(--salt-selectable-borderColor-selected),
-    0 var(--salt-size-fixed-100) 0 0 var(--salt-selectable-borderColor-selected);
 }
 
 /* TODO: Find a better way of doing this */

--- a/packages/core/src/menu/MenuTrigger.tsx
+++ b/packages/core/src/menu/MenuTrigger.tsx
@@ -38,7 +38,7 @@ export const MenuTrigger = forwardRef<HTMLElement, MenuTriggerProps>(
 
     return (
       <MenuTriggerContext.Provider
-        value={{ triggersSubmenu: true, blurActive: focusInside && openState }}
+        value={{ triggersSubmenu: true, blurActive: openState }}
       >
         {cloneElement(children, {
           ...mergeProps(


### PR DESCRIPTION
- Disable `focusItemOnHover` from floating-ui `useListNavigation`
- Remove style used to override focus ring flicker

Closes #5626