### PR TITLE
Clear active option on group label hover

### DIFF
--- a/packages/core/src/__tests__/__e2e__/combo-box/ComboBox.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/combo-box/ComboBox.cy.tsx
@@ -536,6 +536,17 @@ describe("Given a ComboBox", () => {
       .should("exist");
   });
 
+  it("should clear hover state when moving from an option to an adjacent group header", () => {
+    cy.mount(<Grouped />);
+    cy.findByRole("combobox").realClick();
+    cy.findByRole("option", { name: "New York" }).realHover();
+    cy.findByRole("option", { name: "New York" }).should("be.activeDescendant");
+    cy.get(".saltOptionGroup-label").contains("GB").realHover();
+    cy.findByRole("option", { name: "New York" }).should(
+      "not.be.activeDescendant",
+    );
+  });
+
   it("should allow showing an empty message when there are no options", () => {
     cy.mount(<EmptyMessage />);
     cy.findByRole("combobox").realClick();

--- a/packages/core/src/__tests__/__e2e__/dropdown/Dropdown.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/dropdown/Dropdown.cy.tsx
@@ -361,6 +361,17 @@ describe("Given a Dropdown", () => {
       .should("exist");
   });
 
+  it("should clear hover state when moving from an option to an adjacent group header", () => {
+    cy.mount(<Grouped />);
+    cy.findByRole("combobox").realClick();
+    cy.findByRole("option", { name: "New York" }).realHover();
+    cy.findByRole("option", { name: "New York" }).should("be.activeDescendant");
+    cy.get(".saltOptionGroup-label").contains("GB").realHover();
+    cy.findByRole("option", { name: "New York" }).should(
+      "not.be.activeDescendant",
+    );
+  });
+
   it("should support complex options", () => {
     cy.mount(<ComplexOption />);
     cy.findByRole("combobox").realClick();

--- a/packages/core/src/list-control/ListControlContext.tsx
+++ b/packages/core/src/list-control/ListControlContext.tsx
@@ -20,7 +20,7 @@ export interface ListControlContextValue<Item> {
   selectedState: unknown[];
   select: (event: SyntheticEvent, option: OptionValue<Item>) => void;
   activeState?: OptionValue<Item>;
-  setActive: (option: OptionValue<Item>) => void;
+  setActive: (option?: OptionValue<Item>) => void;
   multiselect: boolean;
   focusVisibleState: boolean;
   valueToString: (item: Item) => string;

--- a/packages/core/src/option/OptionGroup.tsx
+++ b/packages/core/src/option/OptionGroup.tsx
@@ -6,6 +6,7 @@ import {
   forwardRef,
   type ReactNode,
 } from "react";
+import { useListControlContext } from "../list-control/ListControlContext";
 import { makePrefixer, useId } from "../utils";
 import optionGroupCss from "./OptionGroup.css";
 
@@ -33,6 +34,7 @@ export const OptionGroup = forwardRef<HTMLDivElement, OptionGroupProps>(
     });
 
     const labelId = useId();
+    const { setActive } = useListControlContext();
 
     return (
       <div
@@ -42,7 +44,12 @@ export const OptionGroup = forwardRef<HTMLDivElement, OptionGroupProps>(
         ref={ref}
         {...rest}
       >
-        <div aria-hidden className={withBaseName("label")} id={labelId}>
+        <div
+          aria-hidden
+          className={withBaseName("label")}
+          id={labelId}
+          onMouseOver={() => setActive(undefined)}
+        >
           {label}
         </div>
         {children}


### PR DESCRIPTION
Ensure hovering a group label clears the active option. Added e2e tests for ComboBox and Dropdown to verify that hovering an adjacent option group header removes the activeDescendant. Updated ListControlContext to allow setActive(undefined) and updated OptionGroup to call setActive(undefined) on label mouseOver to clear hover/active state.

closes #6119 