### PR TITLE
fix(lab): remove innerHTML usage in Draggable component to prevent XSS

### DIFF
--- a/packages/lab/src/tabs/drag-drop/Draggable.tsx
+++ b/packages/lab/src/tabs/drag-drop/Draggable.tsx
@@ -26,7 +26,10 @@ export const Draggable = forwardRef<
   const callbackRef = useCallback(
     (el: HTMLDivElement) => {
       if (el) {
-        el.innerHTML = "";
+        // Clear children safely
+        while (el.firstChild) {
+          el.removeChild(el.firstChild);
+        }
         el.appendChild(element);
         if (scale !== 1) {
           el.style.transform = `scale(${scale},${scale})`;


### PR DESCRIPTION
Replaced unsafe innerHTML assignment with safe DOM manipulation methods to eliminate potential XSS vulnerability in the drag-and-drop functionality.

The previous implementation used el.innerHTML = "" which could be exploited if malicious content was injected into the element.