### PR TITLE
Update Icon component page wording with correct Icon Foundation name

### DIFF
--- a/site/docs/components/icon/examples.mdx
+++ b/site/docs/components/icon/examples.mdx
@@ -17,13 +17,13 @@ package.
 
 ## Icon size
 
-You can change the size of each icon using the `size` property, which acts as a multiplier for the base icon’s size, as described in the [iconography foundation](/salt/foundations/assets). The base size of the icon depends on the active density as described in the [size foundation](/salt/foundations/size).
+You can change the size of each icon using the `size` property, which acts as a multiplier for the base icon’s size, as described in the [icon foundation](/salt/foundations/assets). The base size of the icon depends on the active density as described in the [size foundation](/salt/foundations/size).
 
 <LivePreview componentName="icon" exampleName="IconSize" />
 
 ## Icon types
 
-We provide two icon types: default and solid. Most icons will have both versions, with some exceptions as described in the [iconography foundation](/salt/foundations/assets). The outline style is the default icon type. Use the solid icon for additional emphasis or to represent a toggled "on" state.
+We provide two icon types: default and solid. Most icons will have both versions, with some exceptions as described in the [icon foundation](/salt/foundations/assets). The outline style is the default icon type. Use the solid icon for additional emphasis or to represent a toggled "on" state.
 
 <LivePreview componentName="icon" exampleName="IconTypes" />
 

--- a/site/docs/components/icon/index.mdx
+++ b/site/docs/components/icon/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Icon
 data:
-  description: "`Icon` is a visual representation of an application, a capability, a concept or a specific entity with meaning on an interface (e.g., a floppy disk to represent a save action). Icons help users to recognize and understand actions that transcend linguistic or cultural boundaries. The list of available icons is in the [iconography foundation](/salt/foundations/assets)."
+  description: "`Icon` is a visual representation of an application, a capability, a concept or a specific entity with meaning on an interface (e.g., a floppy disk to represent a save action). Icons help users to recognize and understand actions that transcend linguistic or cultural boundaries. The list of available icons is in the [icon foundation](/salt/foundations/assets/index)."
   sourceCodeUrl: "https://github.com/jpmorganchase/salt-ds/blob/main/packages/icons/src/icon"
   package:
     name: "@salt-ds/icons"


### PR DESCRIPTION
Minor fix to update the Icon component page by replacing "Iconography foundation" with "Icon foundation." A consumer flagged confusion with the previous wording due to site IA change.