### PR TITLE
Change Accordion's value prop to be optional

### DIFF
--- a/.changeset/tough-boxes-try.md
+++ b/.changeset/tough-boxes-try.md
@@ -1,6 +1,5 @@
 ---
 "@salt-ds/core": patch
-"@salt-ds/lab": patch
 ---
 
 Changed Accordion's value prop to be optional.

--- a/.changeset/tough-boxes-try.md
+++ b/.changeset/tough-boxes-try.md
@@ -1,0 +1,6 @@
+---
+"@salt-ds/core": patch
+"@salt-ds/lab": patch
+---
+
+Changed Accordion's value prop to be optional.

--- a/packages/core/src/__tests__/__e2e__/accordion/Accordion.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/accordion/Accordion.cy.tsx
@@ -40,7 +40,7 @@ const AccordionExample = ({
   onUpdated,
 }: AccordionExampleProps) => {
   return (
-    <Accordion onToggle={onToggle} value="example">
+    <Accordion onToggle={onToggle}>
       <AccordionHeader>Summary Text</AccordionHeader>
       <AccordionPanel>
         <DetailsSpy

--- a/packages/core/src/accordion/Accordion.tsx
+++ b/packages/core/src/accordion/Accordion.tsx
@@ -13,9 +13,9 @@ import { AccordionContext } from "./AccordionContext";
 export interface AccordionProps
   extends Omit<ComponentPropsWithoutRef<"div">, "onToggle"> {
   /**
-   * AccordionGroup value.
+   * Optional value used by controlled group patterns.
    */
-  value: string;
+  value?: string;
   /**
    * Whether the accordion is expanded.
    */

--- a/packages/core/src/accordion/AccordionContext.ts
+++ b/packages/core/src/accordion/AccordionContext.ts
@@ -2,7 +2,7 @@ import { type SyntheticEvent, useContext } from "react";
 import { createContext } from "../utils";
 
 export interface AccordionContextValue {
-  value: string;
+  value?: string;
   expanded: boolean;
   toggle: (event: SyntheticEvent<HTMLButtonElement>) => void;
   disabled: boolean;


### PR DESCRIPTION
In a recent review it was discovered value isn't really doing anything.

We should consider removing it in the next breaking change