### PR TITLE
Update HD Compact example

### DIFF
--- a/site/docs/components/ag-grid-theme/examples.mdx
+++ b/site/docs/components/ag-grid-theme/examples.mdx
@@ -93,7 +93,7 @@ The filter remains visible as the user scrolls.
 
 ## HD Compact
 
-You can use the HD Compact theme by applying the `ag-theme-salt-compact-*` class name.
+The HD Compact theme for AG Grid can be applied by using the `ag-theme-salt-compact-*` class name; however, please note that this compact feature is available only in high density, applies exclusively to AG Grid, and is not a systemic feature of the Salt Design System—other Salt components and patterns do not support a compact mode.
 
 <LivePreview componentName="ag-grid-theme" exampleName="HDCompact" />
 


### PR DESCRIPTION
HD Statement changed from: 

> You can use the HD Compact theme by applying the ag-theme-salt-compact-* class name.

to:

> The HD Compact theme for AG Grid can be applied by using the ag-theme-salt-compact-* class name; however, please note that this compact feature is available only in high density, applies exclusively to AG Grid, and is not a systemic feature of the Salt Design System—other Salt components and patterns do not support a compact mode.

Closes: [#5981](https://github.com/jpmorganchase/salt-ds/issues/5981)