### PR TITLE
Fix several issues with `Carousel` when used in multi-slide mode

### DIFF
--- a/.changeset/fix-multi-slide-carousel.md
+++ b/.changeset/fix-multi-slide-carousel.md
@@ -1,0 +1,9 @@
+---
+"@salt-ds/embla-carousel": patch
+---
+
+Fixed several issues with `Carousel` when used in multi-slide mode:
+
+- The carousel no longer snaps back to the first slide when the number of slides is not evenly divisible by `slidesToScroll` (e.g. 5 slides with `slidesToScroll: 2`).
+- Arrow key navigation now moves focus one slide at a time, only scrolling the track when the next slide is in a different snap group.
+- `Tab` and `Shift+Tab` now move focus only between currently visible slides, preventing unintended scrolling when focusing the last slide group.

--- a/packages/embla-carousel/src/Carousel.tsx
+++ b/packages/embla-carousel/src/Carousel.tsx
@@ -74,9 +74,10 @@ export const Carousel = forwardRef<HTMLElement, CarouselProps>(
       window: targetWindow,
     });
 
-    const [emblaRef, emblaApi] = useEmblaCarousel(emblaOptions, [
-      ...emblaPlugins,
-    ]);
+    const [emblaRef, emblaApi] = useEmblaCarousel(
+      { watchFocus: false, ...emblaOptions },
+      [...emblaPlugins],
+    );
 
     const carouselId = useId(id);
 

--- a/packages/embla-carousel/src/CarouselSlides.css
+++ b/packages/embla-carousel/src/CarouselSlides.css
@@ -1,5 +1,5 @@
 .saltCarouselSlides {
-  overflow: hidden;
+  overflow: clip;
   cursor: var(--salt-cursor-grab);
 }
 

