### PR TITLE
Fix TreeNodeTrigger Tooltip bug

### DIFF
--- a/.changeset/rude-rocks-shave.md
+++ b/.changeset/rude-rocks-shave.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/lab": patch
+---
+
+Fixed incorrect Tooltip positioning and behavior when used with TreeNodeTrigger.

--- a/packages/lab/src/__tests__/__e2e__/tree/Tree.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/tree/Tree.cy.tsx
@@ -2132,5 +2132,114 @@ describe("Given a Tree", () => {
       cy.findByRole("tooltip").should("be.visible");
       cy.findByRole("tooltip").should("have.text", "Main documents folder");
     });
+
+    it("should only show the tooltip for the focused node when moving through nested tooltip nodes", () => {
+      cy.mount(
+        <Tree
+          aria-label="File browser"
+          defaultExpanded={["documents", "reports"]}
+        >
+          <TreeNode value="documents">
+            <Tooltip content="Contains all document files" placement="right">
+              <TreeNodeTrigger>
+                <TreeNodeLabel>Documents</TreeNodeLabel>
+              </TreeNodeTrigger>
+            </Tooltip>
+            <TreeNode value="reports">
+              <Tooltip content="Financial reports folder" placement="right">
+                <TreeNodeTrigger>
+                  <TreeNodeLabel>Reports</TreeNodeLabel>
+                </TreeNodeTrigger>
+              </Tooltip>
+              <TreeNode value="annual-report" label="Annual Report" />
+            </TreeNode>
+          </TreeNode>
+        </Tree>,
+      );
+
+      cy.realPress("Tab");
+      cy.get('[role="treeitem"]#documents').should("be.focused");
+      cy.findAllByRole("tooltip").should("have.length", 1);
+      cy.findByRole("tooltip").should(
+        "have.text",
+        "Contains all document files",
+      );
+
+      cy.realPress("ArrowDown");
+      cy.get('[role="treeitem"]#reports').should("be.focused");
+      cy.findAllByRole("tooltip").should("have.length", 1);
+      cy.findByRole("tooltip").should("have.text", "Financial reports folder");
+
+      cy.realPress("ArrowDown");
+      cy.get('[role="treeitem"]#annual-report').should("be.focused");
+      cy.findByRole("tooltip").should("not.exist");
+
+      cy.realPress("ArrowUp");
+      cy.get('[role="treeitem"]#reports').should("be.focused");
+      cy.findAllByRole("tooltip").should("have.length", 1);
+      cy.findByRole("tooltip").should("have.text", "Financial reports folder");
+    });
+  });
+
+  describe("TreeNodeTrigger event forwarding", () => {
+    it("should only call focus and blur handlers for directly focused nodes", () => {
+      const documentsFocusSpy = cy.stub().as("documentsFocusSpy");
+      const documentsBlurSpy = cy.stub().as("documentsBlurSpy");
+      const reportsFocusSpy = cy.stub().as("reportsFocusSpy");
+      const reportsBlurSpy = cy.stub().as("reportsBlurSpy");
+
+      cy.mount(
+        <Tree
+          aria-label="File browser"
+          defaultExpanded={["documents", "reports"]}
+        >
+          <TreeNode value="documents">
+            <TreeNodeTrigger
+              onFocus={documentsFocusSpy}
+              onBlur={documentsBlurSpy}
+            >
+              <TreeNodeLabel>Documents</TreeNodeLabel>
+            </TreeNodeTrigger>
+            <TreeNode value="reports">
+              <TreeNodeTrigger
+                onFocus={reportsFocusSpy}
+                onBlur={reportsBlurSpy}
+              >
+                <TreeNodeLabel>Reports</TreeNodeLabel>
+              </TreeNodeTrigger>
+              <TreeNode value="annual-report" label="Annual Report" />
+            </TreeNode>
+          </TreeNode>
+        </Tree>,
+      );
+
+      cy.realPress("Tab");
+      cy.get('[role="treeitem"]#documents').should("be.focused");
+      cy.get("@documentsFocusSpy").should("have.callCount", 1);
+      cy.get("@documentsBlurSpy").should("not.have.been.called");
+      cy.get("@reportsFocusSpy").should("not.have.been.called");
+      cy.get("@reportsBlurSpy").should("not.have.been.called");
+
+      cy.realPress("ArrowDown");
+      cy.get('[role="treeitem"]#reports').should("be.focused");
+      cy.get("@documentsFocusSpy").should("have.callCount", 1);
+      cy.get("@documentsBlurSpy").should("have.callCount", 1);
+      cy.get("@reportsFocusSpy").should("have.callCount", 1);
+      cy.get("@reportsBlurSpy").should("not.have.been.called");
+
+      cy.realPress("ArrowDown");
+      cy.get('[role="treeitem"]#annual-report').should("be.focused");
+      cy.get("@documentsFocusSpy").should("have.callCount", 1);
+      cy.get("@documentsBlurSpy").should("have.callCount", 1);
+      cy.get("@reportsFocusSpy").should("have.callCount", 1);
+      cy.get("@reportsBlurSpy").should("have.callCount", 1);
+
+      cy.realPress("ArrowUp");
+      cy.get('[role="treeitem"]#reports').should("be.focused");
+      cy.get("@documentsFocusSpy").should("have.callCount", 1);
+      cy.get("@documentsBlurSpy").should("have.callCount", 1);
+      cy.get("@reportsFocusSpy").should("have.callCount", 2);
+      cy.get("@reportsBlurSpy").should("have.callCount", 1);
+    });
   });
 });

--- a/packages/lab/src/tree/TreeNodeTrigger.tsx
+++ b/packages/lab/src/tree/TreeNodeTrigger.tsx
@@ -103,8 +103,8 @@ export const TreeNodeTrigger = forwardRef<
   };
 
   const handleFocus = (event: FocusEvent<HTMLLIElement>) => {
-    onFocus?.(event);
     if (event.target !== event.currentTarget) return;
+    onFocus?.(event);
     if (!wasMouseDownRef.current) {
       setFocusVisible(true);
     }
@@ -113,8 +113,8 @@ export const TreeNodeTrigger = forwardRef<
   };
 
   const handleBlur = (event: FocusEvent<HTMLLIElement>) => {
-    onBlur?.(event);
     if (event.target !== event.currentTarget) return;
+    onBlur?.(event);
     setFocusVisible(false);
   };
 


### PR DESCRIPTION
Addresses #6362 

- TreeNodeTrigger is not a typical flat trigger element: it renders a focusable treeitem, but when expanded it also contains a nested group of descendant treeitems, so native React focus/blur bubbling does not map cleanly to the semantic meaning of “this trigger was focused.” 
- In practice, forwarding bubbled descendant focus through onFocus/onBlur caused parent triggers to behave as though they themselves had gained focus, which is what made parent tooltips open, flash, or persist incorrectly when focus actually moved to a child node. 
- That makes TreeNodeTrigger a special case compared with other trigger components, which usually wrap a single interactive element and therefore can safely expose raw focus events.
- In this case, restricting forwarded focus and blur to event.target === event.currentTarget keeps the external contract aligned with the components real trigger semantics; consumers like Tooltip are notified only when that specific tree node receives focus and not when focus moves anywhere inside its subtree.