### PR TITLE
Highcharts | Fix undefined token read for chart defaults

### DIFF
--- a/.changeset/brown-doodles-move.md
+++ b/.changeset/brown-doodles-move.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/highcharts-theme": patch
+---
+
+Use passive effect in useChart to ensure CSS tokens are read after ThemeApplicator applies root density classes

--- a/packages/highcharts-theme/src/useChart.ts
+++ b/packages/highcharts-theme/src/useChart.ts
@@ -1,9 +1,9 @@
-import { useDensity, useIsomorphicLayoutEffect } from "@salt-ds/core";
+import { useDensity } from "@salt-ds/core";
 import { useWindow } from "@salt-ds/window";
 import type { Options } from "highcharts";
 import Highcharts from "highcharts";
 import type HighchartsReact from "highcharts-react-official";
-import { type RefObject, useRef, useState } from "react";
+import { type RefObject, useEffect, useRef, useState } from "react";
 import { getDefaultOptions } from "./default-options";
 
 export const useChart = (
@@ -20,7 +20,7 @@ export const useChart = (
     return Highcharts.merge(defaults, chartOptions);
   });
 
-  useIsomorphicLayoutEffect(() => {
+  useEffect(() => {
     const chart = chartRef.current?.chart as Highcharts.Chart | null;
     const container = chart?.container ?? null;
 


### PR DESCRIPTION
- useChart reads CSS custom properties in `useIsomorphicLayoutEffect`, but in Storybook (with SaltProvider wrapping stories), ThemeApplicator applies salt-density-* classes to <html> in its own layout effect after useChart runs, so `getComputedStyle(...).getPropertyValue("--salt-*")` returns empty values; on the site this is usually masked because the top-level provider is already mounted and classes are present before chart examples mount
- Replace `useIsomorphicLayoutEffect` with `useEffect` to ensure tokens are available after layout effects settle

Fixes #6075 