--- a/packages/embla-carousel/src/CarouselSlides.tsx
+++ b/packages/embla-carousel/src/CarouselSlides.tsx
@@ -71,6 +71,8 @@ export const CarouselSlides = forwardRef<HTMLDivElement, CarouselSlidesProps>(
     const [focusedSlideIndex, setFocusedSlideIndex] = useState<number>(-1);
     const [dragging, setDragging] = useState(false);
     const focusOnSettle = useRef<boolean>(false);
+    const pendingFocusIndex = useRef<number | null>(null);
+    const hasSettled = useRef<boolean>(false);
 
     const [stableScrollSnap, setStableScrollSnap] = useState<
       number | undefined
@@ -84,13 +86,21 @@ export const CarouselSlides = forwardRef<HTMLDivElement, CarouselSlidesProps>(
 
     useEffect(() => {
       const handleSettle = (emblaApi: EmblaCarouselType) => {
+        if (hasSettled.current) return;
+        hasSettled.current = true;
+
         const selectedScrollSnap = emblaApi?.selectedScrollSnap() ?? 0;
         setStableScrollSnap(selectedScrollSnap);
         const numberOfSnaps = emblaApi?.scrollSnapList().length ?? 1;
-        const numberOfSlidesPerSnap = slideRefs.current.length / numberOfSnaps;
-        const settledSlideIndex = Math.floor(
-          selectedScrollSnap * numberOfSlidesPerSnap,
-        );
+        const numberOfSlides = slideRefs.current.length;
+        const numberOfSlidesPerSnap = Math.ceil(numberOfSlides / numberOfSnaps);
+        const settledSlideIndex =
+          pendingFocusIndex.current ??
+          Math.min(
+            selectedScrollSnap * numberOfSlidesPerSnap,
+            numberOfSlides - 1,
+          );
+        pendingFocusIndex.current = null;
         setFocusedSlideIndex(settledSlideIndex);
         if (focusOnSettle.current) {
           slideRefs.current[settledSlideIndex]?.focus();
@@ -104,14 +114,19 @@ export const CarouselSlides = forwardRef<HTMLDivElement, CarouselSlidesProps>(
       }
 
       const scrollCallback = createCustomSettle(handleSettle);
+      const selectCallback = () => {
+        hasSettled.current = false;
+      };
       const pointerDownCallback = () => {
         setAnnouncementState("drag");
       };
       emblaApi.on("scroll", scrollCallback);
+      emblaApi.on("select", selectCallback);
       emblaApi.on("pointerDown", pointerDownCallback);
       // Cleanup listener on component unmount
       return () => {
         emblaApi.off("scroll", scrollCallback);
+        emblaApi.off("select", selectCallback);
         emblaApi.off("pointerDown", pointerDownCallback);
       };
     }, [emblaApi, setAnnouncementState]);
@@ -123,11 +138,12 @@ export const CarouselSlides = forwardRef<HTMLDivElement, CarouselSlidesProps>(
       if (numberOfSnaps === 0) return;
 
       const numberOfSlides = slideRefs.current.length;
-      const numberOfSlidesPerSnap = numberOfSlides / numberOfSnaps;
+      const numberOfSlidesPerSnap = Math.ceil(numberOfSlides / numberOfSnaps);
 
       if (focusedSlideIndex >= 0) {
-        const nearestScrollSnap = Math.round(
-          focusedSlideIndex / numberOfSlidesPerSnap,
+        const nearestScrollSnap = Math.min(
+          Math.floor(focusedSlideIndex / numberOfSlidesPerSnap),
+          numberOfSnaps - 1,
         );
         if (emblaApi.selectedScrollSnap() !== nearestScrollSnap) {
           emblaApi.scrollTo(nearestScrollSnap);
@@ -183,28 +199,42 @@ export const CarouselSlides = forwardRef<HTMLDivElement, CarouselSlidesProps>(
       if (numberOfSnaps === 0) return;
 
       const numberOfSlides = slideRefs.current.length;
-      const numberOfSlidesPerSnap = numberOfSlides / numberOfSnaps;
+      const numberOfSlidesPerSnap = Math.ceil(numberOfSlides / numberOfSnaps);
 
-      const currentSnap = Math.floor(focusedSlideIndex / numberOfSlidesPerSnap);
-      let newSnap = currentSnap;
+      let newFocusIndex = focusedSlideIndex;
 
       switch (event.key) {
         case "ArrowLeft": {
           event.preventDefault();
-          newSnap = Math.max(currentSnap - 1, 0);
+          newFocusIndex = Math.max(focusedSlideIndex - 1, 0);
           break;
         }
         case "ArrowRight": {
           event.preventDefault();
-          newSnap = Math.min(currentSnap + 1, numberOfSnaps - 1);
+          newFocusIndex = Math.min(focusedSlideIndex + 1, numberOfSlides - 1);
           break;
         }
         default:
           return;
       }
 
-      emblaApi.scrollTo(newSnap);
-      focusOnSettle.current = true;
+      if (newFocusIndex === focusedSlideIndex) return;
+
+      const currentSnap = emblaApi.selectedScrollSnap();
+      const targetSnap = Math.floor(newFocusIndex / numberOfSlidesPerSnap);
+
+      if (targetSnap === currentSnap) {
+        // Same group - move focus directly without scrolling
+        setFocusedSlideIndex(newFocusIndex);
+        slideRefs.current[newFocusIndex]?.focus();
+        setAnnouncementState("focus");
+      } else {
+        // Different group - scroll first, then focus on settle
+        hasSettled.current = false;
+        pendingFocusIndex.current = newFocusIndex;
+        emblaApi.scrollTo(targetSnap);
+        focusOnSettle.current = true;
+      }
     };
 
     const handleMouseDown: MouseEventHandler<HTMLDivElement> = (event) => {

--- a/packages/embla-carousel/src/CarouselSlides.tsx
+++ b/packages/embla-carousel/src/CarouselSlides.tsx
@@ -141,13 +141,22 @@ export const CarouselSlides = forwardRef<HTMLDivElement, CarouselSlidesProps>(
       const numberOfSlidesPerSnap = Math.ceil(numberOfSlides / numberOfSnaps);
 
       if (focusedSlideIndex >= 0) {
-        const nearestScrollSnap = Math.min(
-          Math.floor(focusedSlideIndex / numberOfSlidesPerSnap),
-          numberOfSnaps - 1,
+        const currentSnap = emblaApi.selectedScrollSnap();
+        const currentVisibleIndexes = getVisibleSlideIndexes(
+          emblaApi,
+          currentSnap,
         );
-        if (emblaApi.selectedScrollSnap() !== nearestScrollSnap) {
-          emblaApi.scrollTo(nearestScrollSnap);
-          focusOnSettle.current = true;
+
+        // Don't scroll if the focused slide is already visible in the current snap
+        if (!currentVisibleIndexes.includes(focusedSlideIndex + 1)) {
+          const nearestScrollSnap = Math.min(
+            Math.floor(focusedSlideIndex / numberOfSlidesPerSnap),
+            numberOfSnaps - 1,
+          );
+          if (currentSnap !== nearestScrollSnap) {
+            emblaApi.scrollTo(nearestScrollSnap);
+            focusOnSettle.current = true;
+          }
         }
       } else if (focusedSlideIndex === -1) {
         const initialSnap = emblaApi.selectedScrollSnap();
@@ -221,15 +230,19 @@ export const CarouselSlides = forwardRef<HTMLDivElement, CarouselSlidesProps>(
       if (newFocusIndex === focusedSlideIndex) return;
 
       const currentSnap = emblaApi.selectedScrollSnap();
-      const targetSnap = Math.floor(newFocusIndex / numberOfSlidesPerSnap);
+      const currentVisibleIndexes = getVisibleSlideIndexes(
+        emblaApi,
+        currentSnap,
+      );
 
-      if (targetSnap === currentSnap) {
-        // Same group - move focus directly without scrolling
+      if (currentVisibleIndexes.includes(newFocusIndex + 1)) {
+        // Slide is already visible in current snap - move focus directly without scrolling
         setFocusedSlideIndex(newFocusIndex);
-        slideRefs.current[newFocusIndex]?.focus();
+        slideRefs.current[newFocusIndex]?.focus({ preventScroll: true });
         setAnnouncementState("focus");
       } else {
         // Different group - scroll first, then focus on settle
+        const targetSnap = Math.floor(newFocusIndex / numberOfSlidesPerSnap);
         hasSettled.current = false;
         pendingFocusIndex.current = newFocusIndex;
         emblaApi.scrollTo(targetSnap);
@@ -267,8 +280,8 @@ export const CarouselSlides = forwardRef<HTMLDivElement, CarouselSlidesProps>(
             const childElement = child as ReactElement;
             const existingId = childElement.props.id;
             const isFocused = focusedSlideIndex === index;
-            const isHidden =
-              !visibleSlideIndexes.includes(index + 1) && !isFocused;
+            const isVisible = visibleSlideIndexes.includes(index + 1);
+            const isHidden = !isVisible && !isFocused;
             const element = child as ReactElement;
             return cloneElement(element, {
               "aria-hidden": isHidden,
@@ -277,7 +290,10 @@ export const CarouselSlides = forwardRef<HTMLDivElement, CarouselSlidesProps>(
                 setFocusedSlideIndex(index);
                 element.props?.onFocus?.(event);
               },
-              tabIndex: !isHidden ? 0 : -1,
+              // Only visible slides are tabbable. overflow:clip on the container
+              // prevents native browser scroll, and watchFocus:false on Embla
+              // prevents Embla from scrolling on Tab-triggered focus.
+              tabIndex: isVisible ? 0 : -1,
               ref: (el: HTMLDivElement) => {
                 slideRefs.current[index] = el;
               },

--- a/packages/embla-carousel/src/CarouselSlides.tsx
+++ b/packages/embla-carousel/src/CarouselSlides.tsx
@@ -126,7 +126,7 @@ export const CarouselSlides = forwardRef<HTMLDivElement, CarouselSlidesProps>(
       const numberOfSlidesPerSnap = numberOfSlides / numberOfSnaps;
 
       if (focusedSlideIndex >= 0) {
-        const nearestScrollSnap = Math.floor(
+        const nearestScrollSnap = Math.round(
           focusedSlideIndex / numberOfSlidesPerSnap,
         );
         if (emblaApi.selectedScrollSnap() !== nearestScrollSnap) {

--- a/packages/embla-carousel/src/CarouselSlides.tsx
+++ b/packages/embla-carousel/src/CarouselSlides.tsx
@@ -162,7 +162,10 @@ export const CarouselSlides = forwardRef<HTMLDivElement, CarouselSlidesProps>(
         const initialSnap = emblaApi.selectedScrollSnap();
         const initialSlideIndex =
           initialSnap !== undefined
-            ? Math.floor(initialSnap * numberOfSlidesPerSnap)
+            ? Math.min(
+                Math.floor(initialSnap * numberOfSlidesPerSnap),
+                numberOfSlides - 1,
+              )
             : 0;
 
         setFocusedSlideIndex(initialSlideIndex);
@@ -242,7 +245,10 @@ export const CarouselSlides = forwardRef<HTMLDivElement, CarouselSlidesProps>(
         setAnnouncementState("focus");
       } else {
         // Different group - scroll first, then focus on settle
-        const targetSnap = Math.floor(newFocusIndex / numberOfSlidesPerSnap);
+        const targetSnap = Math.min(
+          Math.floor(newFocusIndex / numberOfSlidesPerSnap),
+          numberOfSnaps - 1,
+        );
         hasSettled.current = false;
         pendingFocusIndex.current = newFocusIndex;
         emblaApi.scrollTo(targetSnap);

--- a/packages/embla-carousel/src/__tests__/__e2e__/Carousel.cy.tsx
+++ b/packages/embla-carousel/src/__tests__/__e2e__/Carousel.cy.tsx
@@ -154,7 +154,6 @@ describe("Given a Carousel", () => {
 
       cy.realPress("ArrowLeft");
       cy.wrap(waitForSettle(emblaApi, 1)).then(() => verifySlide("2", true));
-      cy.wrap(waitForSettle(emblaApi, 1)).then(() => verifySlide("2", true));
 
       cy.realPress("ArrowLeft");
       cy.wrap(waitForSettle(emblaApi, 0)).then(() => verifySlide("1", true));
@@ -258,7 +257,11 @@ describe("Given a Carousel", () => {
 
           return (
             <MultiSlide
-              emblaOptions={{ align: "start", slidesToScroll: 2 }}
+              emblaOptions={{
+                align: "start",
+                slidesToScroll: 2,
+                duration: 1,
+              }}
               getEmblaApi={setEmblaApi}
             />
           );
@@ -311,6 +314,77 @@ describe("Given a Carousel", () => {
         // Wait additional time to ensure it doesn't snap back
         cy.wait(500).then(() => {
           expect(emblaApi?.selectedScrollSnap()).to.be.greaterThan(0);
+        });
+      });
+    });
+
+    it("should move focus within the current snap without scrolling, and only scroll when crossing snap groups", () => {
+      mountMultiSlideCarousel().then((emblaApi) => {
+        // Focus the first slide
+        cy.get(".carouselSlide").eq(0).focus();
+        cy.get(".carouselSlide").eq(0).should("be.focused");
+        cy.wrap(null).then(() => {
+          expect(emblaApi?.selectedScrollSnap()).to.equal(0);
+        });
+
+        // ArrowRight within snap 0: focus moves to slide 2, snap unchanged.
+        cy.realPress("ArrowRight");
+        cy.get(".carouselSlide").eq(1).should("be.focused");
+        cy.wrap(null).then(() => {
+          expect(emblaApi?.selectedScrollSnap()).to.equal(0);
+        });
+
+        // ArrowRight crossing snap boundary: focus moves to slide 3 and the
+        // carousel scrolls to snap 1.
+        cy.realPress("ArrowRight");
+        cy.wrap(waitForSettle(emblaApi, 1)).then(() => {
+          cy.get(".carouselSlide").eq(2).should("be.focused");
+          expect(emblaApi?.selectedScrollSnap()).to.equal(1);
+        });
+
+        // ArrowLeft crossing snap boundary the other way: focus moves to
+        // slide 2 and the carousel scrolls back to snap 0.
+        cy.realPress("ArrowLeft");
+        cy.wrap(waitForSettle(emblaApi, 0)).then(() => {
+          cy.get(".carouselSlide").eq(1).should("be.focused");
+          expect(emblaApi?.selectedScrollSnap()).to.equal(0);
+        });
+
+        // ArrowLeft within snap 0: focus moves to slide 1, snap unchanged.
+        cy.realPress("ArrowLeft");
+        cy.get(".carouselSlide").eq(0).should("be.focused");
+        cy.wrap(null).then(() => {
+          expect(emblaApi?.selectedScrollSnap()).to.equal(0);
+        });
+      });
+    });
+
+    it("should expose every visible slide as an independent tab stop and exclude off-screen slides", () => {
+      mountMultiSlideCarousel().then((emblaApi) => {
+        // Initially visible: slides 1 and 2. The other three slides must not
+        // be reachable with Tab.
+        cy.get(".carouselSlide").eq(0).should("have.attr", "tabindex", "0");
+        cy.get(".carouselSlide").eq(1).should("have.attr", "tabindex", "0");
+        cy.get(".carouselSlide").eq(2).should("have.attr", "tabindex", "-1");
+        cy.get(".carouselSlide").eq(3).should("have.attr", "tabindex", "-1");
+        cy.get(".carouselSlide").eq(4).should("have.attr", "tabindex", "-1");
+
+        // Tab from the first visible slide should land on the second visible
+        // slide, proving each visible slide is an independent tab stop
+        // rather than a single roving tabindex entry.
+        cy.get(".carouselSlide").eq(0).focus();
+        cy.realPress("Tab");
+        cy.get(".carouselSlide").eq(1).should("be.focused");
+
+        // After scrolling to the next snap, the tab-stop set must shift to
+        // the newly visible slides.
+        cy.findByLabelText(/Next slide group/).click();
+        cy.wrap(waitForSettle(emblaApi, 1)).then(() => {
+          cy.get(".carouselSlide").eq(0).should("have.attr", "tabindex", "-1");
+          cy.get(".carouselSlide").eq(1).should("have.attr", "tabindex", "-1");
+          cy.get(".carouselSlide").eq(2).should("have.attr", "tabindex", "0");
+          cy.get(".carouselSlide").eq(3).should("have.attr", "tabindex", "0");
+          cy.get(".carouselSlide").eq(4).should("have.attr", "tabindex", "-1");
         });
       });
     });

--- a/packages/embla-carousel/src/__tests__/__e2e__/Carousel.cy.tsx
+++ b/packages/embla-carousel/src/__tests__/__e2e__/Carousel.cy.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import type { CarouselEmblaApiType } from "../../index";
 
 const composedStories = composeStories(carouselStories);
-const { Default, SlideGroup } = composedStories;
+const { Default, SlideGroup, MultiSlide } = composedStories;
 
 describe("Given a Carousel", () => {
   let emblaTestApi: CarouselEmblaApiType | null | undefined;
@@ -239,6 +239,80 @@ describe("Given a Carousel", () => {
       cy.realPress("End");
       cy.wrap(waitForSettle(emblaApi, 3)).then(() => verifySlide("4", false));
       cy.findAllByRole("tab").eq(3).should("have.focus");
+    });
+  });
+
+  describe("Given a Carousel with odd number of slides in multi-slide mode", () => {
+    let emblaTestApi: CarouselEmblaApiType | null | undefined;
+
+    const mountMultiSlideCarousel =
+      (): Cypress.Chainable<CarouselEmblaApiType> => {
+        const FiveSlideCarousel = () => {
+          const [emblaApi, setEmblaApi] = useState<CarouselEmblaApiType | null>(
+            null,
+          );
+
+          useEffect(() => {
+            emblaTestApi = emblaApi;
+          }, [emblaApi]);
+
+          return (
+            <MultiSlide
+              emblaOptions={{ align: "start", slidesToScroll: 2 }}
+              getEmblaApi={setEmblaApi}
+            />
+          );
+        };
+
+        cy.mount(<FiveSlideCarousel />);
+        cy.findByRole("region").should("exist");
+
+        return cy.wrap(
+          new Cypress.Promise<CarouselEmblaApiType>((resolve) => {
+            const checkEmblaApi = () => {
+              if (emblaTestApi) {
+                resolve(emblaTestApi);
+              } else {
+                setTimeout(checkEmblaApi, 1000);
+              }
+            };
+            checkEmblaApi();
+          }),
+        );
+      };
+
+    beforeEach(() => {
+      emblaTestApi = null;
+    });
+
+    it("should not snap back to start when clicking Next with 5 slides and 2 per view", () => {
+      mountMultiSlideCarousel().then((emblaApi) => {
+        // Verify we start at snap 0
+        cy.wrap(null).then(() => {
+          expect(emblaApi?.selectedScrollSnap()).to.equal(0);
+        });
+
+        // Click next
+        cy.findByLabelText(/Next slide/).click();
+
+        // Wait for settle and verify we moved forward (not back to 0)
+        cy.wrap(
+          new Cypress.Promise((resolve) => {
+            const handleSettle = () => {
+              emblaApi?.off("settle", handleSettle);
+              resolve();
+            };
+            emblaApi?.on("settle", handleSettle);
+          }),
+        ).then(() => {
+          expect(emblaApi?.selectedScrollSnap()).to.be.greaterThan(0);
+        });
+
+        // Wait additional time to ensure it doesn't snap back
+        cy.wait(500).then(() => {
+          expect(emblaApi?.selectedScrollSnap()).to.be.greaterThan(0);
+        });
+      });
     });
   });
 });

--- a/packages/embla-carousel/stories/carousel.stories.css
+++ b/packages/embla-carousel/stories/carousel.stories.css
@@ -49,7 +49,7 @@
 
 .carouselMultipleSlide {
   width: 600px;
-  --carousel-slide-size: 50%;
+  --carousel-slide-size: 48%;
 }
 
 .carouselSlideIsSnapped {

--- a/packages/embla-carousel/stories/carousel.stories.tsx
+++ b/packages/embla-carousel/stories/carousel.stories.tsx
@@ -119,7 +119,7 @@ export const MultiSlide: StoryFn<typeof Carousel> = (args) => {
     <Carousel
       aria-labelledby={`${carouselId}-title`}
       className="carouselMultipleSlide"
-      emblaOptions={{ align: "center", slidesToScroll: "auto" }}
+      emblaOptions={{ align: "center", slidesToScroll: 2 }}
       {...args}
     >
       <H2 id={`${carouselId}-title`} className="carouselHeading">

--- a/packages/embla-carousel/stories/exampleData.ts
+++ b/packages/embla-carousel/stories/exampleData.ts
@@ -26,4 +26,11 @@ export const sliderData = [
       "Simplified view of all your accounts, with search functionality across all transactions.",
     link: "Download app",
   },
+  {
+    title: "Make your first deposit",
+    image: "/img/examples/carouselSlide3.png",
+    content:
+      "Fund your account to start transacting and unlock reporting capabilities, offers, and more.",
+    link: "Fund account",
+  },
 ];

--- a/site/src/examples/carousel/exampleData.ts
+++ b/site/src/examples/carousel/exampleData.ts
@@ -26,4 +26,11 @@ export const sliderData = [
       "Simplified view of all your accounts, with search functionality across all transactions.",
     link: "Download app",
   },
+  {
+    title: "Make your first deposit",
+    image: "/img/examples/carouselSlide3.png",
+    content:
+      "Fund your account to start transacting and unlock reporting capabilities, offers, and more.",
+    link: "Fund account",
+  },
 ];


### PR DESCRIPTION
Added fix for below scenario - 
when you have an odd number of slides in multi-slide mode (2 slides per view), clicking Next scrolls forward then immediately snaps back to the start.
Added fix for https://github.com/jpmorganchase/salt-ds/issues/6069