### PR TITLE
Highcharts | Slightly widen types for v12 compatibility 

### DIFF
--- a/.changeset/legal-deer-open.md
+++ b/.changeset/legal-deer-open.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/highcharts-theme": patch
+---
+
+Fixed `useChart` to update merged chart options when the active Salt theme changes and widen types for Highcharts v12

--- a/packages/highcharts-theme/src/fill-patterns.ts
+++ b/packages/highcharts-theme/src/fill-patterns.ts
@@ -5,6 +5,7 @@ import {
   type SaltChartTokenMap,
 } from "./density-token-map";
 import { getFillPatternColor, getSentimentPatternColors } from "./patterns";
+import type { HighchartsSeriesOptionsCompat } from "./types";
 
 type FillPatternColor = ReturnType<
   typeof getSentimentPatternColors
@@ -37,7 +38,7 @@ type FillPatternPoint = Record<string, unknown> & {
   y?: number;
 };
 
-type FillPatternSeries = NonNullable<Options["series"]>[number] & {
+type FillPatternSeries = HighchartsSeriesOptionsCompat & {
   data?: Array<unknown>;
   dashStyle?: string;
   fillColor?: SeriesColor;

--- a/packages/highcharts-theme/src/merge-chart-options.ts
+++ b/packages/highcharts-theme/src/merge-chart-options.ts
@@ -3,10 +3,10 @@ import Highcharts from "highcharts";
 
 type AxisOptions = Options["xAxis"] | Options["yAxis"];
 
-const mergeAxisOptions = (
-  defaultAxis: AxisOptions,
-  resolvedAxis: AxisOptions,
-): AxisOptions => {
+const mergeAxisOptions = <T extends AxisOptions>(
+  defaultAxis: T,
+  resolvedAxis: T,
+): T => {
   if (resolvedAxis == null) {
     return defaultAxis;
   }
@@ -23,10 +23,12 @@ const mergeAxisOptions = (
     // Highcharts does not reliably merge object axis defaults into axis arrays,
     // so we normalize each axis entry before the top-level merge instead.
     // See: https://github.com/highcharts/highcharts/issues/21155
-    return resolvedAxis.map((axis) => Highcharts.merge(axisDefaults, axis));
+    return resolvedAxis.map((axis) =>
+      Highcharts.merge(axisDefaults, axis),
+    ) as T;
   }
 
-  return Highcharts.merge(axisDefaults, resolvedAxis);
+  return Highcharts.merge(axisDefaults, resolvedAxis) as T;
 };
 
 export const mergeChartOptions = (

--- a/packages/highcharts-theme/src/theme-option-builders.ts
+++ b/packages/highcharts-theme/src/theme-option-builders.ts
@@ -4,9 +4,17 @@ import {
   CATEGORY_DATAVIZ_TOKENS,
   type SaltChartTokenMap,
 } from "./density-token-map";
-import type { HighchartsOptionsCompat } from "./types";
+import type {
+  HighchartsOptionsCompat,
+  HighchartsSeriesOptionsCompat,
+} from "./types";
 
 const AXES_GRID_LINE_SERIES_TYPES = new Set(["bubble", "scatter"]);
+
+const getSeriesType = (
+  series: HighchartsSeriesOptionsCompat,
+): string | undefined =>
+  typeof series.type === "string" ? series.type : undefined;
 
 const shouldShowAxesGridLines = (chartOptions: Options): boolean => {
   if (
@@ -16,24 +24,30 @@ const shouldShowAxesGridLines = (chartOptions: Options): boolean => {
     return true;
   }
 
-  return (chartOptions.series ?? []).some((series) => {
-    return typeof series.type === "string"
-      ? AXES_GRID_LINE_SERIES_TYPES.has(series.type)
-      : false;
-  });
+  return ((chartOptions.series ?? []) as HighchartsSeriesOptionsCompat[]).some(
+    (series) => {
+      const seriesType = getSeriesType(series);
+
+      return seriesType ? AXES_GRID_LINE_SERIES_TYPES.has(seriesType) : false;
+    },
+  );
 };
 
 const isHeatmapChart = (chartOptions: Options): boolean => {
   const chartType = chartOptions.chart?.type;
-  const series = chartOptions.series ?? [];
+  const series = (chartOptions.series ?? []) as HighchartsSeriesOptionsCompat[];
 
   if (chartType === "heatmap") {
     return series.every(
-      (entry) => entry.type == null || entry.type === "heatmap",
+      (entry) =>
+        getSeriesType(entry) == null || getSeriesType(entry) === "heatmap",
     );
   }
 
-  return series.length > 0 && series.every((entry) => entry.type === "heatmap");
+  return (
+    series.length > 0 &&
+    series.every((entry) => getSeriesType(entry) === "heatmap")
+  );
 };
 
 export const buildChartOptions = (

--- a/packages/highcharts-theme/src/types.ts
+++ b/packages/highcharts-theme/src/types.ts
@@ -3,6 +3,12 @@ import type { Options } from "highcharts";
 // Compatibility helpers for supporting Highcharts v10–v12 while
 // allowing newer options that were introduced in later versions.
 
+export type HighchartsSeriesOptionsCompat = NonNullable<
+  Options["series"]
+>[number] & {
+  type?: string;
+};
+
 type PlotPieBorderRadiusCompat = {
   plotOptions?: {
     pie?: {

--- a/packages/highcharts-theme/src/useChart.ts
+++ b/packages/highcharts-theme/src/useChart.ts
@@ -26,8 +26,7 @@ export const useChart = (
 ) => {
   const density = useDensity();
 
-  // Not supporting theme/style options for now
-  const { mode } = useTheme();
+  const { mode, theme } = useTheme();
   const targetWindow = useWindow();
 
   useComponentCssInjection({
@@ -73,6 +72,7 @@ export const useChart = (
     // From v12 onwards, we can use CSS color variables directly in the Options object
     // which enable us to be reactive to theme changes without this extra step
     void mode;
+    void theme;
 
     const chart = chartRef.current?.chart as Highcharts.Chart | null;
     const container = chart?.container ?? null;
@@ -80,7 +80,7 @@ export const useChart = (
     const elementUsed = container ?? targetWindow?.document?.documentElement;
 
     setMergedOptions(getMergedOptions(elementUsed));
-  }, [chartRef, getMergedOptions, mode, targetWindow]);
+  }, [chartRef, getMergedOptions, mode, targetWindow, theme]);
 
   return mergedOptions;
 };

--- a/packages/highcharts-theme/stories/highcharts-theme.stories.tsx
+++ b/packages/highcharts-theme/stories/highcharts-theme.stories.tsx
@@ -1,3 +1,4 @@
+import isChromatic from "chromatic/isChromatic";
 import Highcharts, { type Options } from "highcharts";
 import accessibility from "highcharts/modules/accessibility";
 import HighchartsReact from "highcharts-react-official";
@@ -57,6 +58,29 @@ interface HeatmapStoryArgs extends ChartStoryArgs {
   saltColorAxis?: SaltColorAxis;
 }
 
+const getChromaticStableOptions = (options: Options): Options =>
+  isChromatic()
+    ? {
+        ...options,
+        chart: {
+          ...options.chart,
+          animation: false,
+        },
+        plotOptions: {
+          ...options.plotOptions,
+          series: {
+            ...options.plotOptions?.series,
+            animation: false,
+          },
+        },
+      }
+    : options;
+
+const getChromaticStableArgs = <T extends ChartStoryArgs>(args: T): T => ({
+  ...args,
+  options: getChromaticStableOptions(args.options),
+});
+
 export default {
   title: "Highcharts/Highcharts Theme",
   component: HighchartsReact,
@@ -79,7 +103,9 @@ export default {
 };
 
 export const LineChart = {
-  render: (args: ChartStoryArgs) => <LineChartComponent {...args} />,
+  render: (args: ChartStoryArgs) => (
+    <LineChartComponent {...getChromaticStableArgs(args)} />
+  ),
   args: {
     fillPatterns: false,
     options: lineOptions,
@@ -87,7 +113,9 @@ export const LineChart = {
 };
 
 export const DualAxisChart = {
-  render: (args: ChartStoryArgs) => <DualAxisChartComponent {...args} />,
+  render: (args: ChartStoryArgs) => (
+    <DualAxisChartComponent {...getChromaticStableArgs(args)} />
+  ),
   args: {
     fillPatterns: false,
     options: dualAxisOptions,
@@ -95,7 +123,9 @@ export const DualAxisChart = {
 };
 
 export const HeatmapChart = {
-  render: (args: HeatmapStoryArgs) => <HeatmapChartComponent {...args} />,
+  render: (args: HeatmapStoryArgs) => (
+    <HeatmapChartComponent {...getChromaticStableArgs(args)} />
+  ),
   argTypes: {
     saltColorAxis: {
       control: "object",
@@ -110,7 +140,9 @@ export const HeatmapChart = {
 };
 
 export const HeatmapDataClassesChart = {
-  render: (args: HeatmapStoryArgs) => <HeatmapChartComponent {...args} />,
+  render: (args: HeatmapStoryArgs) => (
+    <HeatmapChartComponent {...getChromaticStableArgs(args)} />
+  ),
   args: {
     fillPatterns: false,
     options: heatmapDataClassesOptions,
@@ -119,7 +151,9 @@ export const HeatmapDataClassesChart = {
 };
 
 export const HeatmapDiscreteRangesChart = {
-  render: (args: HeatmapStoryArgs) => <HeatmapChartComponent {...args} />,
+  render: (args: HeatmapStoryArgs) => (
+    <HeatmapChartComponent {...getChromaticStableArgs(args)} />
+  ),
   args: {
     fillPatterns: false,
     options: heatmapDiscreteRangesOptions,
@@ -128,7 +162,9 @@ export const HeatmapDiscreteRangesChart = {
 };
 
 export const HeatmapTwoColorDiscreteRangesChart = {
-  render: (args: HeatmapStoryArgs) => <HeatmapChartComponent {...args} />,
+  render: (args: HeatmapStoryArgs) => (
+    <HeatmapChartComponent {...getChromaticStableArgs(args)} />
+  ),
   args: {
     fillPatterns: false,
     options: heatmapTwoColorDiscreteRangesOptions,
@@ -137,7 +173,9 @@ export const HeatmapTwoColorDiscreteRangesChart = {
 };
 
 export const HeatmapThresholdChart = {
-  render: (args: HeatmapStoryArgs) => <HeatmapChartComponent {...args} />,
+  render: (args: HeatmapStoryArgs) => (
+    <HeatmapChartComponent {...getChromaticStableArgs(args)} />
+  ),
   args: {
     fillPatterns: false,
     options: heatmapThresholdOptions,
@@ -146,7 +184,9 @@ export const HeatmapThresholdChart = {
 };
 
 export const AreaChart = {
-  render: (args: ChartStoryArgs) => <AreaChartComponent {...args} />,
+  render: (args: ChartStoryArgs) => (
+    <AreaChartComponent {...getChromaticStableArgs(args)} />
+  ),
   args: {
     fillPatterns: false,
     options: areaOptions,
@@ -154,7 +194,9 @@ export const AreaChart = {
 };
 
 export const DonutChart = {
-  render: (args: ChartStoryArgs) => <DonutChartComponent {...args} />,
+  render: (args: ChartStoryArgs) => (
+    <DonutChartComponent {...getChromaticStableArgs(args)} />
+  ),
   args: {
     fillPatterns: false,
     options: donutOptions,
@@ -162,7 +204,9 @@ export const DonutChart = {
 };
 
 export const PieChart = {
-  render: (args: ChartStoryArgs) => <PieChartComponent {...args} />,
+  render: (args: ChartStoryArgs) => (
+    <PieChartComponent {...getChromaticStableArgs(args)} />
+  ),
   args: {
     fillPatterns: false,
     options: pieOptions,
@@ -170,7 +214,9 @@ export const PieChart = {
 };
 
 export const BubbleChart = {
-  render: (args: ChartStoryArgs) => <BubbleChartComponent {...args} />,
+  render: (args: ChartStoryArgs) => (
+    <BubbleChartComponent {...getChromaticStableArgs(args)} />
+  ),
   args: {
     fillPatterns: false,
     options: bubbleOptions,
@@ -178,7 +224,9 @@ export const BubbleChart = {
 };
 
 export const CandlestickChart = {
-  render: (args: ChartStoryArgs) => <CandlestickChartComponent {...args} />,
+  render: (args: ChartStoryArgs) => (
+    <CandlestickChartComponent {...getChromaticStableArgs(args)} />
+  ),
   args: {
     fillPatterns: false,
     options: candlestickOptions,
@@ -186,7 +234,9 @@ export const CandlestickChart = {
 };
 
 export const StackedBarChart = {
-  render: (args: ChartStoryArgs) => <StackedBarChartComponent {...args} />,
+  render: (args: ChartStoryArgs) => (
+    <StackedBarChartComponent {...getChromaticStableArgs(args)} />
+  ),
   args: {
     fillPatterns: false,
     options: stackedBarOptions,
@@ -194,7 +244,9 @@ export const StackedBarChart = {
 };
 
 export const BoxPlotChart = {
-  render: (args: ChartStoryArgs) => <BoxPlotChartComponent {...args} />,
+  render: (args: ChartStoryArgs) => (
+    <BoxPlotChartComponent {...getChromaticStableArgs(args)} />
+  ),
   args: {
     fillPatterns: false,
     options: boxPlotOptions,
@@ -202,7 +254,9 @@ export const BoxPlotChart = {
 };
 
 export const BulletChart = {
-  render: (args: ChartStoryArgs) => <BulletChartComponent {...args} />,
+  render: (args: ChartStoryArgs) => (
+    <BulletChartComponent {...getChromaticStableArgs(args)} />
+  ),
   args: {
     fillPatterns: false,
     options: bulletOptions,
@@ -210,7 +264,9 @@ export const BulletChart = {
 };
 
 export const BarChart = {
-  render: (args: ChartStoryArgs) => <BarChartComponent {...args} />,
+  render: (args: ChartStoryArgs) => (
+    <BarChartComponent {...getChromaticStableArgs(args)} />
+  ),
   args: {
     fillPatterns: false,
     options: barOptions,
@@ -218,7 +274,9 @@ export const BarChart = {
 };
 
 export const ColumnChart = {
-  render: (args: ChartStoryArgs) => <ColumnChartComponent {...args} />,
+  render: (args: ChartStoryArgs) => (
+    <ColumnChartComponent {...getChromaticStableArgs(args)} />
+  ),
   args: {
     fillPatterns: false,
     options: columnOptions,
@@ -226,7 +284,9 @@ export const ColumnChart = {
 };
 
 export const ScatterChart = {
-  render: (args: ChartStoryArgs) => <ScatterChartComponent {...args} />,
+  render: (args: ChartStoryArgs) => (
+    <ScatterChartComponent {...getChromaticStableArgs(args)} />
+  ),
   args: {
     fillPatterns: false,
     options: scatterOptions,
@@ -234,7 +294,9 @@ export const ScatterChart = {
 };
 
 export const WaterfallChart = {
-  render: (args: ChartStoryArgs) => <WaterfallChartComponent {...args} />,
+  render: (args: ChartStoryArgs) => (
+    <WaterfallChartComponent {...getChromaticStableArgs(args)} />
+  ),
   args: {
     fillPatterns: false,
     options: waterfallOptions,

--- a/site/docs/components/chart/examples.mdx
+++ b/site/docs/components/chart/examples.mdx
@@ -17,11 +17,6 @@ data:
       Fills](./usage#patterns-and-fills) for details. Use the "Show patterns"
       switch to toggle patterns.
     </li>
-    <li>
-      This package is a WIP. Please check the [current
-      issues](https://github.com/jpmorganchase/salt-ds/issues/5878) for known
-      issues/gaps.
-    </li>
   </ul>
 </Callout>
 


### PR DESCRIPTION
In Highcharts v12, generated series option types became non-optional.

This was missed before in yarn typecheck because of expected errors from our examples and the difference in module initalization. Tested extensively across the advertised v10, 11 and v12.