### PR TITLE
Highcharts | Doc tweaks

### DIFF
--- a/site/docs/components/chart/examples.mdx
+++ b/site/docs/components/chart/examples.mdx
@@ -128,6 +128,7 @@ Use a scatter chart to show the relationship between two numerical variables.
 ## Bubble chart
 
 Use a bubble chart to show the relationship between two variables, with a third variable represented by the size of each bubble.
+To ensure accessible presentation, data labels have borders when pattern fills are enabled.
 
 <Callout title="Note">
   To use the bubble chart, import the Highcharts `highcharts-more` module and
@@ -139,7 +140,7 @@ Use a bubble chart to show the relationship between two variables, with a third 
 ## Heatmap chart
 
 Use a heatmap chart to compare values across two categorical axes, with color
-used to show magnitude.
+used to show magnitude. To ensure accessible presentation, data labels have have borders by default.
 
 For heatmap variations such as discrete range legends or two-color banding, see
 [Color axis](./usage#color-axis) in the usage guide.

--- a/site/docs/components/chart/examples.mdx
+++ b/site/docs/components/chart/examples.mdx
@@ -128,7 +128,7 @@ Use a scatter chart to show the relationship between two numerical variables.
 ## Bubble chart
 
 Use a bubble chart to show the relationship between two variables, with a third variable represented by the size of each bubble.
-To ensure accessible presentation, data labels have borders when pattern fills are enabled.
+To ensure accessible presentation, data labels have text borders when pattern fills are enabled.
 
 <Callout title="Note">
   To use the bubble chart, import the Highcharts `highcharts-more` module and

--- a/site/docs/foundations/data-visualization/index.mdx
+++ b/site/docs/foundations/data-visualization/index.mdx
@@ -36,20 +36,20 @@ There are many different types of charts, each designed to highlight specific pa
 
 Charts available include:
 
-- Line chart
-- Pie chart
-- Donut chart
-- Column chart
-- Bar chart
-- Stacked bar chart
-- Bullet chart
-- Box plot chart
-- Area chart
-- Scatter chart
-- Bubble chart
-- Waterfall chart
-- Candlestick chart
-- Heatmap chart
+- [Line chart](/salt/components/chart/examples#line-chart)
+- [Pie chart](/salt/components/chart/examples#pie-chart)
+- [Donut chart](/salt/components/chart/examples#donut-chart)
+- [Column chart](/salt/components/chart/examples#column-chart)
+- [Bar chart](/salt/components/chart/examples#bar-chart)
+- [Stacked bar chart](/salt/components/chart/examples#stacked-bar-chart)
+- [Bullet chart](/salt/components/chart/examples#bullet-chart)
+- [Box plot chart](/salt/components/chart/examples#box-plot-chart)
+- [Area chart](/salt/components/chart/examples#area-chart)
+- [Scatter chart](/salt/components/chart/examples#scatter-chart)
+- [Bubble chart](/salt/components/chart/examples#bubble-chart)
+- [Waterfall chart](/salt/components/chart/examples#waterfall-chart)
+- [Candlestick chart](/salt/components/chart/examples#candlestick-chart)
+- [Heatmap chart](/salt/components/chart/examples#heatmap-chart)
 
 Broadly, chart types fall into four main groups:
 


### PR DESCRIPTION
Non-blocking - slight enhancements to docs which point out use of border on labels for accessibility.

Added hyperlinks to the chart types but bug in mosaic means it wont jump to the specific chart - still good to keep for when it gets resolved.