### PR TITLE
Splitter header new code

### DIFF
--- a/site/docs/components/splitter/index.mdx
+++ b/site/docs/components/splitter/index.mdx
@@ -10,7 +10,7 @@ data:
     url: "https://github.com/jpmorganchase/salt-ds/blob/main/packages/react-resizable-panels-theme/CHANGELOG.md"
   externalDependency:
     name: "react-resizable-panels"
-    description: "Salt Design System theme for react-resizable-panels."
+    description: "In code, this is implemented using the React Resizable Panels library, which ensures visual consistency through a Salt-styled package."
     url: "https://react-resizable-panels.vercel.app"
     compatibleVersions: "^3.0.0"
 keywords:


### PR DESCRIPTION
Added in the new code for component header with external dependency info tailored to Splitter.

Partially closes #5896