### PR TITLE
Fix triggers not forwarding props

### DIFF
--- a/.changeset/four-adults-kneel.md
+++ b/.changeset/four-adults-kneel.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Fixed `Menu`, `Collapsible` and `Overlay` triggers not forwarding props.

--- a/packages/core/src/__tests__/__e2e__/menu/Menu.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/menu/Menu.cy.tsx
@@ -261,6 +261,12 @@ describe("Given a Menu", () => {
     cy.mount(<WithTooltip />);
     cy.findByRole("menu").should("not.exist");
 
+    cy.realPress("Tab");
+    cy.findByRole("tooltip").should("be.visible");
+
+    cy.realPress("Tab");
+    cy.findByRole("tooltip").should("not.exist");
+
     cy.findByRole("button").realHover();
     cy.findByRole("tooltip").should("be.visible");
 

--- a/packages/core/src/__tests__/__e2e__/overlay/Overlay.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/overlay/Overlay.cy.tsx
@@ -142,6 +142,12 @@ describe("GIVEN an Overlay", () => {
     cy.mount(<WithTooltip />);
     cy.findByRole("dialog").should("not.exist");
 
+    cy.realPress("Tab");
+    cy.findByRole("tooltip").should("be.visible");
+
+    cy.realPress("Tab");
+    cy.findByRole("tooltip").should("not.exist");
+
     cy.findByRole("button").realHover();
     cy.findByRole("tooltip").should("be.visible");
 

--- a/packages/core/src/collapsible/CollapsibleTrigger.tsx
+++ b/packages/core/src/collapsible/CollapsibleTrigger.tsx
@@ -22,7 +22,7 @@ export const CollapsibleTrigger = forwardRef<
   HTMLButtonElement,
   CollapsibleTriggerProps
 >(function CollapsibleTrigger(props, ref) {
-  const { children, className, onClick } = props;
+  const { children, className, onClick, ...rest } = props;
 
   const { open, setOpen, panelId } = useCollapsibleContext();
 
@@ -43,6 +43,7 @@ export const CollapsibleTrigger = forwardRef<
         "aria-expanded": open,
         "aria-controls": panelId,
         onClick: handleClick,
+        ...rest,
       },
       children.props,
     ),

--- a/packages/core/src/menu/MenuTrigger.tsx
+++ b/packages/core/src/menu/MenuTrigger.tsx
@@ -19,7 +19,7 @@ export interface MenuTriggerProps {
 
 export const MenuTrigger = forwardRef<HTMLElement, MenuTriggerProps>(
   function MenuTrigger(props, ref) {
-    const { children } = props;
+    const { children, ...rest } = props;
 
     const { getReferenceProps, refs, setFocusInside, focusInside, openState } =
       useMenuContext();
@@ -47,6 +47,7 @@ export const MenuTrigger = forwardRef<HTMLElement, MenuTriggerProps>(
                 setFocusInsideParent(true);
                 setFocusInside(false);
               },
+              ...rest,
             }),
             children.props,
           ),

--- a/packages/core/src/overlay/OverlayTrigger.tsx
+++ b/packages/core/src/overlay/OverlayTrigger.tsx
@@ -14,7 +14,7 @@ export interface OverlayTriggerProps {
 
 export const OverlayTrigger = forwardRef<HTMLElement, OverlayTriggerProps>(
   function OverlayTrigger(props, ref) {
-    const { children } = props;
+    const { children, ...rest } = props;
 
     const { reference, getReferenceProps } = useOverlayContext();
 
@@ -31,7 +31,7 @@ export const OverlayTrigger = forwardRef<HTMLElement, OverlayTriggerProps>(
     return (
       <>
         {cloneElement(children, {
-          ...mergeProps(getReferenceProps(), children.props),
+          ...mergeProps(getReferenceProps(rest), children.props),
           ref: handleRef,
         })}
       </>


### PR DESCRIPTION
Closes #5866

## How to test

Hover over the trigger and check for a tooltip
Focus the trigger using tab and check for a tooltip

Menu - https://jpmorganchase-fix-triggers.saltdesignsystem-storybook.pages.dev/?path=/story/core-menu--with-tooltip
Overlay - https://jpmorganchase-fix-triggers.saltdesignsystem-storybook.pages.dev/?path=/story/core-overlay--with-tooltip