### PR TITLE
Bump vite and vitest

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -5,7 +5,6 @@ import { cssInline } from "css-inline-plugin";
 import { defineConfig } from "cypress";
 import { version as reactVersion } from "react";
 import type { UserConfig } from "vite";
-import tsconfigPaths from "vite-tsconfig-paths";
 
 const isReact16Or17 =
   reactVersion.startsWith("16") || reactVersion.startsWith("17");
@@ -13,7 +12,7 @@ const isReact16Or17 =
 async function getViteConfig(config: UserConfig) {
   const { mergeConfig } = await import("vite");
   let viteConfig: UserConfig = {
-    plugins: [react(), tsconfigPaths(), cssInline()],
+    plugins: [react(), cssInline()],
     define: {
       "process.env": {},
     },
@@ -26,6 +25,7 @@ async function getViteConfig(config: UserConfig) {
       sourcemap: !isCI,
     },
     resolve: {
+      tsconfigPaths: true,
       alias: {
         "cypress/react": !isReact16Or17 ? "cypress/react" : "@cypress/react",
       },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/react-dom": "^18.3.7",
     "@types/tinycolor2": "^1.4.3",
     "@typescript/native-preview": "7.0.0-dev.20260601.1",
-    "@vitejs/plugin-react": "^5.0.3",
+    "@vitejs/plugin-react": "^6.0.2",
     "ag-grid-community": "^32.0.0",
     "ag-grid-enterprise": "^32.0.0",
     "ag-grid-react": "^32.0.0",
@@ -99,9 +99,8 @@
     "storybook": "10.5.3",
     "stylelint": "^17.0.0",
     "typescript": "^6.0.0",
-    "vite": "^7.1.5",
-    "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^4.0.0",
+    "vite": "^8.0.14",
+    "vitest": "^4.1.7",
     "yup": "^1.7.1"
   },
   "resolutions": {
@@ -149,8 +148,7 @@
     "get-tsconfig": "^4.7.5",
     "rollup": "^4.24.2",
     "rollup-plugin-esbuild": "^6.1.1",
-    "rollup-plugin-postcss": "^4.0.2",
-    "vite-tsconfig-paths": "^5.1.4"
+    "rollup-plugin-postcss": "^4.0.2"
   },
   "dependenciesMeta": {
     "cypress": {

--- a/package.json
+++ b/package.json
@@ -71,15 +71,15 @@
     "@types/react-dom": "^18.3.7",
     "@types/tinycolor2": "^1.4.3",
     "@typescript/native-preview": "7.0.0-dev.20260601.1",
-    "@vitejs/plugin-react": "^6.0.2",
+    "@vitejs/plugin-react": "^6.0.4",
     "ag-grid-community": "^32.0.0",
     "ag-grid-enterprise": "^32.0.0",
     "ag-grid-react": "^32.0.0",
-    "axe-core": "^4.11.2",
+    "axe-core": "^4.12.1",
     "chromatic": "^18.0.0",
     "ci-info": "^4.0.0",
     "clsx": "^2.0.0",
-    "cypress": "15.10.0",
+    "cypress": "^15.17.0",
     "cypress-axe": "^1.7.0",
     "cypress-real-events": "^1.15.0",
     "deepmerge": "^4.2.2",
@@ -99,8 +99,8 @@
     "storybook": "10.5.3",
     "stylelint": "^17.0.0",
     "typescript": "^6.0.0",
-    "vite": "^8.0.14",
-    "vitest": "^4.1.7",
+    "vite": "^8.2.0",
+    "vitest": "^4.1.10",
     "yup": "^1.7.1"
   },
   "resolutions": {
@@ -117,8 +117,7 @@
     "react-error-boundary": "^6.0.0",
     "tslib": "^2.0.0",
     "path-to-regexp": "^8.4.0",
-    "postcss": "^8.5.24",
-    "vite": "^7.1.5"
+    "postcss": "^8.5.24"
   },
   "browserslist": {
     "production": [

--- a/packages/core/src/__tests__/__e2e__/avatar/Avatar.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/avatar/Avatar.cy.tsx
@@ -1,7 +1,7 @@
 import { UserGroupSolidIcon } from "@salt-ds/icons";
-import * as avatarStories from "@stories/avatar/avatar.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as avatarStories from "~stories/avatar/avatar.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(avatarStories);
 const { Default } = composedStories;

--- a/packages/core/src/__tests__/__e2e__/banner/Banner.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/banner/Banner.cy.tsx
@@ -1,8 +1,8 @@
 import { Banner, BannerActions, BannerContent, Button } from "@salt-ds/core";
 import { RefreshIcon } from "@salt-ds/icons";
-import * as bannerStories from "@stories/banner/banner.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as bannerStories from "~stories/banner/banner.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(bannerStories);
 const { StatusesPrimary } = composedStories;

--- a/packages/core/src/__tests__/__e2e__/border-layout/BorderLayout.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/border-layout/BorderLayout.cy.tsx
@@ -1,7 +1,7 @@
 import { BORDER_POSITION as borderAreas } from "@salt-ds/core";
-import * as borderStories from "@stories/border-layout/border-layout.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as borderStories from "~stories/border-layout/border-layout.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(borderStories);
 const { AllPanels, NoHeaderOrFooter } = composedStories;

--- a/packages/core/src/__tests__/__e2e__/button/Button.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/button/Button.cy.tsx
@@ -1,6 +1,6 @@
-import * as buttonStories from "@stories/button/button.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as buttonStories from "~stories/button/button.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(buttonStories);
 const { Default, FocusableWhenDisabled, LoadingSingle } = composedStories;

--- a/packages/core/src/__tests__/__e2e__/card/Card.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/card/Card.cy.tsx
@@ -6,10 +6,10 @@ import {
   InteractableCard,
   LinkCard,
 } from "@salt-ds/core";
-import * as cardStories from "@stories/card/card.stories";
+import * as cardStories from "~stories/card/card.stories";
 import { composeStories } from "@storybook/react-vite";
 import { Fragment, useState } from "react";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(cardStories);
 const { Default, AccentVariations } = composedStories;

--- a/packages/core/src/__tests__/__e2e__/card/Card.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/card/Card.cy.tsx
@@ -6,9 +6,9 @@ import {
   InteractableCard,
   LinkCard,
 } from "@salt-ds/core";
-import * as cardStories from "~stories/card/card.stories";
 import { composeStories } from "@storybook/react-vite";
 import { Fragment, useState } from "react";
+import * as cardStories from "~stories/card/card.stories";
 import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(cardStories);

--- a/packages/core/src/__tests__/__e2e__/collapsible/Collapsible.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/collapsible/Collapsible.cy.tsx
@@ -1,5 +1,5 @@
-import * as collapsibleStories from "@stories/collapsible/collapsible.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as collapsibleStories from "~stories/collapsible/collapsible.stories";
 
 const composedStories = composeStories(collapsibleStories);
 

--- a/packages/core/src/__tests__/__e2e__/combo-box/ComboBox.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/combo-box/ComboBox.cy.tsx
@@ -1,7 +1,7 @@
 import { ComboBox, Option } from "@salt-ds/core";
-import * as comboBoxStories from "@stories/combo-box/combo-box.stories";
 import { composeStories } from "@storybook/react-vite";
 import { type KeyboardEventHandler, useRef, useState } from "react";
+import * as comboBoxStories from "~stories/combo-box/combo-box.stories";
 import { CustomFloatingComponentProvider, FLOATING_TEST_ID } from "../common";
 
 const {

--- a/packages/core/src/__tests__/__e2e__/dialog/Dialog.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/dialog/Dialog.cy.tsx
@@ -1,5 +1,5 @@
-import * as dialogStories from "@stories/dialog/dialog.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as dialogStories from "~stories/dialog/dialog.stories";
 
 const composedStories = composeStories(dialogStories);
 

--- a/packages/core/src/__tests__/__e2e__/divider/Divider.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/divider/Divider.cy.tsx
@@ -1,6 +1,6 @@
-import * as dividerStories from "@stories/divider/divider.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as dividerStories from "~stories/divider/divider.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(dividerStories);
 const { Variants, Vertical } = composedStories;

--- a/packages/core/src/__tests__/__e2e__/drawer/Drawer.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/drawer/Drawer.cy.tsx
@@ -1,5 +1,5 @@
-import * as drawerStories from "@stories/drawer/drawer.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as drawerStories from "~stories/drawer/drawer.stories";
 
 const composedStories = composeStories(drawerStories);
 

--- a/packages/core/src/__tests__/__e2e__/dropdown/Dropdown.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/dropdown/Dropdown.cy.tsx
@@ -1,7 +1,7 @@
 import { Dropdown, FormField, FormFieldLabel, Option } from "@salt-ds/core";
-import * as dropdownStories from "@stories/dropdown/dropdown.stories";
 import { composeStories } from "@storybook/react-vite";
 import { type KeyboardEventHandler, useRef, useState } from "react";
+import * as dropdownStories from "~stories/dropdown/dropdown.stories";
 import { CustomFloatingComponentProvider, FLOATING_TEST_ID } from "../common";
 
 const {

--- a/packages/core/src/__tests__/__e2e__/file-drop-zone/FileDropZone.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/file-drop-zone/FileDropZone.cy.tsx
@@ -1,7 +1,7 @@
 import { FileDropZoneTrigger } from "@salt-ds/core";
-import * as fileDropZoneStories from "@stories/file-drop-zone/file-drop-zone.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as fileDropZoneStories from "~stories/file-drop-zone/file-drop-zone.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(fileDropZoneStories);
 const { Default } = composedStories;

--- a/packages/core/src/__tests__/__e2e__/flex-item/FlexItem.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/flex-item/FlexItem.cy.tsx
@@ -1,5 +1,5 @@
-import * as flexStories from "@stories/flex-item/flex-item.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as flexStories from "~stories/flex-item/flex-item.stories";
 
 const composedStories = composeStories(flexStories);
 const { FlexItemWrapper } = composedStories;

--- a/packages/core/src/__tests__/__e2e__/flex-layout/FlexLayout.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/flex-layout/FlexLayout.cy.tsx
@@ -1,7 +1,7 @@
 import { SaltProvider } from "@salt-ds/core";
-import * as flexStories from "@stories/flex-layout/flex-layout.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as flexStories from "~stories/flex-layout/flex-layout.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(flexStories);
 const { Default, Nested } = composedStories;

--- a/packages/core/src/__tests__/__e2e__/flow-layout/FlowLayout.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/flow-layout/FlowLayout.cy.tsx
@@ -1,6 +1,6 @@
-import * as flowStories from "@stories/flow-layout/flow-layout.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as flowStories from "~stories/flow-layout/flow-layout.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(flowStories);
 const { Default } = composedStories;

--- a/packages/core/src/__tests__/__e2e__/grid-layout/GridLayout.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/grid-layout/GridLayout.cy.tsx
@@ -1,7 +1,7 @@
 import { SaltProvider } from "@salt-ds/core";
-import * as gridStories from "@stories/grid-layout/grid-layout.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as gridStories from "~stories/grid-layout/grid-layout.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(gridStories);
 const { Default, Nested } = composedStories;

--- a/packages/core/src/__tests__/__e2e__/input/Input.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/input/Input.cy.tsx
@@ -1,7 +1,7 @@
 import { Button, FormField, FormFieldLabel, Input } from "@salt-ds/core";
-import * as inputStories from "@stories/input/input.stories";
 import { composeStories } from "@storybook/react";
 import { type ChangeEvent, useState } from "react";
+import * as inputStories from "~stories/input/input.stories";
 
 const { WithFormField } = composeStories(inputStories);
 

--- a/packages/core/src/__tests__/__e2e__/interactable-card/InteractableCard.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/interactable-card/InteractableCard.cy.tsx
@@ -4,10 +4,10 @@ import {
   type InteractableCardGroupProps,
   type InteractableCardValue,
 } from "@salt-ds/core";
-import * as cardStories from "@stories/interactable-card/interactable-card.stories";
 import { composeStories } from "@storybook/react-vite";
 import { type SyntheticEvent, useState } from "react";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as cardStories from "~stories/interactable-card/interactable-card.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(cardStories);
 const { Default } = composedStories;

--- a/packages/core/src/__tests__/__e2e__/kbd/Kbd.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/kbd/Kbd.cy.tsx
@@ -1,7 +1,7 @@
 import { Kbd } from "@salt-ds/core";
-import * as kbdStories from "@stories/kbd/kbd.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as kbdStories from "~stories/kbd/kbd.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(kbdStories);
 

--- a/packages/core/src/__tests__/__e2e__/link-card/LinkCard.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/link-card/LinkCard.cy.tsx
@@ -1,6 +1,6 @@
-import * as linkCardStories from "@stories/link-card/link-card.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as linkCardStories from "~stories/link-card/link-card.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(linkCardStories);
 const { Default } = composedStories;

--- a/packages/core/src/__tests__/__e2e__/link/Link.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/link/Link.cy.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@salt-ds/core";
-import * as linkStories from "@stories/link/link.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as linkStories from "~stories/link/link.stories";
 
 const composedStories = composeStories(linkStories);
 const { TargetBlankCustomIcon } = composedStories;

--- a/packages/core/src/__tests__/__e2e__/list-box/ListBox.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/list-box/ListBox.cy.tsx
@@ -1,5 +1,5 @@
-import * as listBoxStories from "@stories/list-box/list-box.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as listBoxStories from "~stories/list-box/list-box.stories";
 
 const {
   SingleSelect,

--- a/packages/core/src/__tests__/__e2e__/mega-menu/MegaMenu.accessibility.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/mega-menu/MegaMenu.accessibility.cy.tsx
@@ -1,5 +1,5 @@
-import * as megaMenuStories from "@stories/mega-menu/mega-menu.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as megaMenuStories from "~stories/mega-menu/mega-menu.stories";
 
 const {
   Baseline,

--- a/packages/core/src/__tests__/__e2e__/mega-menu/MegaMenu.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/mega-menu/MegaMenu.cy.tsx
@@ -1,5 +1,5 @@
-import * as megaMenuStories from "@stories/mega-menu/mega-menu.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as megaMenuStories from "~stories/mega-menu/mega-menu.stories";
 
 const { Baseline, DefaultOpen, Controlled } = composeStories(megaMenuStories);
 

--- a/packages/core/src/__tests__/__e2e__/mega-menu/MegaMenu.keyboardNavigation.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/mega-menu/MegaMenu.keyboardNavigation.cy.tsx
@@ -1,5 +1,5 @@
-import * as megaMenuStories from "@stories/mega-menu/mega-menu.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as megaMenuStories from "~stories/mega-menu/mega-menu.stories";
 
 const {
   Baseline,

--- a/packages/core/src/__tests__/__e2e__/menu/Menu.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/menu/Menu.cy.tsx
@@ -1,5 +1,5 @@
-import * as menuStories from "@stories/menu/menu.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as menuStories from "~stories/menu/menu.stories";
 import { CustomFloatingComponentProvider, FLOATING_TEST_ID } from "../common";
 
 const {

--- a/packages/core/src/__tests__/__e2e__/multiline-input/MultilineInput.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/multiline-input/MultilineInput.cy.tsx
@@ -1,6 +1,6 @@
-import * as multilineInputStories from "@stories/multiline-input/multiline-input.stories";
 import { composeStories } from "@storybook/react-vite";
 import type { ChangeEvent } from "react";
+import * as multilineInputStories from "~stories/multiline-input/multiline-input.stories";
 
 const {
   Default,

--- a/packages/core/src/__tests__/__e2e__/number-input/NumberInput.accessibility.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/number-input/NumberInput.accessibility.cy.tsx
@@ -1,6 +1,6 @@
-import * as numberInputStories from "@stories/number-input/number-input.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as numberInputStories from "~stories/number-input/number-input.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(numberInputStories);
 const { Default } = composedStories;

--- a/packages/core/src/__tests__/__e2e__/number-input/NumberInput.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/number-input/NumberInput.cy.tsx
@@ -4,9 +4,9 @@ import {
   NumberInput,
   type NumberInputProps,
 } from "@salt-ds/core";
-import * as numberInputStories from "@stories/number-input/number-input.stories";
 import { composeStories } from "@storybook/react-vite";
 import { type SyntheticEvent, useState } from "react";
+import * as numberInputStories from "~stories/number-input/number-input.stories";
 
 const composedStories = composeStories(numberInputStories);
 

--- a/packages/core/src/__tests__/__e2e__/overlay/Overlay.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/overlay/Overlay.cy.tsx
@@ -1,6 +1,6 @@
-import * as overlayStories from "@stories/overlay/overlay.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as overlayStories from "~stories/overlay/overlay.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(overlayStories);
 const { Default, Right, Bottom, Left, CloseButton, LongContent, WithTooltip } =

--- a/packages/core/src/__tests__/__e2e__/parent-child-layout/ParentChildLayout.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/parent-child-layout/ParentChildLayout.cy.tsx
@@ -1,6 +1,6 @@
 import { SaltProvider } from "@salt-ds/core";
-import * as parentChildStories from "@stories/parent-child-layout/parent-child-layout.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as parentChildStories from "~stories/parent-child-layout/parent-child-layout.stories";
 
 const composedStories = composeStories(parentChildStories);
 

--- a/packages/core/src/__tests__/__e2e__/pill/PillGroup.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/pill/PillGroup.cy.tsx
@@ -1,6 +1,6 @@
 import { FormField, FormFieldHelperText, FormFieldLabel } from "@salt-ds/core";
-import * as pillGroupStories from "@stories/pill/pill-group.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as pillGroupStories from "~stories/pill/pill-group.stories";
 
 const {
   Default,

--- a/packages/core/src/__tests__/__e2e__/progress/CircularProgress.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/progress/CircularProgress.cy.tsx
@@ -1,5 +1,5 @@
-import * as circularProgressStories from "@stories/progress/circular-progress.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as circularProgressStories from "~stories/progress/circular-progress.stories";
 
 const composedStories = composeStories(circularProgressStories);
 const { Default } = composedStories;

--- a/packages/core/src/__tests__/__e2e__/progress/LinearProgress.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/progress/LinearProgress.cy.tsx
@@ -1,5 +1,5 @@
-import * as linearProgressStories from "@stories/progress/linear-progress.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as linearProgressStories from "~stories/progress/linear-progress.stories";
 
 const composedStories = composeStories(linearProgressStories);
 const { Default, Indeterminate } = composedStories;

--- a/packages/core/src/__tests__/__e2e__/radio-button/RadioButtonGroup.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/radio-button/RadioButtonGroup.cy.tsx
@@ -4,10 +4,10 @@ import {
   RadioButton,
   RadioButtonGroup,
 } from "@salt-ds/core";
-import * as radioButtonStories from "@stories/radio-button/radio-button.stories";
 import { composeStories } from "@storybook/react-vite";
 import type { ChangeEventHandler } from "react";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as radioButtonStories from "~stories/radio-button/radio-button.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(radioButtonStories);
 

--- a/packages/core/src/__tests__/__e2e__/rating/Rating.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/rating/Rating.cy.tsx
@@ -1,6 +1,6 @@
-import * as ratingStories from "@stories/rating/rating.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as ratingStories from "~stories/rating/rating.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(ratingStories);
 const {

--- a/packages/core/src/__tests__/__e2e__/scrim/Scrim.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/scrim/Scrim.cy.tsx
@@ -1,6 +1,6 @@
-import * as scrimStories from "@stories/scrim/scrim.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as scrimStories from "~stories/scrim/scrim.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 import { Scrim } from "../../../scrim";
 
 const composedStories = composeStories(scrimStories);

--- a/packages/core/src/__tests__/__e2e__/segmented-button-group/SegmentedButtonGroup.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/segmented-button-group/SegmentedButtonGroup.cy.tsx
@@ -1,5 +1,5 @@
-import * as segmentedButtonStories from "@stories/segmented-button-group/segmented-button-group.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as segmentedButtonStories from "~stories/segmented-button-group/segmented-button-group.stories";
 
 const composedStories = composeStories(segmentedButtonStories);
 

--- a/packages/core/src/__tests__/__e2e__/side-panel/SidePanel.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/side-panel/SidePanel.cy.tsx
@@ -11,10 +11,10 @@ import {
   Text,
   useSidePanel,
 } from "@salt-ds/core";
-import * as sidePanel from "@stories/side-panel/side-panel.stories";
 import { composeStories } from "@storybook/react-vite";
 import { useRef, useState } from "react";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as sidePanel from "~stories/side-panel/side-panel.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(sidePanel);
 const { Left, Default, ManualTrigger, WithTable, Scrollable, WithNav } =

--- a/packages/core/src/__tests__/__e2e__/skip-link/SkipLink.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/skip-link/SkipLink.cy.tsx
@@ -1,6 +1,6 @@
-import * as skipLinkStories from "@stories/skip-link/skip-link.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as skipLinkStories from "~stories/skip-link/skip-link.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(skipLinkStories);
 const { Default } = composedStories;

--- a/packages/core/src/__tests__/__e2e__/slider/RangeSlider.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/slider/RangeSlider.cy.tsx
@@ -1,6 +1,6 @@
-import * as rangeSliderStories from "@stories/range-slider/range-slider.stories";
 import { composeStories } from "@storybook/react-vite";
 import { type ChangeEvent, useState } from "react";
+import * as rangeSliderStories from "~stories/range-slider/range-slider.stories";
 
 const composedStories = composeStories(rangeSliderStories);
 

--- a/packages/core/src/__tests__/__e2e__/slider/Slider.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/slider/Slider.cy.tsx
@@ -1,6 +1,6 @@
-import * as sliderStories from "@stories/slider/slider.stories";
 import { composeStories } from "@storybook/react-vite";
 import { type ChangeEvent, useState } from "react";
+import * as sliderStories from "~stories/slider/slider.stories";
 
 const composedStories = composeStories(sliderStories);
 

--- a/packages/core/src/__tests__/__e2e__/split-layout/SplitLayout.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/split-layout/SplitLayout.cy.tsx
@@ -1,6 +1,6 @@
-import * as splitStories from "@stories/split-layout/split-layout.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as splitStories from "~stories/split-layout/split-layout.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(splitStories);
 const { Default } = composedStories;

--- a/packages/core/src/__tests__/__e2e__/stack-layout/StackLayout.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/stack-layout/StackLayout.cy.tsx
@@ -1,6 +1,6 @@
-import * as stackStories from "@stories/stack-layout/stack-layout.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as stackStories from "~stories/stack-layout/stack-layout.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(stackStories);
 const { Default } = composedStories;

--- a/packages/core/src/__tests__/__e2e__/status-indicator/StatusIndicator.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/status-indicator/StatusIndicator.cy.tsx
@@ -1,6 +1,6 @@
-import * as statusIndicatorStories from "@stories/status-indicator/status-indicator.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as statusIndicatorStories from "~stories/status-indicator/status-indicator.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(statusIndicatorStories);
 const { Default } = composedStories;

--- a/packages/core/src/__tests__/__e2e__/switch/Switch.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/switch/Switch.cy.tsx
@@ -1,7 +1,7 @@
-import * as switchStories from "@stories/switch/switch.stories";
 import { composeStories } from "@storybook/react";
 import type { ChangeEvent } from "react";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as switchStories from "~stories/switch/switch.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(switchStories);
 const { Default, Disabled, Controlled, WithFormField, Readonly } =

--- a/packages/core/src/__tests__/__e2e__/table/Table.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/table/Table.cy.tsx
@@ -1,6 +1,6 @@
-import * as tableStories from "@stories/table/table.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as tableStories from "~stories/table/table.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(tableStories);
 const {

--- a/packages/core/src/__tests__/__e2e__/tabs/Tabs.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/tabs/Tabs.cy.tsx
@@ -6,9 +6,9 @@ import {
   Tabs,
   TabTrigger,
 } from "@salt-ds/core";
-import * as tabsStories from "@stories/tabs/tabs.stories";
 import { composeStories } from "@storybook/react-vite";
 import { type ReactElement, useEffect, useState } from "react";
+import * as tabsStories from "~stories/tabs/tabs.stories";
 
 const {
   Bordered,

--- a/packages/core/src/__tests__/__e2e__/toast/Toast.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/toast/Toast.cy.tsx
@@ -1,8 +1,8 @@
 import { Toast, ToastContent } from "@salt-ds/core";
 import { LinkedIcon } from "@salt-ds/icons";
-import * as toastStories from "@stories/toast/toast.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as toastStories from "~stories/toast/toast.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(toastStories);
 

--- a/packages/core/src/__tests__/__e2e__/toggle-button/ToggleButton.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/toggle-button/ToggleButton.cy.tsx
@@ -1,7 +1,7 @@
 import { ToggleButton } from "@salt-ds/core";
 import { HomeIcon } from "@salt-ds/icons";
-import * as toggleButtonStories from "@stories/toggle-button/toggle-button.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as toggleButtonStories from "~stories/toggle-button/toggle-button.stories";
 
 const { Controlled, DefaultSelected } = composeStories(toggleButtonStories);
 

--- a/packages/core/src/__tests__/__e2e__/toggletip/Toggletip.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/toggletip/Toggletip.cy.tsx
@@ -1,8 +1,8 @@
 import { Toggletip, ToggletipPanel, ToggletipTrigger } from "@salt-ds/core";
 import { HelpCircleIcon } from "@salt-ds/icons";
-import * as toggletipStories from "@stories/toggletip/toggletip.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as toggletipStories from "~stories/toggletip/toggletip.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 import { CustomFloatingComponentProvider, FLOATING_TEST_ID } from "../common";
 

--- a/packages/core/src/__tests__/__e2e__/toolbar/Toolbar.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/toolbar/Toolbar.cy.tsx
@@ -17,9 +17,9 @@ import {
   DatePickerSingleInput,
   DatePickerTrigger,
 } from "@salt-ds/date-components";
-import * as toolbarStories from "@stories/toolbar/toolbar.cypress.stories";
 import { composeStories } from "@storybook/react-vite";
 import { type FocusEventHandler, useState } from "react";
+import * as toolbarStories from "~stories/toolbar/toolbar.cypress.stories";
 
 const {
   DefaultSharedOverflowFixture,

--- a/packages/core/src/__tests__/__e2e__/tooltip/Tooltip.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/tooltip/Tooltip.cy.tsx
@@ -1,8 +1,8 @@
 import { FormField, Tooltip } from "@salt-ds/core";
 import { InfoIcon } from "@salt-ds/icons";
-import * as tooltipStories from "@stories/tooltip/tooltip.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as tooltipStories from "~stories/tooltip/tooltip.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 import { CustomFloatingComponentProvider, FLOATING_TEST_ID } from "../common";
 

--- a/packages/core/src/__tests__/__e2e__/vertical-navigation/VerticalNavigation.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/vertical-navigation/VerticalNavigation.cy.tsx
@@ -1,5 +1,5 @@
-import * as verticalNavigationStories from "@stories/vertical-navigation/vertical-navigation.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as verticalNavigationStories from "~stories/vertical-navigation/vertical-navigation.stories";
 
 const { Basic, CollapsibleSubmenu, WithExpandButton } = composeStories(
   verticalNavigationStories,

--- a/packages/core/stories/collapsible/collapsible.stories.tsx
+++ b/packages/core/stories/collapsible/collapsible.stories.tsx
@@ -23,9 +23,9 @@ import {
   MessageIcon,
   UserIcon,
 } from "@salt-ds/icons";
-import persona from "@stories/assets/avatar.png";
 import type { StoryFn } from "@storybook/react";
 import { useState } from "react";
+import persona from "~stories/assets/avatar.png";
 
 export default {
   title: "Core/Collapsible",

--- a/packages/core/stories/range-slider/range-slider.stories.tsx
+++ b/packages/core/stories/range-slider/range-slider.stories.tsx
@@ -10,8 +10,10 @@ import {
   useResponsiveProp,
 } from "@salt-ds/core";
 import type { StoryFn } from "@storybook/react-vite";
-import { toFloat } from "packages/core/src/slider/internal/utils";
 import { type SyntheticEvent, useState } from "react";
+
+const toFloat = (value: number | string) =>
+  typeof value === "string" ? Number.parseFloat(value) : value;
 
 const marks = [
   {

--- a/packages/countries/src/__tests__/__e2e__/CountrySymbol.cy.tsx
+++ b/packages/countries/src/__tests__/__e2e__/CountrySymbol.cy.tsx
@@ -1,5 +1,5 @@
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../cypress/tests/checkAccessibility";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 import * as countrySymbolStory from "../../../stories/CountrySymbol.stories";
 
 const composedStories = composeStories(countrySymbolStory);

--- a/packages/countries/src/__tests__/__e2e__/LazyCountrySymbol.cy.tsx
+++ b/packages/countries/src/__tests__/__e2e__/LazyCountrySymbol.cy.tsx
@@ -1,5 +1,5 @@
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../cypress/tests/checkAccessibility";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 import * as countrySymbolStory from "../../../stories/LazyCountrySymbol.stories";
 
 const composedStories = composeStories(countrySymbolStory);

--- a/packages/date-components/src/__tests__/__e2e__/calendar/Calendar.a11y.cy.tsx
+++ b/packages/date-components/src/__tests__/__e2e__/calendar/Calendar.a11y.cy.tsx
@@ -2,10 +2,9 @@ import { AdapterDateFnsTZ } from "@salt-ds/date-adapters/date-fns-tz";
 import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
 import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
 import { AdapterMoment } from "@salt-ds/date-adapters/moment";
-
-import * as calendarStories from "@stories/calendar/calendar.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as calendarStories from "~stories/calendar/calendar.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(calendarStories);
 

--- a/packages/date-components/src/__tests__/__e2e__/calendar/Calendar.cy.tsx
+++ b/packages/date-components/src/__tests__/__e2e__/calendar/Calendar.cy.tsx
@@ -8,7 +8,7 @@ import {
   CalendarGrid,
   CalendarNavigation,
 } from "@salt-ds/date-components";
-import * as calendarStories from "@stories/calendar/calendar.stories";
+import * as calendarStories from "~stories/calendar/calendar.stories";
 import "moment/dist/locale/es";
 
 // Initialize adapters

--- a/packages/date-components/src/__tests__/__e2e__/calendar/Calendar.range.cy.tsx
+++ b/packages/date-components/src/__tests__/__e2e__/calendar/Calendar.range.cy.tsx
@@ -13,7 +13,7 @@ import {
   type DateRangeSelection,
 } from "@salt-ds/date-components";
 
-import * as dateInputStories from "@stories/calendar/calendar.stories";
+import * as dateInputStories from "~stories/calendar/calendar.stories";
 
 const {
   // Storybook wraps components in it's own LocalizationProvider, so do not compose Stories

--- a/packages/date-components/src/__tests__/__e2e__/calendar/Calendar.single.cy.tsx
+++ b/packages/date-components/src/__tests__/__e2e__/calendar/Calendar.single.cy.tsx
@@ -13,7 +13,7 @@ import {
   type SingleDateSelection,
 } from "@salt-ds/date-components";
 
-import * as dateInputStories from "@stories/calendar/calendar.stories";
+import * as dateInputStories from "~stories/calendar/calendar.stories";
 
 const {
   // Storybook wraps components in it's own LocalizationProvider, so do not compose Stories

--- a/packages/date-components/src/__tests__/__e2e__/date-input/DateInput.cy.tsx
+++ b/packages/date-components/src/__tests__/__e2e__/date-input/DateInput.cy.tsx
@@ -2,9 +2,9 @@ import { AdapterDateFns } from "@salt-ds/date-adapters/date-fns";
 import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
 import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
 import { AdapterMoment } from "@salt-ds/date-adapters/moment";
-import * as dateInputStories from "@stories/date-input/date-input.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as dateInputStories from "~stories/date-input/date-input.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(dateInputStories);
 

--- a/packages/date-components/src/__tests__/__e2e__/date-input/DateInputRange.cy.tsx
+++ b/packages/date-components/src/__tests__/__e2e__/date-input/DateInputRange.cy.tsx
@@ -15,9 +15,9 @@ import {
   type DateParserField,
   type DateRangeSelection,
 } from "@salt-ds/date-components";
-import * as dateInputStories from "@stories/date-input/date-input.stories";
 import { es as dateFnsEs } from "date-fns/locale";
 import { type ChangeEvent, type SyntheticEvent, useState } from "react";
+import * as dateInputStories from "~stories/date-input/date-input.stories";
 import "moment/dist/locale/es";
 import "dayjs/locale/es";
 

--- a/packages/date-components/src/__tests__/__e2e__/date-input/DateInputSingle.cy.tsx
+++ b/packages/date-components/src/__tests__/__e2e__/date-input/DateInputSingle.cy.tsx
@@ -10,9 +10,9 @@ import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
 import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
 import { AdapterMoment } from "@salt-ds/date-adapters/moment";
 import { DateInputSingle } from "@salt-ds/date-components";
-import * as dateInputStories from "@stories/date-input/date-input.stories";
 import { es as dateFnsEs } from "date-fns/locale";
 import { type ChangeEvent, type SyntheticEvent, useState } from "react";
+import * as dateInputStories from "~stories/date-input/date-input.stories";
 import "moment/dist/locale/es";
 import "dayjs/locale/es";
 

--- a/packages/date-components/src/__tests__/__e2e__/date-picker/DatePicker.cy.tsx
+++ b/packages/date-components/src/__tests__/__e2e__/date-picker/DatePicker.cy.tsx
@@ -2,9 +2,9 @@ import { AdapterDateFnsTZ } from "@salt-ds/date-adapters/date-fns-tz";
 import { AdapterDayjs } from "@salt-ds/date-adapters/dayjs";
 import { AdapterLuxon } from "@salt-ds/date-adapters/luxon";
 import { AdapterMoment } from "@salt-ds/date-adapters/moment";
-import * as datePickerStories from "@stories/date-picker/date-picker.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as datePickerStories from "~stories/date-picker/date-picker.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(datePickerStories);
 

--- a/packages/date-components/src/__tests__/__e2e__/date-picker/DatePicker.range.cy.tsx
+++ b/packages/date-components/src/__tests__/__e2e__/date-picker/DatePicker.range.cy.tsx
@@ -17,10 +17,10 @@ import {
   DatePickerRangePanel,
   DatePickerTrigger,
 } from "@salt-ds/date-components";
-import * as datePickerStories from "@stories/date-picker/date-picker.stories";
 import type { Dayjs } from "dayjs";
 import type { DateTime } from "luxon";
 import type { Moment } from "moment/moment";
+import * as datePickerStories from "~stories/date-picker/date-picker.stories";
 
 // Initialize adapters
 const adapterDateFnsTZ = new AdapterDateFnsTZ();

--- a/packages/date-components/src/__tests__/__e2e__/date-picker/DatePicker.single.cy.tsx
+++ b/packages/date-components/src/__tests__/__e2e__/date-picker/DatePicker.single.cy.tsx
@@ -16,10 +16,10 @@ import {
   DatePickerSingleInput,
   DatePickerTrigger,
 } from "@salt-ds/date-components";
-import * as datePickerStories from "@stories/date-picker/date-picker.stories";
 import type { Dayjs } from "dayjs";
 import type { DateTime } from "luxon";
 import type { Moment } from "moment";
+import * as datePickerStories from "~stories/date-picker/date-picker.stories";
 
 // Initialize adapters
 const adapterDateFnsTZ = new AdapterDateFnsTZ();

--- a/packages/date-components/stories/calendar/calendar-date-fns.qa.stories.tsx
+++ b/packages/date-components/stories/calendar/calendar-date-fns.qa.stories.tsx
@@ -2,7 +2,7 @@ import { Calendar } from "@salt-ds/date-components";
 import type { StoryFn } from "@storybook/react-vite";
 import { enUS as dateFnsEnUs } from "date-fns/locale";
 import type { QAContainerProps } from "docs/components";
-import { withDateMock } from "../../../../.storybook/decorators/withDateMock";
+import { withDateMock } from "~storybook-decorators/withDateMock";
 import { calendarQaStories } from "./calendar.qa.stories";
 
 const QAContainerParameters = {

--- a/packages/date-components/stories/calendar/calendar-day.qa.stories.tsx
+++ b/packages/date-components/stories/calendar/calendar-day.qa.stories.tsx
@@ -1,7 +1,7 @@
-import { withDateMock } from ".storybook/decorators/withDateMock";
 import { Calendar, useLocalization } from "@salt-ds/date-components";
 import type { StoryFn } from "@storybook/react-vite";
 import { QAContainer, type QAContainerProps } from "docs/components";
+import { withDateMock } from "~storybook-decorators/withDateMock";
 import { CalendarDay } from "../../src/calendar/internal/CalendarDay";
 import "./calendar.stories.css";
 

--- a/packages/date-components/stories/calendar/calendar-dayjs.qa.stories.tsx
+++ b/packages/date-components/stories/calendar/calendar-dayjs.qa.stories.tsx
@@ -1,7 +1,7 @@
 import { Calendar } from "@salt-ds/date-components";
 import type { StoryFn } from "@storybook/react-vite";
 import type { QAContainerProps } from "docs/components";
-import { withDateMock } from "../../../../.storybook/decorators/withDateMock";
+import { withDateMock } from "~storybook-decorators/withDateMock";
 import { calendarQaStories } from "./calendar.qa.stories";
 
 const QAContainerParameters = {

--- a/packages/date-components/stories/calendar/calendar-luxon.qa.stories.tsx
+++ b/packages/date-components/stories/calendar/calendar-luxon.qa.stories.tsx
@@ -1,7 +1,7 @@
 import { Calendar } from "@salt-ds/date-components";
 import type { StoryFn } from "@storybook/react-vite";
 import type { QAContainerProps } from "docs/components";
-import { withDateMock } from "../../../../.storybook/decorators/withDateMock";
+import { withDateMock } from "~storybook-decorators/withDateMock";
 import { calendarQaStories } from "./calendar.qa.stories";
 
 const QAContainerParameters = {

--- a/packages/date-components/stories/calendar/calendar-moment.qa.stories.tsx
+++ b/packages/date-components/stories/calendar/calendar-moment.qa.stories.tsx
@@ -1,7 +1,7 @@
 import { Calendar } from "@salt-ds/date-components";
 import type { StoryFn } from "@storybook/react-vite";
 import type { QAContainerProps } from "docs/components";
-import { withDateMock } from "../../../../.storybook/decorators/withDateMock";
+import { withDateMock } from "~storybook-decorators/withDateMock";
 import { calendarQaStories } from "./calendar.qa.stories";
 
 const QAContainerParameters = {

--- a/packages/date-components/stories/calendar/calendar.qa.stories.tsx
+++ b/packages/date-components/stories/calendar/calendar.qa.stories.tsx
@@ -1,4 +1,3 @@
-import { withDateMock } from ".storybook/decorators/withDateMock";
 import {
   Calendar,
   CalendarGrid,
@@ -6,6 +5,7 @@ import {
   useLocalization,
 } from "@salt-ds/date-components";
 import { QAContainer, type QAContainerProps } from "docs/components";
+import { withDateMock } from "~storybook-decorators/withDateMock";
 
 export default {
   title: "Date Components/Calendar/QA",

--- a/packages/date-components/stories/calendar/calendar.stories.tsx
+++ b/packages/date-components/stories/calendar/calendar.stories.tsx
@@ -43,10 +43,10 @@ import "./calendar.stories.css";
 import "dayjs/locale/es"; // Import the Spanish locale
 import { es as dateFnsEs } from "date-fns/locale";
 import "moment/dist/locale/es";
-import { withDateMock } from ".storybook/decorators/withDateMock";
 import type { Dayjs } from "dayjs";
 import type { DateTime } from "luxon";
 import type { Moment } from "moment/moment";
+import { withDateMock } from "~storybook-decorators/withDateMock";
 
 export default {
   title: "Date Components/Calendar",

--- a/packages/date-components/stories/date-input/date-input.qa.stories.tsx
+++ b/packages/date-components/stories/date-input/date-input.qa.stories.tsx
@@ -1,4 +1,3 @@
-import { withDateMock } from ".storybook/decorators/withDateMock";
 import {
   DateInputRange,
   DateInputSingle,
@@ -7,6 +6,7 @@ import {
 import type { StoryFn } from "@storybook/react-vite";
 import { enUS as dateFnsEnUs } from "date-fns/locale";
 import { QAContainer, type QAContainerProps } from "docs/components";
+import { withDateMock } from "~storybook-decorators/withDateMock";
 
 export default {
   title: "Date Components/Date Input/QA",

--- a/packages/date-components/stories/date-input/date-input.stories.tsx
+++ b/packages/date-components/stories/date-input/date-input.stories.tsx
@@ -1,4 +1,3 @@
-import { withDateMock } from ".storybook/decorators/withDateMock";
 import {
   Button,
   Dropdown,
@@ -28,6 +27,7 @@ import {
 import type { Meta, StoryFn } from "@storybook/react-vite";
 import { type SyntheticEvent, useCallback, useEffect, useState } from "react";
 import { fn } from "storybook/test";
+import { withDateMock } from "~storybook-decorators/withDateMock";
 
 export default {
   title: "Date Components/Date Input",

--- a/packages/date-components/stories/date-picker/date-picker-range.qa.stories.tsx
+++ b/packages/date-components/stories/date-picker/date-picker-range.qa.stories.tsx
@@ -13,11 +13,11 @@ import type { StoryFn } from "@storybook/react-vite";
 import { enUS as dateFnsEnUs, es as dateFnsEs } from "date-fns/locale";
 import { QAContainer, type QAContainerProps } from "docs/components";
 import "dayjs/locale/es";
-import { withDateMock } from ".storybook/decorators/withDateMock";
 import type { DateFrameworkType } from "@salt-ds/date-adapters";
 import type { Dayjs } from "dayjs";
 import type { DateTime } from "luxon";
 import type { Moment } from "moment";
+import { withDateMock } from "~storybook-decorators/withDateMock";
 
 export default {
   title: "Date Components/Date Picker/QA",

--- a/packages/date-components/stories/date-picker/date-picker-single.qa.stories.tsx
+++ b/packages/date-components/stories/date-picker/date-picker-single.qa.stories.tsx
@@ -11,11 +11,11 @@ import type { StoryFn } from "@storybook/react-vite";
 import { enUS as dateFnsEnUs, es as dateFnsEs } from "date-fns/locale";
 import { QAContainer, type QAContainerProps } from "docs/components";
 import "dayjs/locale/es";
-import { withDateMock } from ".storybook/decorators/withDateMock";
 import type { DateFrameworkType } from "@salt-ds/date-adapters";
 import type { Dayjs } from "dayjs";
 import type { DateTime } from "luxon";
 import type { Moment } from "moment/moment";
+import { withDateMock } from "~storybook-decorators/withDateMock";
 
 export default {
   title: "Date Components/Date Picker/QA",

--- a/packages/date-components/stories/date-picker/date-picker.stories.tsx
+++ b/packages/date-components/stories/date-picker/date-picker.stories.tsx
@@ -70,10 +70,10 @@ import "dayjs/locale/es";
 import "dayjs/locale/zh-cn";
 import { es as dateFnsEs, zhCN as dateFnsZhCn } from "date-fns/locale";
 import "./date-picker.stories.css";
-import { withDateMock } from ".storybook/decorators/withDateMock";
 import type { Dayjs } from "dayjs";
 import type { DateTime } from "luxon";
 import type { Moment } from "moment/moment";
+import { withDateMock } from "~storybook-decorators/withDateMock";
 
 export default {
   title: "Date Components/Date Picker",

--- a/packages/embla-carousel/src/__tests__/__e2e__/Carousel.accessibility.cy.tsx
+++ b/packages/embla-carousel/src/__tests__/__e2e__/Carousel.accessibility.cy.tsx
@@ -1,6 +1,6 @@
-import * as carouselStories from "@stories/carousel.stories";
 import { composeStories } from "@storybook/react";
-import { checkAccessibility } from "../../../../../cypress/tests/checkAccessibility";
+import * as carouselStories from "~stories/carousel.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(carouselStories);
 

--- a/packages/embla-carousel/src/__tests__/__e2e__/Carousel.cy.tsx
+++ b/packages/embla-carousel/src/__tests__/__e2e__/Carousel.cy.tsx
@@ -1,7 +1,7 @@
-import * as carouselStories from "@stories/carousel.stories";
 import { composeStories } from "@storybook/react-vite";
 import ClassNames from "embla-carousel-class-names";
 import { useEffect, useState } from "react";
+import * as carouselStories from "~stories/carousel.stories";
 import type { CarouselEmblaApiType } from "../../index";
 
 const composedStories = composeStories(carouselStories);

--- a/packages/embla-carousel/stories/renderSlides.tsx
+++ b/packages/embla-carousel/stories/renderSlides.tsx
@@ -1,10 +1,10 @@
 import { H3, Link, Text, useId } from "@salt-ds/core";
 import { CarouselCard } from "@salt-ds/embla-carousel";
 
-import carouselSlide1 from "@stories/assets/carouselSlide1.png";
-import carouselSlide2 from "@stories/assets/carouselSlide2.png";
-import carouselSlide3 from "@stories/assets/carouselSlide3.png";
-import carouselSlide4 from "@stories/assets/carouselSlide4.png";
+import carouselSlide1 from "~stories/assets/carouselSlide1.png";
+import carouselSlide2 from "~stories/assets/carouselSlide2.png";
+import carouselSlide3 from "~stories/assets/carouselSlide3.png";
+import carouselSlide4 from "~stories/assets/carouselSlide4.png";
 
 export const renderSlides = ({
   withActions,

--- a/packages/icons/src/__tests__/__e2e__/Icon.cy.tsx
+++ b/packages/icons/src/__tests__/__e2e__/Icon.cy.tsx
@@ -1,5 +1,5 @@
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../cypress/tests/checkAccessibility";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 import * as iconStory from "../../../stories/icon.stories";
 
 const composedStories = composeStories(iconStory);

--- a/packages/lab/src/__tests__/__e2e__/cascading-menu/CascadingMenu.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/cascading-menu/CascadingMenu.cy.tsx
@@ -1,6 +1,6 @@
-import * as cascadingMenuStories from "@stories/cascading-menu/cascading-menu.stories";
 import { composeStories } from "@storybook/react-vite";
 import { version } from "react";
+import * as cascadingMenuStories from "~stories/cascading-menu/cascading-menu.stories";
 
 const { Default } = composeStories(cascadingMenuStories);
 

--- a/packages/lab/src/__tests__/__e2e__/combo-box-deprecated/ComboBox.accessibility.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/combo-box-deprecated/ComboBox.accessibility.cy.tsx
@@ -1,5 +1,5 @@
-import * as comboBoxStories from "@stories/combobox/combobox-deprecated.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as comboBoxStories from "~stories/combobox/combobox-deprecated.stories";
 
 const {
   Default,

--- a/packages/lab/src/__tests__/__e2e__/combo-box-deprecated/ComboBox.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/combo-box-deprecated/ComboBox.cy.tsx
@@ -1,5 +1,5 @@
-import * as comboBoxStories from "@stories/combobox/combobox-deprecated.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as comboBoxStories from "~stories/combobox/combobox-deprecated.stories";
 
 const {
   Default,

--- a/packages/lab/src/__tests__/__e2e__/combo-box-deprecated/ComboBox.keyboardNavigation.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/combo-box-deprecated/ComboBox.keyboardNavigation.cy.tsx
@@ -1,6 +1,6 @@
-import * as comboBoxStories from "@stories/combobox/combobox-deprecated.stories";
 import { composeStories } from "@storybook/react-vite";
 import { version } from "react";
+import * as comboBoxStories from "~stories/combobox/combobox-deprecated.stories";
 
 const {
   Default,

--- a/packages/lab/src/__tests__/__e2e__/combo-box-deprecated/ComboBox.selection.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/combo-box-deprecated/ComboBox.selection.cy.tsx
@@ -1,5 +1,5 @@
-import * as comboBoxStories from "@stories/combobox/combobox-deprecated.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as comboBoxStories from "~stories/combobox/combobox-deprecated.stories";
 
 const { Default, MultiSelect } = composeStories(comboBoxStories);
 

--- a/packages/lab/src/__tests__/__e2e__/combo-box/ComboBox.accessibility.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/combo-box/ComboBox.accessibility.cy.tsx
@@ -1,5 +1,5 @@
-import * as comboBoxStories from "@stories/combobox/combobox.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as comboBoxStories from "~stories/combobox/combobox.stories";
 
 const {
   Default,

--- a/packages/lab/src/__tests__/__e2e__/combo-box/ComboBox.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/combo-box/ComboBox.cy.tsx
@@ -1,5 +1,5 @@
-import * as comboBoxStories from "@stories/combobox/combobox.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as comboBoxStories from "~stories/combobox/combobox.stories";
 
 const {
   Default,

--- a/packages/lab/src/__tests__/__e2e__/combo-box/ComboBox.keyboardNavigation.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/combo-box/ComboBox.keyboardNavigation.cy.tsx
@@ -1,5 +1,5 @@
-import * as comboBoxStories from "@stories/combobox/combobox.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as comboBoxStories from "~stories/combobox/combobox.stories";
 
 const {
   Default,

--- a/packages/lab/src/__tests__/__e2e__/combo-box/ComboBox.selection.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/combo-box/ComboBox.selection.cy.tsx
@@ -1,5 +1,5 @@
-import * as comboBoxStories from "@stories/combobox/combobox.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as comboBoxStories from "~stories/combobox/combobox.stories";
 
 const { Default /*, MultiSelect*/ } = composeStories(comboBoxStories);
 

--- a/packages/lab/src/__tests__/__e2e__/deck-layout/DeckLayout.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/deck-layout/DeckLayout.cy.tsx
@@ -1,6 +1,6 @@
-import * as deckStories from "@stories/deck-layout/deck-layout.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as deckStories from "~stories/deck-layout/deck-layout.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(deckStories);
 const { Default } = composedStories;

--- a/packages/lab/src/__tests__/__e2e__/layer-layout/LayerLayout.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/layer-layout/LayerLayout.cy.tsx
@@ -1,5 +1,5 @@
-import * as layerStories from "@stories/layer-layout/layer-layout.stories";
 import { composeStories } from "@storybook/react-vite";
+import * as layerStories from "~stories/layer-layout/layer-layout.stories";
 
 const composedStories = composeStories(layerStories);
 

--- a/packages/lab/src/__tests__/__e2e__/system-status/SystemStatus.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/system-status/SystemStatus.cy.tsx
@@ -1,7 +1,7 @@
 import { SystemStatus, SystemStatusContent } from "@salt-ds/lab";
-import * as systemStatusStories from "@stories/system-status/system-status.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as systemStatusStories from "~stories/system-status/system-status.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(systemStatusStories);
 // biome-ignore lint/suspicious/noShadowRestrictedNames: Error is the story name.

--- a/packages/lab/src/__tests__/__e2e__/toast-group/ToastGroup.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/toast-group/ToastGroup.cy.tsx
@@ -1,9 +1,9 @@
 import { Button, Toast, ToastContent } from "@salt-ds/core";
 import { CloseIcon } from "@salt-ds/icons";
 import { ToastGroup } from "@salt-ds/lab";
-import * as toastGroupStories from "@stories/toast-group/toast-group.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as toastGroupStories from "~stories/toast-group/toast-group.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(toastGroupStories);
 

--- a/packages/lab/src/__tests__/__e2e__/tokenized-input-next/TokenizedInputNext.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/tokenized-input-next/TokenizedInputNext.cy.tsx
@@ -1,6 +1,6 @@
-import * as tokenizedInputNextStories from "@stories/tokenized-input-next/tokenized-input-next.stories";
 import { composeStories } from "@storybook/react-vite";
-import { checkAccessibility } from "../../../../../../cypress/tests/checkAccessibility";
+import * as tokenizedInputNextStories from "~stories/tokenized-input-next/tokenized-input-next.stories";
+import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(tokenizedInputNextStories);
 

--- a/packages/lab/stories/toast-group/toast-group.stories.tsx
+++ b/packages/lab/stories/toast-group/toast-group.stories.tsx
@@ -1,4 +1,3 @@
-import { withDateMock } from ".storybook/decorators/withDateMock";
 import {
   Button,
   FlowLayout,
@@ -11,6 +10,7 @@ import { CloseIcon } from "@salt-ds/icons";
 import { ToastGroup } from "@salt-ds/lab";
 import type { Meta } from "@storybook/react-vite";
 import { Fragment, type ReactNode, useState } from "react";
+import { withDateMock } from "~storybook-decorators/withDateMock";
 
 export default {
   title: "Lab/Toast Group",

--- a/tooling/typescript-turbosnap/package.json
+++ b/tooling/typescript-turbosnap/package.json
@@ -8,6 +8,6 @@
     "ts-morph": "^27.0.0"
   },
   "peerDependencies": {
-    "vite": "^7.1.11"
+    "vite": "^8.0.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,9 @@
     "noImplicitAny": true,
     "jsx": "react-jsx",
     "paths": {
-      ".storybook/*": ["./.storybook/*"],
-      "@stories/*": [
+      "~storybook-decorators/*": ["./.storybook/decorators/*"],
+      "~test-utils/*": ["./cypress/tests/*"],
+      "~stories/*": [
         "./packages/ag-grid-theme/stories/*",
         "./packages/core/stories/*",
         "./packages/date-components/stories/*",
@@ -30,8 +31,7 @@
       ],
       "@salt-ds/date-adapters/*": [
         "./packages/date-adapters/src/*-adapter/index.ts"
-      ],
-      "packages/*": ["./packages/*"]
+      ]
     },
     "types": [
       "cypress",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,10 @@
-import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  plugins: [tsconfigPaths()],
   test: {
     include: ["**/*.spec.[jt]s?(x)"],
+  },
+  resolve: {
+    tsconfigPaths: true,
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1900,9 +1900,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cypress/request@npm:^3.0.10":
-  version: 3.0.10
-  resolution: "@cypress/request@npm:3.0.10"
+"@cypress/request@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "@cypress/request@npm:4.0.1"
   dependencies:
     aws-sign2: "npm:~0.7.0"
     aws4: "npm:^1.8.0"
@@ -1917,12 +1917,11 @@ __metadata:
     json-stringify-safe: "npm:~5.0.1"
     mime-types: "npm:~2.1.19"
     performance-now: "npm:^2.1.0"
-    qs: "npm:~6.14.1"
+    qs: "npm:^6.15.2"
     safe-buffer: "npm:^5.1.2"
     tough-cookie: "npm:^5.0.0"
     tunnel-agent: "npm:^0.6.0"
-    uuid: "npm:^8.3.2"
-  checksum: 10/23c86075f5fbbd4a56403cb98dbce92b2bc33cbb0ec5779d7cb45c9ad50b5d056ff73037f11680842bb2bc4f2b79b995d91880ca7e9a893b8be650d93fad2e33
+  checksum: 10/7facc78b2940f5f7d12bc1f31c07fbf78bb71ce32c304551fccd265c77f564f093c3a1dd871048d744525f84013ae291de7654c93ffcbec54cab2a0b15e0d20f
   languageName: node
   linkType: hard
 
@@ -1947,7 +1946,7 @@ __metadata:
   version: 0.20.3
   resolution: "@e965/xlsx@npm:0.20.3"
   bin:
-    xlsx: ./bin/xlsx.njs
+    xlsx: bin/xlsx.njs
   checksum: 10/0e92ca7622a7dc4de0b4f8f4b9b506c5e1dbd511cd759b27bf3131a3da877f33b15f446e628739ce265457486c617ac60416db2fd03415dc8b0f20150ef67e22
   languageName: node
   linkType: hard
@@ -1972,6 +1971,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:2.0.0-alpha.3":
+  version: 2.0.0-alpha.3
+  resolution: "@emnapi/core@npm:2.0.0-alpha.3"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:2.0.1"
+    tslib: "npm:^2.4.0"
+  checksum: 10/cd71d0af78c858daf14d378d960922ac9a00e108401c76d852fe467916fd5ac8d5575303a14c73d24eaed8dc626464f2a29f2905542b9a457e4b90a6ed519008
+  languageName: node
+  linkType: hard
+
 "@emnapi/runtime@npm:1.10.0, @emnapi/runtime@npm:^1.7.0":
   version: 1.10.0
   resolution: "@emnapi/runtime@npm:1.10.0"
@@ -1990,12 +1999,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/runtime@npm:2.0.0-alpha.3":
+  version: 2.0.0-alpha.3
+  resolution: "@emnapi/runtime@npm:2.0.0-alpha.3"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/f5acb0f51e225b18f4aba6223016e3628d23a05f90ef4be11f7a25b09e0c8b285350f095818e087946945b696127286a50a57f7aaf94d420e6116f5e2101c531
+  languageName: node
+  linkType: hard
+
 "@emnapi/wasi-threads@npm:1.2.1":
   version: 1.2.1
   resolution: "@emnapi/wasi-threads@npm:1.2.1"
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10/57cd4292be81c05d26aa886d68a9e4c449ff666e8503fed6463dfc6b64a4e4213f03c152d53296b7cda32840271e38cd33347332070658f01befeb9bf4e59f36
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@emnapi/wasi-threads@npm:2.0.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/91dbd7d2ec4ebe01e0e889d9d4d6b79a2a3180ed61e2bdc537c2f7dcb026ac2f8d54126a0966bbcf6fc714f834638d40462c6c9a9bcfb35ee2a7b9897cd06877
   languageName: node
   linkType: hard
 
@@ -2709,7 +2736,7 @@ __metadata:
     md5: "npm:*"
     mkdirp: "npm:^1.0.4"
   bin:
-    mosaic: ./dist/index.mjs
+    mosaic: dist/index.mjs
   checksum: 10/3d05c1d56e574fb1dd7d9d0ca9e7f66ce5d11e3d8382d6e04bb8ad73c01e2281c2cafd3e810538b4ccfb3d1290cc0e0efd6d60cd69a84665b5fe4711f6144240
   languageName: node
   linkType: hard
@@ -3537,15 +3564,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/wasm-runtime@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "@napi-rs/wasm-runtime@npm:1.1.4"
+"@napi-rs/wasm-runtime@npm:^1.1.4, @napi-rs/wasm-runtime@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "@napi-rs/wasm-runtime@npm:1.2.1"
   dependencies:
-    "@tybys/wasm-util": "npm:^0.10.1"
+    "@tybys/wasm-util": "npm:^0.10.3"
   peerDependencies:
-    "@emnapi/core": ^1.7.1
-    "@emnapi/runtime": ^1.7.1
-  checksum: 10/1db3dc7eeb981306b09360487bd8ce4dfa5588d273bd8ea9f07dccca1b4ade57b675414180fc9bb66966c6c50b17208b0263194993e2f7f92cc7af28bda4d1af
+    "@emnapi/core": ^1.7.1 || ^2.0.0-alpha.3
+    "@emnapi/runtime": ^1.7.1 || ^2.0.0-alpha.3
+  checksum: 10/be5045244f03460f6141d2241b6bbbd8ba280ea9cda5aed7ae855bf6ca4b60eaaf43a7133486a0ecdec7c1a24334106bbf03968582736ad2e5c26121e2b8e098
   languageName: node
   linkType: hard
 
@@ -3836,6 +3863,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-project/types@npm:=0.142.0":
+  version: 0.142.0
+  resolution: "@oxc-project/types@npm:0.142.0"
+  checksum: 10/490ea98f11955763f3baad4fe0b8dc5cafff4be465fdbc1d1685ef5be3ac686781894536de8ca02dc5d4b62b36bcbd98a4401c728786df1190f7a8fc5495287b
+  languageName: node
+  linkType: hard
+
 "@oxc-project/types@npm:^0.127.0":
   version: 0.127.0
   resolution: "@oxc-project/types@npm:0.127.0"
@@ -4001,7 +4035,116 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/pluginutils@npm:^1.0.0":
+"@rolldown/binding-android-arm64@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-android-arm64@npm:1.2.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-arm64@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.2.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-x64@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-darwin-x64@npm:1.2.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-freebsd-x64@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.2.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.2.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-gnu@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.2.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-musl@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.2.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-ppc64-gnu@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.2.1"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-s390x-gnu@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.2.1"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-gnu@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.2.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-musl@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.2.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-openharmony-arm64@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.2.1"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-wasm32-wasi@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-wasm32-wasi@npm:1.2.1"
+  dependencies:
+    "@emnapi/core": "npm:2.0.0-alpha.3"
+    "@emnapi/runtime": "npm:2.0.0-alpha.3"
+    "@napi-rs/wasm-runtime": "npm:^1.2.0"
+  checksum: 10/230cb2f4d2a1dad5ae2c70ef5073c6a21d5fce3fd38cde49c80fd2e22f656807db69622830fa9dbf9c071bc37f705f2a5aca84d1dadccd0c32dbf5c0f9eea4ec
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-arm64-msvc@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.2.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-x64-msvc@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.2.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/pluginutils@npm:^1.0.0, @rolldown/pluginutils@npm:^1.0.1":
   version: 1.0.1
   resolution: "@rolldown/pluginutils@npm:1.0.1"
   checksum: 10/4e95cf9ce23d75e5aa03ea0249cd86f7d1e21f83fbf6f8520e4edd8a251ba1b82c4ba9bc13cd24b6c4661daec6225b06e6d35c64c604e731b230b2a49af47d05
@@ -4492,16 +4635,16 @@ __metadata:
     "@types/react-dom": "npm:^18.3.7"
     "@types/tinycolor2": "npm:^1.4.3"
     "@typescript/native-preview": "npm:7.0.0-dev.20260601.1"
-    "@vitejs/plugin-react": "npm:^6.0.2"
+    "@vitejs/plugin-react": "npm:^6.0.4"
     ag-grid-community: "npm:^32.0.0"
     ag-grid-enterprise: "npm:^32.0.0"
     ag-grid-react: "npm:^32.0.0"
-    axe-core: "npm:^4.11.2"
+    axe-core: "npm:^4.12.1"
     browserslist-to-esbuild: "npm:^2.1.1"
     chromatic: "npm:^18.0.0"
     ci-info: "npm:^4.0.0"
     clsx: "npm:^2.0.0"
-    cypress: "npm:15.10.0"
+    cypress: "npm:^15.17.0"
     cypress-axe: "npm:^1.7.0"
     cypress-real-events: "npm:^1.15.0"
     deepmerge: "npm:^4.2.2"
@@ -4526,8 +4669,8 @@ __metadata:
     storybook: "npm:10.5.3"
     stylelint: "npm:^17.0.0"
     typescript: "npm:^6.0.0"
-    vite: "npm:^8.0.14"
-    vitest: "npm:^4.1.7"
+    vite: "npm:^8.2.0"
+    vitest: "npm:^4.1.10"
     yup: "npm:^1.7.1"
   dependenciesMeta:
     cypress:
@@ -6348,12 +6491,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tybys/wasm-util@npm:^0.10.1":
-  version: 0.10.2
-  resolution: "@tybys/wasm-util@npm:0.10.2"
+"@tybys/wasm-util@npm:^0.10.3":
+  version: 0.10.3
+  resolution: "@tybys/wasm-util@npm:0.10.3"
   dependencies:
     tslib: "npm:^2.4.0"
-  checksum: 10/d12f1dafe12d7a573c406b35ffef0038042b9cc9fbcc74d657267eb635499b956276afc05eebdbd81bea582e1c4c921421a1dd7243a93daaa8c8216b19395c23
+  checksum: 10/6cf39f7a2926b1c8bc6fe3f9f03318a33dd6dae81bdbd059983f9c6ee22d10a827f12564d648c05a2d4926e03c86cbe2799fb20609ee65e9efc39603039b4765
   languageName: node
   linkType: hard
 
@@ -6547,19 +6690,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^24.0.0":
+"@types/node@npm:^12.7.1":
+  version: 12.20.46
+  resolution: "@types/node@npm:12.20.46"
+  checksum: 10/c5347aa669ff439e9177a2799d0bc464d8533e4fb07f2ec112be118adf2668bf29b4fef153f9639550f190c84c8e96afcf96a04309af42e49754b42578cf1572
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^24.0.0":
   version: 24.10.1
   resolution: "@types/node@npm:24.10.1"
   dependencies:
     undici-types: "npm:~7.16.0"
   checksum: 10/ddac8c97be5f7401e31ea0e9316c6e864993c6cd06689b7f9874ecfb576ef8349f2d14298248a08b94a6dd029570a46a285cddc4d50e524817f1a3730b29a86e
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^12.7.1":
-  version: 12.20.46
-  resolution: "@types/node@npm:12.20.46"
-  checksum: 10/c5347aa669ff439e9177a2799d0bc464d8533e4fb07f2ec112be118adf2668bf29b4fef153f9639550f190c84c8e96afcf96a04309af42e49754b42578cf1572
   languageName: node
   linkType: hard
 
@@ -6726,15 +6869,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/yauzl@npm:^2.9.1":
-  version: 2.9.2
-  resolution: "@types/yauzl@npm:2.9.2"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10/dfb49abe82605615712fc694eaa4f7068fe30aa03f38c085e2c2e74408beaad30471d36da9654a811482ece2ea4405575fd99b19c0aa327ed2a9736b554bbf43
-  languageName: node
-  linkType: hard
-
 "@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260601.1":
   version: 7.0.0-dev.20260601.1
   resolution: "@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260601.1"
@@ -6811,7 +6945,7 @@ __metadata:
     "@typescript/native-preview-win32-x64":
       optional: true
   bin:
-    tsgo: ./bin/tsgo.js
+    tsgo: bin/tsgo.js
   checksum: 10/b765917a1f5861ca45a43d53c85401a82e3d523deaee7e232ee7d2e18590556c5e501c5d48871332e558af7aca1b4d3878d790aca885e6b9caa534eac7928412
   languageName: node
   linkType: hard
@@ -6874,11 +7008,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-react@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "@vitejs/plugin-react@npm:6.0.2"
+"@vitejs/plugin-react@npm:^6.0.4":
+  version: 6.0.4
+  resolution: "@vitejs/plugin-react@npm:6.0.4"
   dependencies:
-    "@rolldown/pluginutils": "npm:^1.0.0"
+    "@rolldown/pluginutils": "npm:^1.0.1"
   peerDependencies:
     "@rolldown/plugin-babel": ^0.1.7 || ^0.2.0
     babel-plugin-react-compiler: ^1.0.0
@@ -6888,7 +7022,7 @@ __metadata:
       optional: true
     babel-plugin-react-compiler:
       optional: true
-  checksum: 10/4b3693e94c1907aac699df34fa71c8d5d53228b110f7520dcaca56c96c7127772e806147fa9d2f15edfc64cdefbe13b28c4c71e058601f7311d303ad435701c6
+  checksum: 10/f8995d3c543d6e554f7c71003f7d849529a148f3d0182a23fa3073a698847bf6618369b46799da785935086289721c612d666613da554b33a540108a0f6e249e
   languageName: node
   linkType: hard
 
@@ -6905,25 +7039,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/expect@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/expect@npm:4.1.7"
+"@vitest/expect@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/expect@npm:4.1.10"
   dependencies:
     "@standard-schema/spec": "npm:^1.1.0"
     "@types/chai": "npm:^5.2.2"
-    "@vitest/spy": "npm:4.1.7"
-    "@vitest/utils": "npm:4.1.7"
+    "@vitest/spy": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
     chai: "npm:^6.2.2"
     tinyrainbow: "npm:^3.1.0"
-  checksum: 10/a609af6c0497cd510ce8aed099f18faf6d6642bc8eb3432b688f2b39d7354a04d1c4ee9dc28bcfb9d4be701ceac88384d586592a520a324b3773ea43e8a1e677
+  checksum: 10/487fcad404a68968a54ae5fb9d099f12170cd793420a04b34a5606516317090c50a8303ab687c70166ee181864e3e138941d4a96d0405434dcd37696b3105350
   languageName: node
   linkType: hard
 
-"@vitest/mocker@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/mocker@npm:4.1.7"
+"@vitest/mocker@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/mocker@npm:4.1.10"
   dependencies:
-    "@vitest/spy": "npm:4.1.7"
+    "@vitest/spy": "npm:4.1.10"
     estree-walker: "npm:^3.0.3"
     magic-string: "npm:^0.30.21"
   peerDependencies:
@@ -6934,7 +7068,7 @@ __metadata:
       optional: true
     vite:
       optional: true
-  checksum: 10/124d0ec9cc099fde1fca4b065b81a389e9ba2204ecba9729751a0a022d0ffaa34609d9dc60c1f8494ee972c2209035a4476ff1dddc1790e07d1ca28a1103b30d
+  checksum: 10/ae9645d1bcdad3ab7de7182feb4f1c9148a5ff97cef19581eec9257112aace94889eee9a1ad12e40ce59453ac05f52453b5fdb49ff76a31af8ccdbaaa4471ef3
   languageName: node
   linkType: hard
 
@@ -6947,34 +7081,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/pretty-format@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/pretty-format@npm:4.1.7"
+"@vitest/pretty-format@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/pretty-format@npm:4.1.10"
   dependencies:
     tinyrainbow: "npm:^3.1.0"
-  checksum: 10/79c86c39173577250955744c3444d8c0c9304c95c7d351b91a916229252c3733a0e969741a8f3441a5c4777b5a4371707ecb747ea4bfd2c07e72ddf1ef621293
+  checksum: 10/e4f6907143ab0e40dda29d70b17027586c92921d622091321f10512e660b3995dcee7aa56e17b750b72560f295e25f96035372348415f18ebfd39b66a55b4704
   languageName: node
   linkType: hard
 
-"@vitest/runner@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/runner@npm:4.1.7"
+"@vitest/runner@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/runner@npm:4.1.10"
   dependencies:
-    "@vitest/utils": "npm:4.1.7"
+    "@vitest/utils": "npm:4.1.10"
     pathe: "npm:^2.0.3"
-  checksum: 10/429f1e0cc93f66a681d8acc816e21ac41258b07550f9139d004aab103bb06be53e3d91fc66886cef1ba1460a120f5fe4b12d6fe32dafdb1b06740dd119d70f7e
+  checksum: 10/2c962cb13af0880990036808a35679b7ac6657c8f542490234c2faa6ffd2ab080ac6bf21b487c64d84aa635cfb37b49eb679098c2003a100dfc6c4d5e87bf055
   languageName: node
   linkType: hard
 
-"@vitest/snapshot@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/snapshot@npm:4.1.7"
+"@vitest/snapshot@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/snapshot@npm:4.1.10"
   dependencies:
-    "@vitest/pretty-format": "npm:4.1.7"
-    "@vitest/utils": "npm:4.1.7"
+    "@vitest/pretty-format": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
     magic-string: "npm:^0.30.21"
     pathe: "npm:^2.0.3"
-  checksum: 10/ef7001add6724c025772891616338e6081ecdb11a92c084ca1d09c4662cf632e5877bec4cb38056aabc311f29fbe149c89fbf332975829087f3817554fe92cde
+  checksum: 10/7940d83ffd2fbebf9a04ea31e196b7e8bf981093ec739950959fe8dd29caa33c80823780fb4b1063d9459c44a0a8d8b2748c00dfb6941becd7404e6d687eea01
   languageName: node
   linkType: hard
 
@@ -6987,10 +7121,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/spy@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/spy@npm:4.1.7"
-  checksum: 10/49a9959c615f45ec593379a6d1a238190d08524857a6c4819b724134ce8a1a96d94e20144723d245941ce1ada54d8b00552573810d629880ecb8c3ff03b6d1ad
+"@vitest/spy@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/spy@npm:4.1.10"
+  checksum: 10/7c1b79a95474338e0659f0f2e43be4df1ef7939ff5b37b044954e0287582947803bd417508f44a7f244809672309d9b3dd67660b704ec3fe7f323cc958ae47a3
   languageName: node
   linkType: hard
 
@@ -7005,14 +7139,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/utils@npm:4.1.7":
-  version: 4.1.7
-  resolution: "@vitest/utils@npm:4.1.7"
+"@vitest/utils@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/utils@npm:4.1.10"
   dependencies:
-    "@vitest/pretty-format": "npm:4.1.7"
+    "@vitest/pretty-format": "npm:4.1.10"
     convert-source-map: "npm:^2.0.0"
     tinyrainbow: "npm:^3.1.0"
-  checksum: 10/9cc729618dade24de3ad6862c288c22e9daac3fda5cae0abc9b6ce87035cc8e7efa2b66c3c124ae08beef462b36761b062e792bbc619798b832a7ea9382ed12a
+  checksum: 10/95484aad55c7b00bbcd4963e27cbb86fe207620a6093973d68da9d0a06bad37c388d84c9ab43d5f35d88e46c8f376a5592d9c54c025c958361160f4802bb25ee
   languageName: node
   linkType: hard
 
@@ -7127,16 +7261,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aggregate-error@npm:^3.0.0":
-  version: 3.1.0
-  resolution: "aggregate-error@npm:3.1.0"
-  dependencies:
-    clean-stack: "npm:^2.0.0"
-    indent-string: "npm:^4.0.0"
-  checksum: 10/1101a33f21baa27a2fa8e04b698271e64616b886795fd43c31068c07533c7b3facfcaf4e9e0cab3624bd88f729a592f1c901a1a229c9e490eafce411a8644b79
-  languageName: node
-  linkType: hard
-
 "ahocorasick@npm:1.0.2":
   version: 1.0.2
   resolution: "ahocorasick@npm:1.0.2"
@@ -7177,12 +7301,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-escapes@npm:^4.3.0, ansi-escapes@npm:^4.3.2":
+"ansi-escapes@npm:^4.3.2":
   version: 4.3.2
   resolution: "ansi-escapes@npm:4.3.2"
   dependencies:
     type-fest: "npm:^0.21.3"
   checksum: 10/8661034456193ffeda0c15c8c564a9636b0c04094b7f78bd01517929c17c504090a60f7a75f949f5af91289c264d3e1001d91492c1bd58efc8e100500ce04de2
+  languageName: node
+  linkType: hard
+
+"ansi-escapes@npm:^7.0.0":
+  version: 7.3.0
+  resolution: "ansi-escapes@npm:7.3.0"
+  dependencies:
+    environment: "npm:^1.0.0"
+  checksum: 10/189e23e75aacf00ee647ba0545687456cc4bc62547dd0cf6c7728f91fce88854c8e885d5819a278b39981bb846d9427693d2380c562aecdb0cf91d3342141e93
   languageName: node
   linkType: hard
 
@@ -7216,10 +7349,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^6.1.0":
-  version: 6.2.1
-  resolution: "ansi-styles@npm:6.2.1"
-  checksum: 10/70fdf883b704d17a5dfc9cde206e698c16bcd74e7f196ab821511651aee4f9f76c9514bdfa6ca3a27b5e49138b89cb222a28caf3afe4567570139577f991df32
+"ansi-styles@npm:^6.1.0, ansi-styles@npm:^6.2.1, ansi-styles@npm:^6.2.3":
+  version: 6.2.3
+  resolution: "ansi-styles@npm:6.2.3"
+  checksum: 10/c49dad7639f3e48859bd51824c93b9eb0db628afc243c51c3dd2410c4a15ede1a83881c6c7341aa2b159c4f90c11befb38f2ba848c07c66c9f9de4bcd7cb9f30
   languageName: node
   linkType: hard
 
@@ -7427,10 +7560,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axe-core@npm:^4.11.2, axe-core@npm:^4.2.0":
-  version: 4.11.2
-  resolution: "axe-core@npm:4.11.2"
-  checksum: 10/495a6baa80a157603e5ea9ebfefb06ef4f947d722f8adcefea3a086c918363437406fa5adf27bd9f759314f7661f023110bd5490b3d13f623c92d3dbdf432298
+"axe-core@npm:^4.12.1, axe-core@npm:^4.2.0":
+  version: 4.12.1
+  resolution: "axe-core@npm:4.12.1"
+  checksum: 10/08c2ff348524b57dfb68f4e866b1a6363147203b721c734ed00090c16eb911cd015cf71fd96a8bafe42609715f649d21b2e188fae622ac8ef6144b144582f6c4
   languageName: node
   linkType: hard
 
@@ -7555,7 +7688,7 @@ __metadata:
   peerDependencies:
     browserslist: "*"
   bin:
-    browserslist-to-esbuild: ./cli/index.js
+    browserslist-to-esbuild: cli/index.js
   checksum: 10/5e91b23ba5ac47412b7456bbb74ee11b35d1083163e9e8e001e48f3a975c65758a4559ab532812d8518877a1d8f68c5b649b88a08722b9543b38e633e6943f7d
   languageName: node
   linkType: hard
@@ -7571,13 +7704,6 @@ __metadata:
   bin:
     browserslist: cli.js
   checksum: 10/4a5442b1a0d09c4c64454f184b8fed17d8c3e202034bf39de28f74497d7bd28dddee121b2bab4e34825fe0ed4c166d84e32a39f576c76fce73c1f8f05e4b6ee6
-  languageName: node
-  linkType: hard
-
-"buffer-crc32@npm:~0.2.3":
-  version: 0.2.13
-  resolution: "buffer-crc32@npm:0.2.13"
-  checksum: 10/06252347ae6daca3453b94e4b2f1d3754a3b146a111d81c68924c22d91889a40623264e95e67955b1cb4a68cbedf317abeabb5140a9766ed248973096db5ce1c
   languageName: node
   linkType: hard
 
@@ -7671,10 +7797,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cachedir@npm:^2.3.0":
-  version: 2.3.0
-  resolution: "cachedir@npm:2.3.0"
-  checksum: 10/ec90cb0f2e6336e266aa748dbadf3da9e0b20e843e43f1591acab7a3f1451337dc2f26cb9dd833ae8cfefeffeeb43ef5b5ff62782a685f4e3c2305dd98482fcb
+"cachedir@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "cachedir@npm:2.4.0"
+  checksum: 10/43198514eaa61f65b5535ed29ad651f22836fba3868ed58a6a87731f05462f317d39098fa3ac778801c25455483c9b7f32a2fcad1f690a978947431f12a0f4d0
   languageName: node
   linkType: hard
 
@@ -7929,19 +8055,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clean-stack@npm:^2.0.0":
-  version: 2.2.0
-  resolution: "clean-stack@npm:2.2.0"
-  checksum: 10/2ac8cd2b2f5ec986a3c743935ec85b07bc174d5421a5efc8017e1f146a1cf5f781ae962618f416352103b32c9cd7e203276e8c28241bbe946160cab16149fb68
-  languageName: node
-  linkType: hard
-
-"cli-cursor@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "cli-cursor@npm:3.1.0"
+"cli-cursor@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "cli-cursor@npm:5.0.0"
   dependencies:
-    restore-cursor: "npm:^3.1.0"
-  checksum: 10/2692784c6cd2fd85cfdbd11f53aea73a463a6d64a77c3e098b2b4697a20443f430c220629e1ca3b195ea5ac4a97a74c2ee411f3807abf6df2b66211fec0c0a29
+    restore-cursor: "npm:^5.0.0"
+  checksum: 10/1eb9a3f878b31addfe8d82c6d915ec2330cec8447ab1f117f4aa34f0137fbb3137ec3466e1c9a65bcb7557f6e486d343f2da57f253a2f668d691372dfa15c090
   languageName: node
   linkType: hard
 
@@ -7958,13 +8077,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-truncate@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "cli-truncate@npm:2.1.0"
+"cli-truncate@npm:^5.0.0":
+  version: 5.2.0
+  resolution: "cli-truncate@npm:5.2.0"
   dependencies:
-    slice-ansi: "npm:^3.0.0"
-    string-width: "npm:^4.2.0"
-  checksum: 10/976f1887de067a8cd6ec830a7a8508336aebe6cec79b521d98ed13f67ef073b637f7305675b6247dd22f9e9cf045ec55fe746c7bdb288fbe8db0dfdc9fd52e55
+    slice-ansi: "npm:^8.0.0"
+    string-width: "npm:^8.2.0"
+  checksum: 10/b789b6c2caff1560259aedeb6aaafcf41167d478df418d718a8c92edd6bc5a0ece272b8fb7e7911fbd31cef7b1ac8a30f2b21d90c3174b55a018fe3f2604a137
   languageName: node
   linkType: hard
 
@@ -8044,7 +8163,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"colorette@npm:^2.0.16":
+"colorette@npm:^2.0.20":
   version: 2.0.20
   resolution: "colorette@npm:2.0.20"
   checksum: 10/0b8de48bfa5d10afc160b8eaa2b9938f34a892530b2f7d7897e0458d9535a066e3998b49da9d21161c78225b272df19ae3a64d6df28b4c9734c0e55bbd02406f
@@ -8168,8 +8287,8 @@ __metadata:
     tree-kill: "npm:^1.2.2"
     yargs: "npm:^17.7.2"
   bin:
-    conc: ./dist/bin/concurrently.js
-    concurrently: ./dist/bin/concurrently.js
+    conc: dist/bin/concurrently.js
+    concurrently: dist/bin/concurrently.js
   checksum: 10/1cf3d2e68841698412adb104991d1390ff6a212e6e5f2066a7e5cc837dc39287d11d57dd2ed452174e048d71de628764cd65a5fafaa620ed6f16255ab5ed14aa
   languageName: node
   linkType: hard
@@ -8252,8 +8371,8 @@ __metadata:
     "@epic-web/invariant": "npm:^1.0.0"
     cross-spawn: "npm:^7.0.6"
   bin:
-    cross-env: ./dist/bin/cross-env.js
-    cross-env-shell: ./dist/bin/cross-env-shell.js
+    cross-env: dist/bin/cross-env.js
+    cross-env-shell: dist/bin/cross-env-shell.js
   checksum: 10/1585ccc7c819ed03e0b8d385515d422b34a467404a695f9615e44178bbf2f1e38679691c691e4b8e9208ad7bf79867996ec2eadaac51b93b7e3e5edcc2c8a1e2
   languageName: node
   linkType: hard
@@ -8633,11 +8752,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:15.10.0":
-  version: 15.10.0
-  resolution: "cypress@npm:15.10.0"
+"cypress@npm:^15.17.0":
+  version: 15.17.0
+  resolution: "cypress@npm:15.17.0"
   dependencies:
-    "@cypress/request": "npm:^3.0.10"
+    "@cypress/request": "npm:^4.0.0"
     "@cypress/xvfb": "npm:^1.2.4"
     "@types/sinonjs__fake-timers": "npm:8.1.1"
     "@types/sizzle": "npm:^2.3.2"
@@ -8646,25 +8765,21 @@ __metadata:
     blob-util: "npm:^2.0.2"
     bluebird: "npm:^3.7.2"
     buffer: "npm:^5.7.1"
-    cachedir: "npm:^2.3.0"
+    cachedir: "npm:^2.4.0"
     chalk: "npm:^4.1.0"
     ci-info: "npm:^4.1.0"
-    cli-cursor: "npm:^3.1.0"
     cli-table3: "npm:0.6.1"
     commander: "npm:^6.2.1"
     common-tags: "npm:^1.8.0"
     dayjs: "npm:^1.10.4"
     debug: "npm:^4.3.4"
-    enquirer: "npm:^2.3.6"
     eventemitter2: "npm:6.4.7"
     execa: "npm:4.1.0"
     executable: "npm:^4.1.1"
-    extract-zip: "npm:2.0.1"
-    figures: "npm:^3.2.0"
     fs-extra: "npm:^9.1.0"
     hasha: "npm:5.2.2"
     is-installed-globally: "npm:~0.4.0"
-    listr2: "npm:^3.8.3"
+    listr2: "npm:^9.0.5"
     lodash: "npm:^4.17.23"
     log-symbols: "npm:^4.0.0"
     minimist: "npm:^1.2.8"
@@ -8674,14 +8789,15 @@ __metadata:
     proxy-from-env: "npm:1.0.0"
     request-progress: "npm:^3.0.0"
     supports-color: "npm:^8.1.1"
-    systeminformation: "npm:^5.27.14"
+    systeminformation: "npm:^5.31.1"
     tmp: "npm:~0.2.4"
     tree-kill: "npm:1.2.2"
+    tslib: "npm:1.14.1"
     untildify: "npm:^4.0.0"
-    yauzl: "npm:^2.10.0"
+    yauzl: "npm:^3.3.1"
   bin:
     cypress: bin/cypress
-  checksum: 10/d32e501737f48580ba28072b680b8ad53fd1da3bcfca101c6c6fffcc8e5692a280bd01b792dffdc4e1e37407883bb1979669ea11bc8f2f49c59c118c72d8acce
+  checksum: 10/b4d01d3cebbe9f2525a486cc41af8e14f78dd5a9e9330e53d4ff68148332cc96a82b36016f32424bfc116a04802e0079d59a7908af87a84df6d9247369ae35fb
   languageName: node
   linkType: hard
 
@@ -8708,7 +8824,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.4, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.3.1, debug@npm:^4.3.4, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -8903,7 +9019,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-libc@npm:^2.1.2":
+"detect-libc@npm:^2.0.3, detect-libc@npm:^2.1.2":
   version: 2.1.2
   resolution: "detect-libc@npm:2.1.2"
   checksum: 10/b736c8d97d5d46164c0d1bed53eb4e6a3b1d8530d460211e2d52f1c552875e706c58a5376854e4e54f8b828c9cada58c855288c968522eb93ac7696d65970766
@@ -9164,6 +9280,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"emoji-regex@npm:^10.3.0":
+  version: 10.6.0
+  resolution: "emoji-regex@npm:10.6.0"
+  checksum: 10/98cc0b0e1daed1ed25afbf69dcb921fee00f712f51aab93aa1547e4e4e8171725cc4f0098aaa645b4f611a19da11ec9f4623eb6ff2b72314b39a8f2ae7c12bf2
+  languageName: node
+  linkType: hard
+
 "emoji-regex@npm:^8.0.0":
   version: 8.0.0
   resolution: "emoji-regex@npm:8.0.0"
@@ -9203,7 +9326,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enquirer@npm:^2.3.6, enquirer@npm:^2.4.1":
+"enquirer@npm:^2.4.1":
   version: 2.4.1
   resolution: "enquirer@npm:2.4.1"
   dependencies:
@@ -9240,6 +9363,13 @@ __metadata:
   dependencies:
     is-safe-filename: "npm:^0.1.0"
   checksum: 10/97a6ef4f7e05e9e7b464645c0539a31889947b8fe14545332af47ea61bb3556ce47f6d17491a5959c098a1ce0605d4f494e4c837f8fbc1f0a60b8201d8b19ce7
+  languageName: node
+  linkType: hard
+
+"environment@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "environment@npm:1.1.0"
+  checksum: 10/dd3c1b9825e7f71f1e72b03c2344799ac73f2e9ef81b78ea8b373e55db021786c6b9f3858ea43a436a2c4611052670ec0afe85bc029c384cc71165feee2f4ba6
   languageName: node
   linkType: hard
 
@@ -9433,13 +9563,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escape-string-regexp@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "escape-string-regexp@npm:1.0.5"
-  checksum: 10/6092fda75c63b110c706b6a9bfde8a612ad595b628f0bd2147eea1d3406723020810e591effc7db1da91d80a71a737a313567c5abb3813e8d9c71f4aa595b410
-  languageName: node
-  linkType: hard
-
 "escape-string-regexp@npm:^5.0.0":
   version: 5.0.0
   resolution: "escape-string-regexp@npm:5.0.0"
@@ -9566,6 +9689,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eventemitter3@npm:^5.0.1":
+  version: 5.0.4
+  resolution: "eventemitter3@npm:5.0.4"
+  checksum: 10/54f5c8c543650d65f92d03dbef1bb73a682a920490c44699ad8f863a6b19bbca42fb7409aa09ca09cb98a44149d9a7bc1dffd55ca88a740bd928c7be0ad666a0
+  languageName: node
+  linkType: hard
+
 "execa@npm:4.1.0":
   version: 4.1.0
   resolution: "execa@npm:4.1.0"
@@ -9655,23 +9785,6 @@ __metadata:
   version: 0.1.7
   resolution: "extendable-error@npm:0.1.7"
   checksum: 10/80478be7429a1675d2085f701239796bab3230ed6f2fb1b138fbabec24bea6516b7c5ceb6e9c209efcc9c089948d93715703845653535f8e8a49655066a9255e
-  languageName: node
-  linkType: hard
-
-"extract-zip@npm:2.0.1":
-  version: 2.0.1
-  resolution: "extract-zip@npm:2.0.1"
-  dependencies:
-    "@types/yauzl": "npm:^2.9.1"
-    debug: "npm:^4.1.1"
-    get-stream: "npm:^5.1.0"
-    yauzl: "npm:^2.10.0"
-  dependenciesMeta:
-    "@types/yauzl":
-      optional: true
-  bin:
-    extract-zip: cli.js
-  checksum: 10/8cbda9debdd6d6980819cc69734d874ddd71051c9fe5bde1ef307ebcedfe949ba57b004894b585f758b7c9eeeea0e3d87f2dda89b7d25320459c2c9643ebb635
   languageName: node
   linkType: hard
 
@@ -9860,15 +9973,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fd-slicer@npm:~1.1.0":
-  version: 1.1.0
-  resolution: "fd-slicer@npm:1.1.0"
-  dependencies:
-    pend: "npm:~1.2.0"
-  checksum: 10/db3e34fa483b5873b73f248e818f8a8b59a6427fd8b1436cd439c195fdf11e8659419404826059a642b57d18075c856d06d6a50a1413b714f12f833a9341ead3
-  languageName: node
-  linkType: hard
-
 "fdir@npm:^6.2.0, fdir@npm:^6.5.0":
   version: 6.5.0
   resolution: "fdir@npm:6.5.0"
@@ -9878,15 +9982,6 @@ __metadata:
     picomatch:
       optional: true
   checksum: 10/14ca1c9f0a0e8f4f2e9bf4e8551065a164a09545dae548c12a18d238b72e51e5a7b39bd8e5494b56463a0877672d0a6c1ef62c6fa0677db1b0c847773be939b1
-  languageName: node
-  linkType: hard
-
-"figures@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "figures@npm:3.2.0"
-  dependencies:
-    escape-string-regexp: "npm:^1.0.5"
-  checksum: 10/a3bf94e001be51d3770500789157f067218d4bc681a65e1f69d482de15120bcac822dceb1a7b3803f32e4e3a61a46df44f7f2c8ba95d6375e7491502e0dd3d97
   languageName: node
   linkType: hard
 
@@ -10146,10 +10241,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-east-asian-width@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "get-east-asian-width@npm:1.5.0"
-  checksum: 10/60bc34cd1e975055ab99f0f177e31bed3e516ff7cee9c536474383954a976abaa6b94a51d99ad158ef1e372790fa096cab7d07f166bb0778f6587954c0fbe946
+"get-east-asian-width@npm:^1.0.0, get-east-asian-width@npm:^1.3.1, get-east-asian-width@npm:^1.5.0":
+  version: 1.6.0
+  resolution: "get-east-asian-width@npm:1.6.0"
+  checksum: 10/3e5370b5df1f0020db711d8a3f9ee2cbfc9c7542daa99a699e9d7b9acf66e7868b89084741565a45d30d80afedf6e1218e0fb8bef7a583924a449c2816777380
   languageName: node
   linkType: hard
 
@@ -10184,7 +10279,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^5.0.0, get-stream@npm:^5.1.0":
+"get-stream@npm:^5.0.0":
   version: 5.2.0
   resolution: "get-stream@npm:5.2.0"
   dependencies:
@@ -10255,7 +10350,7 @@ __metadata:
     package-json-from-dist: "npm:^1.0.0"
     path-scurry: "npm:^1.11.1"
   bin:
-    glob: ./dist/esm/bin.mjs
+    glob: dist/esm/bin.mjs
   checksum: 10/ab3bccfefcc0afaedbd1f480cd0c4a2c0e322eb3f0aa7ceaa31b3f00b825069f17cf0f1fc8b6f256795074b903f37c0ade37ddda6a176aa57f1c2bbfe7240653
   languageName: node
   linkType: hard
@@ -11131,7 +11226,7 @@ __metadata:
   version: 3.0.0
   resolution: "is-docker@npm:3.0.0"
   bin:
-    is-docker: ./cli.js
+    is-docker: cli.js
   checksum: 10/b698118f04feb7eaf3338922bd79cba064ea54a1c3db6ec8c0c8d8ee7613e7e5854d802d3ef646812a8a3ace81182a085dfa0a71cc68b06f3fa794b9783b3c90
   languageName: node
   linkType: hard
@@ -11157,6 +11252,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-fullwidth-code-point@npm:^5.0.0, is-fullwidth-code-point@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "is-fullwidth-code-point@npm:5.1.0"
+  dependencies:
+    get-east-asian-width: "npm:^1.3.1"
+  checksum: 10/4700d8a82cb71bd2a2955587b2823c36dc4660eadd4047bfbd070821ddbce8504fc5f9b28725567ecddf405b1e06c6692c9b719f65df6af9ec5262bc11393a6a
+  languageName: node
+  linkType: hard
+
 "is-glob@npm:^4.0.1, is-glob@npm:^4.0.3, is-glob@npm:~4.0.1":
   version: 4.0.3
   resolution: "is-glob@npm:4.0.3"
@@ -11179,7 +11283,7 @@ __metadata:
   dependencies:
     is-docker: "npm:^3.0.0"
   bin:
-    is-inside-container: ./cli.js
+    is-inside-container: cli.js
   checksum: 10/c50b75a2ab66ab3e8b92b3bc534e1ea72ca25766832c0623ac22d134116a98bcf012197d1caabe1d1c4bd5f84363d4aa5c36bb4b585fbcaf57be172cd10a1a03
   languageName: node
   linkType: hard
@@ -11662,6 +11766,126 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-android-arm64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-android-arm64@npm:1.33.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-arm64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-darwin-arm64@npm:1.33.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-x64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-darwin-x64@npm:1.33.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-freebsd-x64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-freebsd-x64@npm:1.33.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm-gnueabihf@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.33.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-gnu@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-arm64-gnu@npm:1.33.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-musl@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-arm64-musl@npm:1.33.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-gnu@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-x64-gnu@npm:1.33.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-musl@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-x64-musl@npm:1.33.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-arm64-msvc@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-win32-arm64-msvc@npm:1.33.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-x64-msvc@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-win32-x64-msvc@npm:1.33.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss@npm:^1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss@npm:1.33.0"
+  dependencies:
+    detect-libc: "npm:^2.0.3"
+    lightningcss-android-arm64: "npm:1.33.0"
+    lightningcss-darwin-arm64: "npm:1.33.0"
+    lightningcss-darwin-x64: "npm:1.33.0"
+    lightningcss-freebsd-x64: "npm:1.33.0"
+    lightningcss-linux-arm-gnueabihf: "npm:1.33.0"
+    lightningcss-linux-arm64-gnu: "npm:1.33.0"
+    lightningcss-linux-arm64-musl: "npm:1.33.0"
+    lightningcss-linux-x64-gnu: "npm:1.33.0"
+    lightningcss-linux-x64-musl: "npm:1.33.0"
+    lightningcss-win32-arm64-msvc: "npm:1.33.0"
+    lightningcss-win32-x64-msvc: "npm:1.33.0"
+  dependenciesMeta:
+    lightningcss-android-arm64:
+      optional: true
+    lightningcss-darwin-arm64:
+      optional: true
+    lightningcss-darwin-x64:
+      optional: true
+    lightningcss-freebsd-x64:
+      optional: true
+    lightningcss-linux-arm-gnueabihf:
+      optional: true
+    lightningcss-linux-arm64-gnu:
+      optional: true
+    lightningcss-linux-arm64-musl:
+      optional: true
+    lightningcss-linux-x64-gnu:
+      optional: true
+    lightningcss-linux-x64-musl:
+      optional: true
+    lightningcss-win32-arm64-msvc:
+      optional: true
+    lightningcss-win32-x64-msvc:
+      optional: true
+  checksum: 10/9b3b5db404af352fe5861926b9909281d29bede175539035c1a01e1ad4dcee8bb6f871e8e3d01a67a85e9e1cd18a63e52871a48cf62feab4d1aa868d4f2c3c2e
+  languageName: node
+  linkType: hard
+
 "lilconfig@npm:^2.0.3, lilconfig@npm:^2.0.4":
   version: 2.0.4
   resolution: "lilconfig@npm:2.0.4"
@@ -11676,24 +11900,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"listr2@npm:^3.8.3":
-  version: 3.14.0
-  resolution: "listr2@npm:3.14.0"
+"listr2@npm:^9.0.5":
+  version: 9.0.5
+  resolution: "listr2@npm:9.0.5"
   dependencies:
-    cli-truncate: "npm:^2.1.0"
-    colorette: "npm:^2.0.16"
-    log-update: "npm:^4.0.0"
-    p-map: "npm:^4.0.0"
-    rfdc: "npm:^1.3.0"
-    rxjs: "npm:^7.5.1"
-    through: "npm:^2.3.8"
-    wrap-ansi: "npm:^7.0.0"
-  peerDependencies:
-    enquirer: ">= 2.3.0 < 3"
-  peerDependenciesMeta:
-    enquirer:
-      optional: true
-  checksum: 10/cebbd692330279ea82f05468cbb0a16f5b40015a6163e0a2fb04ef168da8e2d6c54e129148e90112d92e7f9ecb85a56e6b88d867a58a8ebdf36e0c98df49ae5c
+    cli-truncate: "npm:^5.0.0"
+    colorette: "npm:^2.0.20"
+    eventemitter3: "npm:^5.0.1"
+    log-update: "npm:^6.1.0"
+    rfdc: "npm:^1.4.1"
+    wrap-ansi: "npm:^9.0.0"
+  checksum: 10/b78ffd60443aed9a8e0fc9162eb941ea4d63210700d61a895eb29348f23fc668327e26bbca87a9e6a6208e7fa96c475fe1f1c6c19b46f376f547e0cba3b935ae
   languageName: node
   linkType: hard
 
@@ -11793,15 +12010,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"log-update@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "log-update@npm:4.0.0"
+"log-update@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "log-update@npm:6.1.0"
   dependencies:
-    ansi-escapes: "npm:^4.3.0"
-    cli-cursor: "npm:^3.1.0"
-    slice-ansi: "npm:^4.0.0"
-    wrap-ansi: "npm:^6.2.0"
-  checksum: 10/ae2f85bbabc1906034154fb7d4c4477c79b3e703d22d78adee8b3862fa913942772e7fa11713e3d96fb46de4e3cabefbf5d0a544344f03b58d3c4bff52aa9eb2
+    ansi-escapes: "npm:^7.0.0"
+    cli-cursor: "npm:^5.0.0"
+    slice-ansi: "npm:^7.1.0"
+    strip-ansi: "npm:^7.1.0"
+    wrap-ansi: "npm:^9.0.0"
+  checksum: 10/5abb4131e33b1e7f8416bb194fe17a3603d83e4657c5bf5bb81ce4187f3b00ea481643b85c3d5cefe6037a452cdcf7f1391ab8ea0d9c23e75d19589830ec4f11
   languageName: node
   linkType: hard
 
@@ -12787,6 +13005,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mimic-function@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "mimic-function@npm:5.0.1"
+  checksum: 10/eb5893c99e902ccebbc267c6c6b83092966af84682957f79313311edb95e8bb5f39fb048d77132b700474d1c86d90ccc211e99bae0935447a4834eb4c882982c
+  languageName: node
+  linkType: hard
+
 "mimic-response@npm:^4.0.0":
   version: 4.0.0
   resolution: "mimic-response@npm:4.0.0"
@@ -13005,7 +13230,7 @@ __metadata:
   version: 4.2.0
   resolution: "mustache@npm:4.2.0"
   bin:
-    mustache: ./bin/mustache
+    mustache: bin/mustache
   checksum: 10/6e668bd5803255ab0779c3983b9412b5c4f4f90e822230e0e8f414f5449ed7a137eed29430e835aa689886f663385cfe05f808eb34b16e1f3a95525889b05cd3
   languageName: node
   linkType: hard
@@ -13046,7 +13271,7 @@ __metadata:
   version: 3.3.16
   resolution: "nanoid@npm:3.3.16"
   bin:
-    nanoid: ./bin/nanoid.cjs
+    nanoid: bin/nanoid.cjs
   checksum: 10/8004af92b5541af1dbd23b69845b5026f777d5b7ef07163cea1837aae86e052ced8b383cecbf8a4f1b5e77ae207df96dc45e16b9e0fa3c4b761d085f1e42851b
   languageName: node
   linkType: hard
@@ -13165,7 +13390,7 @@ __metadata:
     sass:
       optional: true
   bin:
-    next: ./dist/bin/next
+    next: dist/bin/next
   checksum: 10/29434e14b1a3026eeb2e2e719885be592319f4777cb0414017769d87c382051fb1352cb2c94b9b1b0a5f17526d8c6d731f5d425012146135a4583b09c1e7be00
   languageName: node
   linkType: hard
@@ -13201,9 +13426,9 @@ __metadata:
   version: 4.8.4
   resolution: "node-gyp-build@npm:4.8.4"
   bin:
-    node-gyp-build: ./bin.js
-    node-gyp-build-optional: ./optional.js
-    node-gyp-build-test: ./build-test.js
+    node-gyp-build: bin.js
+    node-gyp-build-optional: optional.js
+    node-gyp-build-test: build-test.js
   checksum: 10/6a7d62289d1afc419fc8fc9bd00aa4e554369e50ca0acbc215cb91446148b75ff7e2a3b53c2c5b2c09a39d416d69f3d3237937860373104b5fe429bf30ad9ac5
   languageName: node
   linkType: hard
@@ -13223,7 +13448,7 @@ __metadata:
     tinyglobby: "npm:^0.2.12"
     which: "npm:^6.0.0"
   bin:
-    node-gyp: ./bin/node-gyp.js
+    node-gyp: bin/node-gyp.js
   checksum: 10/d93079236cef1dd7fa4df683708d8708ad255c55865f6656664c8959e4d3963d908ac48e8f9f341705432e979dbbf502a40d68d65a17fe35956a5a05ba6c1cb4
   languageName: node
   linkType: hard
@@ -13316,7 +13541,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-inspect@npm:^1.13.3":
+"object-inspect@npm:^1.13.3, object-inspect@npm:^1.13.4":
   version: 1.13.4
   resolution: "object-inspect@npm:1.13.4"
   checksum: 10/aa13b1190ad3e366f6c83ad8a16ed37a19ed57d267385aa4bfdccda833d7b90465c057ff6c55d035a6b2e52c1a2295582b294217a0a3a1ae7abdd6877ef781fb
@@ -13388,6 +13613,15 @@ __metadata:
   dependencies:
     mimic-fn: "npm:^2.1.0"
   checksum: 10/e9fd0695a01cf226652f0385bf16b7a24153dbbb2039f764c8ba6d2306a8506b0e4ce570de6ad99c7a6eb49520743afdb66edd95ee979c1a342554ed49a9aadd
+  languageName: node
+  linkType: hard
+
+"onetime@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "onetime@npm:7.0.0"
+  dependencies:
+    mimic-function: "npm:^5.0.0"
+  checksum: 10/eb08d2da9339819e2f9d52cab9caf2557d80e9af8c7d1ae86e1a0fef027d00a88e9f5bd67494d350df360f7c559fbb44e800b32f310fb989c860214eacbb561c
   languageName: node
   linkType: hard
 
@@ -13670,15 +13904,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-map@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "p-map@npm:4.0.0"
-  dependencies:
-    aggregate-error: "npm:^3.0.0"
-  checksum: 10/7ba4a2b1e24c05e1fc14bbaea0fc6d85cf005ae7e9c9425d4575550f37e2e584b1af97bcde78eacd7559208f20995988d52881334db16cf77bc1bcf68e48ed7c
-  languageName: node
-  linkType: hard
-
 "p-map@npm:^7.0.2":
   version: 7.0.3
   resolution: "p-map@npm:7.0.3"
@@ -13916,10 +14141,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3, picomatch@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "picomatch@npm:4.0.4"
-  checksum: 10/f6ef80a3590827ce20378ae110ac78209cc4f74d39236370f1780f957b7ee41c12acde0e4651b90f39983506fd2f5e449994716f516db2e9752924aff8de93ce
+"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3, picomatch@npm:^4.0.4, picomatch@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "picomatch@npm:4.0.5"
+  checksum: 10/8bad770af9dcdb7f94ad1a893adcbe08a97d75a18872f8fed37161d3124217471c402b3929f051532f795f4ff2e53dcebb1644df4c1a5f3a9c476fef3b9f8c51
   languageName: node
   linkType: hard
 
@@ -13976,7 +14201,7 @@ __metadata:
     sonic-boom: "npm:^4.0.1"
     thread-stream: "npm:^4.0.0"
   bin:
-    pino: ./bin.js
+    pino: bin.js
   checksum: 10/46cad7bf1859c83a8a9c43af764e5165f44057ce76d44b1b2b4390f2abccb8a579f42abfe742d88b4d8e1d339213afb46ea50fc39c50095dd1f0f9fe26ea1342
   languageName: node
   linkType: hard
@@ -14453,7 +14678,7 @@ __metadata:
   version: 2.8.8
   resolution: "prettier@npm:2.8.8"
   bin:
-    prettier: ./bin-prettier.js
+    prettier: bin-prettier.js
   checksum: 10/00cdb6ab0281f98306cd1847425c24cbaaa48a5ff03633945ab4c701901b8e96ad558eb0777364ffc312f437af9b5a07d0f45346266e8245beaf6247b9c62b24
   languageName: node
   linkType: hard
@@ -14462,7 +14687,7 @@ __metadata:
   version: 3.3.3
   resolution: "prettier@npm:3.3.3"
   bin:
-    prettier: ./bin/prettier.cjs
+    prettier: bin/prettier.cjs
   checksum: 10/5beac1f30b5b40162532b8e2f7c3a4eb650910a2695e9c8512a62ffdc09dae93190c29db9107fa7f26d1b6c71aad3628ecb9b5de1ecb0911191099be109434d7
   languageName: node
   linkType: hard
@@ -14630,12 +14855,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:~6.14.1":
-  version: 6.14.2
-  resolution: "qs@npm:6.14.2"
+"qs@npm:^6.15.2":
+  version: 6.15.3
+  resolution: "qs@npm:6.15.3"
   dependencies:
-    side-channel: "npm:^1.1.0"
-  checksum: 10/682933a85bb4b7bd0d66e13c0a40d9e612b5e4bcc2cb9238f711a9368cd22d91654097a74fff93551e58146db282c56ac094957dfdc60ce64ea72c3c9d7779ac
+    es-define-property: "npm:^1.0.1"
+    side-channel: "npm:^1.1.1"
+  checksum: 10/1cbb4b050872a19ba8a311445be29babb8f66ea5d6462b3c48c6efb2c95187cd286b69734cd4caea1878cca3b9d1f0e9b49335336be9e999a7d8d7cf137ba60d
   languageName: node
   linkType: hard
 
@@ -15267,7 +15493,7 @@ __metadata:
     argparse: "npm:^1.0.10"
     autolinker: "npm:^3.11.0"
   bin:
-    remarkable: ./bin/remarkable.js
+    remarkable: bin/remarkable.js
   checksum: 10/3734e9cd5105b9655a993e498890d99706a86707bccabf5d64b57f0f8ec9c5e66cdd7f06aae5fe07ca8633d93377edc803318626dd581e75f5f85aba69c350fb
   languageName: node
   linkType: hard
@@ -15352,7 +15578,7 @@ __metadata:
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
-    resolve: ./bin/resolve
+    resolve: bin/resolve
   checksum: 10/e1b2e738884a08de03f97ee71494335eba8c2b0feb1de9ae065e82c48997f349f77a2b10e8817e147cf610bfabc4b1cb7891ee8eaf5bf80d4ad514a34c4fab0a
   languageName: node
   linkType: hard
@@ -15365,7 +15591,7 @@ __metadata:
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
-    resolve: ./bin/resolve
+    resolve: bin/resolve
   checksum: 10/fd342cad25e52cd6f4f3d1716e189717f2522bfd6641109fe7aa372f32b5714a296ed7c238ddbe7ebb0c1ddfe0b7f71c9984171024c97cf1b2073e3e40ff71a8
   languageName: node
   linkType: hard
@@ -15388,13 +15614,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"restore-cursor@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "restore-cursor@npm:3.1.0"
+"restore-cursor@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "restore-cursor@npm:5.1.0"
   dependencies:
-    onetime: "npm:^5.1.0"
-    signal-exit: "npm:^3.0.2"
-  checksum: 10/f877dd8741796b909f2a82454ec111afb84eb45890eb49ac947d87991379406b3b83ff9673a46012fca0d7844bb989f45cc5b788254cf1a39b6b5a9659de0630
+    onetime: "npm:^7.0.0"
+    signal-exit: "npm:^4.1.0"
+  checksum: 10/838dd54e458d89cfbc1a923b343c1b0f170a04100b4ce1733e97531842d7b440463967e521216e8ab6c6f8e89df877acc7b7f4c18ec76e99fb9bf5a60d358d2c
   languageName: node
   linkType: hard
 
@@ -15433,7 +15659,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rfdc@npm:^1.2.0, rfdc@npm:^1.3.0, rfdc@npm:^1.3.1":
+"rfdc@npm:^1.2.0, rfdc@npm:^1.3.1, rfdc@npm:^1.4.1":
   version: 1.4.1
   resolution: "rfdc@npm:1.4.1"
   checksum: 10/2f3d11d3d8929b4bfeefc9acb03aae90f971401de0add5ae6c5e38fec14f0405e6a4aad8fdb76344bfdd20c5193110e3750cbbd28ba86d73729d222b6cf4a729
@@ -15456,8 +15682,66 @@ __metadata:
     glob: "npm:^13.0.3"
     package-json-from-dist: "npm:^1.0.1"
   bin:
-    rimraf: ./dist/esm/bin.mjs
+    rimraf: dist/esm/bin.mjs
   checksum: 10/dd98ec2ad7cd2cccae1c7110754d472eac8edb2bab8a8b057dce04edfe1433dab246a889b3fd85a66c78ca81caa1429caa0e736c7647f6832b04fd5d4dfb8ab8
+  languageName: node
+  linkType: hard
+
+"rolldown@npm:~1.2.0":
+  version: 1.2.1
+  resolution: "rolldown@npm:1.2.1"
+  dependencies:
+    "@oxc-project/types": "npm:=0.142.0"
+    "@rolldown/binding-android-arm64": "npm:1.2.1"
+    "@rolldown/binding-darwin-arm64": "npm:1.2.1"
+    "@rolldown/binding-darwin-x64": "npm:1.2.1"
+    "@rolldown/binding-freebsd-x64": "npm:1.2.1"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.2.1"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.2.1"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.2.1"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.2.1"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.2.1"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.2.1"
+    "@rolldown/binding-linux-x64-musl": "npm:1.2.1"
+    "@rolldown/binding-openharmony-arm64": "npm:1.2.1"
+    "@rolldown/binding-wasm32-wasi": "npm:1.2.1"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.2.1"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.2.1"
+    "@rolldown/pluginutils": "npm:^1.0.0"
+  dependenciesMeta:
+    "@rolldown/binding-android-arm64":
+      optional: true
+    "@rolldown/binding-darwin-arm64":
+      optional: true
+    "@rolldown/binding-darwin-x64":
+      optional: true
+    "@rolldown/binding-freebsd-x64":
+      optional: true
+    "@rolldown/binding-linux-arm-gnueabihf":
+      optional: true
+    "@rolldown/binding-linux-arm64-gnu":
+      optional: true
+    "@rolldown/binding-linux-arm64-musl":
+      optional: true
+    "@rolldown/binding-linux-ppc64-gnu":
+      optional: true
+    "@rolldown/binding-linux-s390x-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-musl":
+      optional: true
+    "@rolldown/binding-openharmony-arm64":
+      optional: true
+    "@rolldown/binding-wasm32-wasi":
+      optional: true
+    "@rolldown/binding-win32-arm64-msvc":
+      optional: true
+    "@rolldown/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    rolldown: ./bin/cli.mjs
+  checksum: 10/32cdaf5488cb64700907d27ede2a5936d3c1acb88e2b701bf6ecf88846fbed5f3b23f5da55ba101a0cebe2f0d6f5a746fa66b81692adfb806feb44b784d06de7
   languageName: node
   linkType: hard
 
@@ -15508,7 +15792,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^4.24.2, rollup@npm:^4.43.0":
+"rollup@npm:^4.24.2":
   version: 4.59.0
   resolution: "rollup@npm:4.59.0"
   dependencies:
@@ -15614,7 +15898,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.5.1, rxjs@npm:^7.5.5, rxjs@npm:^7.8.1":
+"rxjs@npm:^7.5.5, rxjs@npm:^7.8.1":
   version: 7.8.1
   resolution: "rxjs@npm:7.8.1"
   dependencies:
@@ -15704,7 +15988,7 @@ __metadata:
   version: 6.3.1
   resolution: "semver@npm:6.3.1"
   bin:
-    semver: ./bin/semver.js
+    semver: bin/semver.js
   checksum: 10/1ef3a85bd02a760c6ef76a45b8c1ce18226de40831e02a00bad78485390b98b6ccaa31046245fc63bba4a47a6a592b6c7eedc65cc47126e60489f9cc1ce3ed7e
   languageName: node
   linkType: hard
@@ -15756,7 +16040,7 @@ __metadata:
     safe-buffer: "npm:^5.2.1"
     to-buffer: "npm:^1.2.0"
   bin:
-    sha.js: ./bin.js
+    sha.js: bin.js
   checksum: 10/39c0993592c2ab34eb2daae2199a2a1d502713765aecb611fd97c0c4ab7cd53e902d628e1962aaf384bafd28f55951fef46dcc78799069ce41d74b03aa13b5a7
   languageName: node
   linkType: hard
@@ -15910,13 +16194,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"side-channel-list@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "side-channel-list@npm:1.0.0"
+"side-channel-list@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "side-channel-list@npm:1.0.1"
   dependencies:
     es-errors: "npm:^1.3.0"
-    object-inspect: "npm:^1.13.3"
-  checksum: 10/603b928997abd21c5a5f02ae6b9cc36b72e3176ad6827fab0417ead74580cc4fb4d5c7d0a8a2ff4ead34d0f9e35701ed7a41853dac8a6d1a664fcce1a044f86f
+    object-inspect: "npm:^1.13.4"
+  checksum: 10/3499671cd52adaee739eac1e14d07530b8e3530192741aeb05e7fe4ad1b51d1368ceea2cd3c21b0f62b05410a5c70a7c4d997ba4b143303ef73d0c65dfd1c252
   languageName: node
   linkType: hard
 
@@ -15945,16 +16229,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"side-channel@npm:^1.0.4, side-channel@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "side-channel@npm:1.1.0"
+"side-channel@npm:^1.0.4, side-channel@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "side-channel@npm:1.1.1"
   dependencies:
     es-errors: "npm:^1.3.0"
-    object-inspect: "npm:^1.13.3"
-    side-channel-list: "npm:^1.0.0"
+    object-inspect: "npm:^1.13.4"
+    side-channel-list: "npm:^1.0.1"
     side-channel-map: "npm:^1.0.1"
     side-channel-weakmap: "npm:^1.0.2"
-  checksum: 10/7d53b9db292c6262f326b6ff3bc1611db84ece36c2c7dc0e937954c13c73185b0406c56589e2bb8d071d6fee468e14c39fb5d203ee39be66b7b8174f179afaba
+  checksum: 10/5fa6393ff6ad25d8b4a38e9ba095481e498c8ebe5ab78481c1455146255a3d18ca37a6f936595cc671a6149134cdc295bbd2fa017620bdc73cbc7380634fa2fc
   languageName: node
   linkType: hard
 
@@ -16009,17 +16293,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"slice-ansi@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "slice-ansi@npm:3.0.0"
-  dependencies:
-    ansi-styles: "npm:^4.0.0"
-    astral-regex: "npm:^2.0.0"
-    is-fullwidth-code-point: "npm:^3.0.0"
-  checksum: 10/5ec6d022d12e016347e9e3e98a7eb2a592213a43a65f1b61b74d2c78288da0aded781f665807a9f3876b9daa9ad94f64f77d7633a0458876c3a4fdc4eb223f24
-  languageName: node
-  linkType: hard
-
 "slice-ansi@npm:^4.0.0":
   version: 4.0.0
   resolution: "slice-ansi@npm:4.0.0"
@@ -16028,6 +16301,26 @@ __metadata:
     astral-regex: "npm:^2.0.0"
     is-fullwidth-code-point: "npm:^3.0.0"
   checksum: 10/4a82d7f085b0e1b070e004941ada3c40d3818563ac44766cca4ceadd2080427d337554f9f99a13aaeb3b4a94d9964d9466c807b3d7b7541d1ec37ee32d308756
+  languageName: node
+  linkType: hard
+
+"slice-ansi@npm:^7.1.0":
+  version: 7.1.2
+  resolution: "slice-ansi@npm:7.1.2"
+  dependencies:
+    ansi-styles: "npm:^6.2.1"
+    is-fullwidth-code-point: "npm:^5.0.0"
+  checksum: 10/75f61e1285c294b18c88521a0cdb22cdcbe9b0fd5e8e26f649be804cc43122aa7751bd960a968e3ed7f5aa7f3c67ac605c939019eae916870ec288e878b6fafb
+  languageName: node
+  linkType: hard
+
+"slice-ansi@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "slice-ansi@npm:8.0.0"
+  dependencies:
+    ansi-styles: "npm:^6.2.3"
+    is-fullwidth-code-point: "npm:^5.1.0"
+  checksum: 10/6a7e146852047e26dd5857b35c767e52906549c580cce0ad2287cc32f54f5a582494f674817fc9ac21b2e4ac1ddeaa85b3dee409782681b465330278890c73a8
   languageName: node
   linkType: hard
 
@@ -16147,6 +16440,10 @@ __metadata:
     jsbn: "npm:~0.1.0"
     safer-buffer: "npm:^2.0.2"
     tweetnacl: "npm:~0.14.0"
+  bin:
+    sshpk-conv: bin/sshpk-conv
+    sshpk-sign: bin/sshpk-sign
+    sshpk-verify: bin/sshpk-verify
   checksum: 10/858339d43e3c6b6a848772a66f69442ce74f1a37655d9f35ba9d1f85329499ff0000af9f8ab83dbb39ad24c0c370edabe0be1e39863f70c6cded9924b8458c34
   languageName: node
   linkType: hard
@@ -16278,6 +16575,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string-width@npm:^7.0.0":
+  version: 7.2.0
+  resolution: "string-width@npm:7.2.0"
+  dependencies:
+    emoji-regex: "npm:^10.3.0"
+    get-east-asian-width: "npm:^1.0.0"
+    strip-ansi: "npm:^7.1.0"
+  checksum: 10/42f9e82f61314904a81393f6ef75b832c39f39761797250de68c041d8ba4df2ef80db49ab6cd3a292923a6f0f409b8c9980d120f7d32c820b4a8a84a2598a295
+  languageName: node
+  linkType: hard
+
 "string-width@npm:^8.2.0":
   version: 8.2.0
   resolution: "string-width@npm:8.2.0"
@@ -16316,7 +16624,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^7.0.1, strip-ansi@npm:^7.1.2":
+"strip-ansi@npm:^7.0.1, strip-ansi@npm:^7.1.0, strip-ansi@npm:^7.1.2":
   version: 7.2.0
   resolution: "strip-ansi@npm:7.2.0"
   dependencies:
@@ -16507,8 +16815,8 @@ __metadata:
     pirates: "npm:^4.0.1"
     ts-interface-checker: "npm:^0.1.9"
   bin:
-    sucrase: ./bin/sucrase
-    sucrase-node: ./bin/sucrase-node
+    sucrase: bin/sucrase
+    sucrase-node: bin/sucrase-node
   checksum: 10/bc601558a62826f1c32287d4fdfa4f2c09fe0fec4c4d39d0e257fd9116d7d6227a18309721d4185ec84c9dc1af0d5ec0e05a42a337fbb74fc293e068549aacbe
   languageName: node
   linkType: hard
@@ -16749,12 +17057,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"systeminformation@npm:^5.27.14":
-  version: 5.33.0
-  resolution: "systeminformation@npm:5.33.0"
+"systeminformation@npm:^5.31.1":
+  version: 5.33.1
+  resolution: "systeminformation@npm:5.33.1"
   bin:
     systeminformation: lib/cli.js
-  checksum: 10/036cc553705174f5f52ece206f4072df4546d202bd34f450731328a1cdbddeeb24a87325fa9b841b4f46c54098cdfa9b2fb82ef1783c2929e6e929725dfde001
+  checksum: 10/54e8749be385a91b32cd5de0a7dbd16478e60c7b679b173a58f9f447b1785d2f4820f4c642b25de1bc0e71611a38fad9905a75477fcb60cd36e7a389e6b56162
   conditions: (os=darwin | os=linux | os=win32 | os=freebsd | os=openbsd | os=netbsd | os=sunos | os=android)
   languageName: node
   linkType: hard
@@ -16849,13 +17157,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"through@npm:^2.3.8":
-  version: 2.3.8
-  resolution: "through@npm:2.3.8"
-  checksum: 10/5da78346f70139a7d213b65a0106f3c398d6bc5301f9248b5275f420abc2c4b1e77c2abc72d218dedc28c41efb2e7c312cb76a7730d04f9c2d37d247da3f4198
-  languageName: node
-  linkType: hard
-
 "tiny-case@npm:^1.0.3":
   version: 1.0.3
   resolution: "tiny-case@npm:1.0.3"
@@ -16891,7 +17192,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.14, tinyglobby@npm:^0.2.15":
+"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.14, tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.17":
   version: 0.2.17
   resolution: "tinyglobby@npm:0.2.17"
   dependencies:
@@ -17241,8 +17542,8 @@ __metadata:
   version: 6.0.2
   resolution: "typescript@npm:6.0.2"
   bin:
-    tsc: ./bin/tsc
-    tsserver: ./bin/tsserver
+    tsc: bin/tsc
+    tsserver: bin/tsserver
   checksum: 10/b9fc2fcee7ee8e5ca6f5138181964550531e18e2d20ecb71b802d4d495881e3444e0ef94cbb6e84eb2ba41e913f6feae3ca33cc722b32e6e6dfadb32d23b80e6
   languageName: node
   linkType: hard
@@ -17251,8 +17552,8 @@ __metadata:
   version: 6.0.2
   resolution: "typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>::version=6.0.2&hash=5786d5"
   bin:
-    tsc: ./bin/tsc
-    tsserver: ./bin/tsserver
+    tsc: bin/tsc
+    tsserver: bin/tsserver
   checksum: 10/e5501dfcf8c5b6b9a61f6fa53decc40187cebe3a2b7b2bd51c615007ad4cf6d58298461fef63294f6be9d5f2f33019b2a2e2bf02d9cb7d7f6ec94372bf24ffa2
   languageName: node
   linkType: hard
@@ -17522,7 +17823,7 @@ __metadata:
   version: 11.1.1
   resolution: "uuid@npm:11.1.1"
   bin:
-    uuid: ./dist/esm/bin/uuid
+    uuid: dist/esm/bin/uuid
   checksum: 10/16411d3dc12a08d6691616c09a75e66a7f900ba1beef6628a76fe0602f82fae2ee537b564d0b7bc95c24f58d059ca9b58c75a1e806118efb50e17822ff00ddd2
   languageName: node
   linkType: hard
@@ -17533,15 +17834,6 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 10/b2a4d30ecd6581015175487426558aafd7f7b4013a2e30802c128cc28cad9abe46ecd36c02f7fbcde7908fd4672334818d56a441c0871963d6bd89d911bef2ea
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
-  bin:
-    uuid: ./dist/bin/uuid
-  checksum: 10/9a5f7aa1d6f56dd1e8d5f2478f855f25c645e64e26e347a98e98d95781d5ed20062d6cca2eecb58ba7c84bc3910be95c0451ef4161906abaab44f9cb68ffbdd1
   languageName: node
   linkType: hard
 
@@ -17657,26 +17949,26 @@ __metadata:
   dependencies:
     ts-morph: "npm:^27.0.0"
   peerDependencies:
-    vite: ^7.1.11
+    vite: ^8.0.0
   languageName: unknown
   linkType: soft
 
-"vite@npm:^7.1.5":
-  version: 7.3.5
-  resolution: "vite@npm:7.3.5"
+"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0, vite@npm:^8.2.0":
+  version: 8.2.0
+  resolution: "vite@npm:8.2.0"
   dependencies:
-    esbuild: "npm:^0.27.0"
-    fdir: "npm:^6.5.0"
     fsevents: "npm:~2.3.3"
-    picomatch: "npm:^4.0.3"
-    postcss: "npm:^8.5.6"
-    rollup: "npm:^4.43.0"
-    tinyglobby: "npm:^0.2.15"
+    lightningcss: "npm:^1.33.0"
+    picomatch: "npm:^4.0.5"
+    postcss: "npm:^8.5.23"
+    rolldown: "npm:~1.2.0"
+    tinyglobby: "npm:^0.2.17"
   peerDependencies:
     "@types/node": ^20.19.0 || >=22.12.0
+    "@vitejs/devtools": ^0.4.0
+    esbuild: ^0.27.0 || ^0.28.0
     jiti: ">=1.21.0"
     less: ^4.0.0
-    lightningcss: ^1.21.0
     sass: ^1.70.0
     sass-embedded: ^1.70.0
     stylus: ">=0.54.8"
@@ -17690,11 +17982,13 @@ __metadata:
   peerDependenciesMeta:
     "@types/node":
       optional: true
+    "@vitejs/devtools":
+      optional: true
+    esbuild:
+      optional: true
     jiti:
       optional: true
     less:
-      optional: true
-    lightningcss:
       optional: true
     sass:
       optional: true
@@ -17712,21 +18006,21 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10/2e1337510d6b81948b035f8b096c9be22daf1101fc52ad3d06cad9e090057ba1c1396e5e12cbaac2485f9c6cdcc854f978fe862280bdfe1a9a4149c60734c125
+  checksum: 10/c019ae45923186aeced9c7ccd661250473e43eb5a136e8031a7ee2b02b69d9dfe5bd6a267130e2888a1dc69a3e5481779e467f5c2e0f15671e9360b40a8056ff
   languageName: node
   linkType: hard
 
-"vitest@npm:^4.1.7":
-  version: 4.1.7
-  resolution: "vitest@npm:4.1.7"
+"vitest@npm:^4.1.10":
+  version: 4.1.10
+  resolution: "vitest@npm:4.1.10"
   dependencies:
-    "@vitest/expect": "npm:4.1.7"
-    "@vitest/mocker": "npm:4.1.7"
-    "@vitest/pretty-format": "npm:4.1.7"
-    "@vitest/runner": "npm:4.1.7"
-    "@vitest/snapshot": "npm:4.1.7"
-    "@vitest/spy": "npm:4.1.7"
-    "@vitest/utils": "npm:4.1.7"
+    "@vitest/expect": "npm:4.1.10"
+    "@vitest/mocker": "npm:4.1.10"
+    "@vitest/pretty-format": "npm:4.1.10"
+    "@vitest/runner": "npm:4.1.10"
+    "@vitest/snapshot": "npm:4.1.10"
+    "@vitest/spy": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
     es-module-lexer: "npm:^2.0.0"
     expect-type: "npm:^1.3.0"
     magic-string: "npm:^0.30.21"
@@ -17744,12 +18038,12 @@ __metadata:
     "@edge-runtime/vm": "*"
     "@opentelemetry/api": ^1.9.0
     "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
-    "@vitest/browser-playwright": 4.1.7
-    "@vitest/browser-preview": 4.1.7
-    "@vitest/browser-webdriverio": 4.1.7
-    "@vitest/coverage-istanbul": 4.1.7
-    "@vitest/coverage-v8": 4.1.7
-    "@vitest/ui": 4.1.7
+    "@vitest/browser-playwright": 4.1.10
+    "@vitest/browser-preview": 4.1.10
+    "@vitest/browser-webdriverio": 4.1.10
+    "@vitest/coverage-istanbul": 4.1.10
+    "@vitest/coverage-v8": 4.1.10
+    "@vitest/ui": 4.1.10
     happy-dom: "*"
     jsdom: "*"
     vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -17780,7 +18074,7 @@ __metadata:
       optional: false
   bin:
     vitest: ./vitest.mjs
-  checksum: 10/23ce0ce8bf81856c1acf983c6138efda5d01b60cbdc5734abd0948f3b39cde14ea7bf0981a2ec8a6b05fe7f3658b211116997fd658fcd20c2f5740b5465502ca
+  checksum: 10/020843460fe696c23be2a363634dde4daf54625f1c443c24066ba3f87c478b0ccfdd5124343ba30eb092f54902ffea09f4bed0af4a16a9ee805e494ee2dce34e
   languageName: node
   linkType: hard
 
@@ -17898,7 +18192,7 @@ __metadata:
   dependencies:
     isexe: "npm:^3.1.1"
   bin:
-    node-which: ./bin/which.js
+    node-which: bin/which.js
   checksum: 10/df19b2cd8aac94b333fa29b42e8e371a21e634a742a3b156716f7752a5afe1d73fb5d8bce9b89326f453d96879e8fe626eb421e0117eb1a3ce9fd8c97f6b7db9
   languageName: node
   linkType: hard
@@ -17945,6 +18239,17 @@ __metadata:
     string-width: "npm:^5.0.1"
     strip-ansi: "npm:^7.0.1"
   checksum: 10/7b1e4b35e9bb2312d2ee9ee7dc95b8cb5f8b4b5a89f7dde5543fe66c1e3715663094defa50d75454ac900bd210f702d575f15f3f17fa9ec0291806d2578d1ddf
+  languageName: node
+  linkType: hard
+
+"wrap-ansi@npm:^9.0.0":
+  version: 9.0.2
+  resolution: "wrap-ansi@npm:9.0.2"
+  dependencies:
+    ansi-styles: "npm:^6.2.1"
+    string-width: "npm:^7.0.0"
+    strip-ansi: "npm:^7.1.0"
+  checksum: 10/f3907e1ea9717404ca53a338fa5a017c2121550c3a5305180e2bc08c03e21aa45068df55b0d7676bf57be1880ba51a84458c17241ebedea485fafa9ef16b4024
   languageName: node
   linkType: hard
 
@@ -18057,7 +18362,7 @@ __metadata:
   version: 2.8.3
   resolution: "yaml@npm:2.8.3"
   bin:
-    yaml: ./bin.mjs
+    yaml: bin.mjs
   checksum: 10/ecad41d39d34fae5cc17ea2d4b7f7f55faacd45cbce8983ba22d48d1ed1a92ed242ea49ea813a79ac39a69f75f9c5a03e7b5395fd954d55476f25e21a47c141d
   languageName: node
   linkType: hard
@@ -18084,13 +18389,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yauzl@npm:^2.10.0":
-  version: 2.10.0
-  resolution: "yauzl@npm:2.10.0"
+"yauzl@npm:^3.3.1":
+  version: 3.4.0
+  resolution: "yauzl@npm:3.4.0"
   dependencies:
-    buffer-crc32: "npm:~0.2.3"
-    fd-slicer: "npm:~1.1.0"
-  checksum: 10/1e4c311050dc0cf2ee3dbe8854fe0a6cde50e420b3e561a8d97042526b4cf7a0718d6c8d89e9e526a152f4a9cec55bcea9c3617264115f48bd6704cf12a04445
+    pend: "npm:~1.2.0"
+  checksum: 10/76c1ca208478135dcd0b9f8baaa2e40a761652e0ec793c5a6bdeb973118f9720adc487f388e8394b4cfb73ae1976083ff58be4ea0ec60e060ffc9cf232db2c0a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -678,7 +678,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.28.0, @babel/core@npm:^7.28.4":
+"@babel/core@npm:^7.28.0":
   version: 7.29.7
   resolution: "@babel/core@npm:7.29.7"
   dependencies:
@@ -757,13 +757,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-plugin-utils@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/helper-plugin-utils@npm:7.27.1"
-  checksum: 10/96136c2428888e620e2ec493c25888f9ceb4a21099dcf3dd4508ea64b58cdedbd5a9fb6c7b352546de84d6c24edafe482318646932a22c449ebd16d16c22d864
-  languageName: node
-  linkType: hard
-
 "@babel/helper-string-parser@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/helper-string-parser@npm:7.29.7"
@@ -803,28 +796,6 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 10/da40c5928c95997b01aabe84fc3440881b8f20b866714fefa142961d37e82ffc03fbb9afed706f15f8a688278f95286ca0cea0d87ad6c77600f8c6c45d9824ee
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-react-jsx-self@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-react-jsx-self@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10/72cbae66a58c6c36f7e12e8ed79f292192d858dd4bb00e9e89d8b695e4c5cb6ef48eec84bffff421a5db93fd10412c581f1cccdb00264065df76f121995bdb68
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-react-jsx-source@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-react-jsx-source@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10/e2843362adb53692be5ee9fa07a386d2d8883daad2063a3575b3c373fc14cdf4ea7978c67a183cb631b4c9c8d77b2f48c24c088f8e65cc3600cb8e97d72a7161
   languageName: node
   linkType: hard
 
@@ -1976,7 +1947,7 @@ __metadata:
   version: 0.20.3
   resolution: "@e965/xlsx@npm:0.20.3"
   bin:
-    xlsx: bin/xlsx.njs
+    xlsx: ./bin/xlsx.njs
   checksum: 10/0e92ca7622a7dc4de0b4f8f4b9b506c5e1dbd511cd759b27bf3131a3da877f33b15f446e628739ce265457486c617ac60416db2fd03415dc8b0f20150ef67e22
   languageName: node
   linkType: hard
@@ -2738,7 +2709,7 @@ __metadata:
     md5: "npm:*"
     mkdirp: "npm:^1.0.4"
   bin:
-    mosaic: dist/index.mjs
+    mosaic: ./dist/index.mjs
   checksum: 10/3d05c1d56e574fb1dd7d9d0ca9e7f66ce5d11e3d8382d6e04bb8ad73c01e2281c2cafd3e810538b4ccfb3d1290cc0e0efd6d60cd69a84665b5fe4711f6144240
   languageName: node
   linkType: hard
@@ -4030,10 +4001,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/pluginutils@npm:1.0.0-beta.35":
-  version: 1.0.0-beta.35
-  resolution: "@rolldown/pluginutils@npm:1.0.0-beta.35"
-  checksum: 10/f6e28e437df02d1a184ce49726ffb53dfc24e3c3c67602c41352ddcbbeb51b292f7f973b62b0abd807af38b9913fa4d48f6892c698e1c6210642d0a33ec1a102
+"@rolldown/pluginutils@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@rolldown/pluginutils@npm:1.0.1"
+  checksum: 10/4e95cf9ce23d75e5aa03ea0249cd86f7d1e21f83fbf6f8520e4edd8a251ba1b82c4ba9bc13cd24b6c4661daec6225b06e6d35c64c604e731b230b2a49af47d05
   languageName: node
   linkType: hard
 
@@ -4521,7 +4492,7 @@ __metadata:
     "@types/react-dom": "npm:^18.3.7"
     "@types/tinycolor2": "npm:^1.4.3"
     "@typescript/native-preview": "npm:7.0.0-dev.20260601.1"
-    "@vitejs/plugin-react": "npm:^5.0.3"
+    "@vitejs/plugin-react": "npm:^6.0.2"
     ag-grid-community: "npm:^32.0.0"
     ag-grid-enterprise: "npm:^32.0.0"
     ag-grid-react: "npm:^32.0.0"
@@ -4555,9 +4526,8 @@ __metadata:
     storybook: "npm:10.5.3"
     stylelint: "npm:^17.0.0"
     typescript: "npm:^6.0.0"
-    vite: "npm:^7.1.5"
-    vite-tsconfig-paths: "npm:^5.1.4"
-    vitest: "npm:^4.0.0"
+    vite: "npm:^8.0.14"
+    vitest: "npm:^4.1.7"
     yup: "npm:^1.7.1"
   dependenciesMeta:
     cypress:
@@ -6841,7 +6811,7 @@ __metadata:
     "@typescript/native-preview-win32-x64":
       optional: true
   bin:
-    tsgo: bin/tsgo.js
+    tsgo: ./bin/tsgo.js
   checksum: 10/b765917a1f5861ca45a43d53c85401a82e3d523deaee7e232ee7d2e18590556c5e501c5d48871332e558af7aca1b4d3878d790aca885e6b9caa534eac7928412
   languageName: node
   linkType: hard
@@ -6904,19 +6874,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-react@npm:^5.0.3":
-  version: 5.0.3
-  resolution: "@vitejs/plugin-react@npm:5.0.3"
+"@vitejs/plugin-react@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "@vitejs/plugin-react@npm:6.0.2"
   dependencies:
-    "@babel/core": "npm:^7.28.4"
-    "@babel/plugin-transform-react-jsx-self": "npm:^7.27.1"
-    "@babel/plugin-transform-react-jsx-source": "npm:^7.27.1"
-    "@rolldown/pluginutils": "npm:1.0.0-beta.35"
-    "@types/babel__core": "npm:^7.20.5"
-    react-refresh: "npm:^0.17.0"
+    "@rolldown/pluginutils": "npm:^1.0.0"
   peerDependencies:
-    vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
-  checksum: 10/152e159f1121e8c403eba6d77a16fe67e316e432826ffbb81a72753f093597cb3eb65d9e46049fddac9099701974bce817d6908c5228a5f9c32c54f0baf13c66
+    "@rolldown/plugin-babel": ^0.1.7 || ^0.2.0
+    babel-plugin-react-compiler: ^1.0.0
+    vite: ^8.0.0
+  peerDependenciesMeta:
+    "@rolldown/plugin-babel":
+      optional: true
+    babel-plugin-react-compiler:
+      optional: true
+  checksum: 10/4b3693e94c1907aac699df34fa71c8d5d53228b110f7520dcaca56c96c7127772e806147fa9d2f15edfc64cdefbe13b28c4c71e058601f7311d303ad435701c6
   languageName: node
   linkType: hard
 
@@ -6933,25 +6905,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/expect@npm:4.1.10":
-  version: 4.1.10
-  resolution: "@vitest/expect@npm:4.1.10"
+"@vitest/expect@npm:4.1.7":
+  version: 4.1.7
+  resolution: "@vitest/expect@npm:4.1.7"
   dependencies:
     "@standard-schema/spec": "npm:^1.1.0"
     "@types/chai": "npm:^5.2.2"
-    "@vitest/spy": "npm:4.1.10"
-    "@vitest/utils": "npm:4.1.10"
+    "@vitest/spy": "npm:4.1.7"
+    "@vitest/utils": "npm:4.1.7"
     chai: "npm:^6.2.2"
     tinyrainbow: "npm:^3.1.0"
-  checksum: 10/487fcad404a68968a54ae5fb9d099f12170cd793420a04b34a5606516317090c50a8303ab687c70166ee181864e3e138941d4a96d0405434dcd37696b3105350
+  checksum: 10/a609af6c0497cd510ce8aed099f18faf6d6642bc8eb3432b688f2b39d7354a04d1c4ee9dc28bcfb9d4be701ceac88384d586592a520a324b3773ea43e8a1e677
   languageName: node
   linkType: hard
 
-"@vitest/mocker@npm:4.1.10":
-  version: 4.1.10
-  resolution: "@vitest/mocker@npm:4.1.10"
+"@vitest/mocker@npm:4.1.7":
+  version: 4.1.7
+  resolution: "@vitest/mocker@npm:4.1.7"
   dependencies:
-    "@vitest/spy": "npm:4.1.10"
+    "@vitest/spy": "npm:4.1.7"
     estree-walker: "npm:^3.0.3"
     magic-string: "npm:^0.30.21"
   peerDependencies:
@@ -6962,7 +6934,7 @@ __metadata:
       optional: true
     vite:
       optional: true
-  checksum: 10/ae9645d1bcdad3ab7de7182feb4f1c9148a5ff97cef19581eec9257112aace94889eee9a1ad12e40ce59453ac05f52453b5fdb49ff76a31af8ccdbaaa4471ef3
+  checksum: 10/124d0ec9cc099fde1fca4b065b81a389e9ba2204ecba9729751a0a022d0ffaa34609d9dc60c1f8494ee972c2209035a4476ff1dddc1790e07d1ca28a1103b30d
   languageName: node
   linkType: hard
 
@@ -6975,34 +6947,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/pretty-format@npm:4.1.10":
-  version: 4.1.10
-  resolution: "@vitest/pretty-format@npm:4.1.10"
+"@vitest/pretty-format@npm:4.1.7":
+  version: 4.1.7
+  resolution: "@vitest/pretty-format@npm:4.1.7"
   dependencies:
     tinyrainbow: "npm:^3.1.0"
-  checksum: 10/e4f6907143ab0e40dda29d70b17027586c92921d622091321f10512e660b3995dcee7aa56e17b750b72560f295e25f96035372348415f18ebfd39b66a55b4704
+  checksum: 10/79c86c39173577250955744c3444d8c0c9304c95c7d351b91a916229252c3733a0e969741a8f3441a5c4777b5a4371707ecb747ea4bfd2c07e72ddf1ef621293
   languageName: node
   linkType: hard
 
-"@vitest/runner@npm:4.1.10":
-  version: 4.1.10
-  resolution: "@vitest/runner@npm:4.1.10"
+"@vitest/runner@npm:4.1.7":
+  version: 4.1.7
+  resolution: "@vitest/runner@npm:4.1.7"
   dependencies:
-    "@vitest/utils": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.7"
     pathe: "npm:^2.0.3"
-  checksum: 10/2c962cb13af0880990036808a35679b7ac6657c8f542490234c2faa6ffd2ab080ac6bf21b487c64d84aa635cfb37b49eb679098c2003a100dfc6c4d5e87bf055
+  checksum: 10/429f1e0cc93f66a681d8acc816e21ac41258b07550f9139d004aab103bb06be53e3d91fc66886cef1ba1460a120f5fe4b12d6fe32dafdb1b06740dd119d70f7e
   languageName: node
   linkType: hard
 
-"@vitest/snapshot@npm:4.1.10":
-  version: 4.1.10
-  resolution: "@vitest/snapshot@npm:4.1.10"
+"@vitest/snapshot@npm:4.1.7":
+  version: 4.1.7
+  resolution: "@vitest/snapshot@npm:4.1.7"
   dependencies:
-    "@vitest/pretty-format": "npm:4.1.10"
-    "@vitest/utils": "npm:4.1.10"
+    "@vitest/pretty-format": "npm:4.1.7"
+    "@vitest/utils": "npm:4.1.7"
     magic-string: "npm:^0.30.21"
     pathe: "npm:^2.0.3"
-  checksum: 10/7940d83ffd2fbebf9a04ea31e196b7e8bf981093ec739950959fe8dd29caa33c80823780fb4b1063d9459c44a0a8d8b2748c00dfb6941becd7404e6d687eea01
+  checksum: 10/ef7001add6724c025772891616338e6081ecdb11a92c084ca1d09c4662cf632e5877bec4cb38056aabc311f29fbe149c89fbf332975829087f3817554fe92cde
   languageName: node
   linkType: hard
 
@@ -7015,10 +6987,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/spy@npm:4.1.10":
-  version: 4.1.10
-  resolution: "@vitest/spy@npm:4.1.10"
-  checksum: 10/7c1b79a95474338e0659f0f2e43be4df1ef7939ff5b37b044954e0287582947803bd417508f44a7f244809672309d9b3dd67660b704ec3fe7f323cc958ae47a3
+"@vitest/spy@npm:4.1.7":
+  version: 4.1.7
+  resolution: "@vitest/spy@npm:4.1.7"
+  checksum: 10/49a9959c615f45ec593379a6d1a238190d08524857a6c4819b724134ce8a1a96d94e20144723d245941ce1ada54d8b00552573810d629880ecb8c3ff03b6d1ad
   languageName: node
   linkType: hard
 
@@ -7033,14 +7005,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/utils@npm:4.1.10":
-  version: 4.1.10
-  resolution: "@vitest/utils@npm:4.1.10"
+"@vitest/utils@npm:4.1.7":
+  version: 4.1.7
+  resolution: "@vitest/utils@npm:4.1.7"
   dependencies:
-    "@vitest/pretty-format": "npm:4.1.10"
+    "@vitest/pretty-format": "npm:4.1.7"
     convert-source-map: "npm:^2.0.0"
     tinyrainbow: "npm:^3.1.0"
-  checksum: 10/95484aad55c7b00bbcd4963e27cbb86fe207620a6093973d68da9d0a06bad37c388d84c9ab43d5f35d88e46c8f376a5592d9c54c025c958361160f4802bb25ee
+  checksum: 10/9cc729618dade24de3ad6862c288c22e9daac3fda5cae0abc9b6ce87035cc8e7efa2b66c3c124ae08beef462b36761b062e792bbc619798b832a7ea9382ed12a
   languageName: node
   linkType: hard
 
@@ -7583,7 +7555,7 @@ __metadata:
   peerDependencies:
     browserslist: "*"
   bin:
-    browserslist-to-esbuild: cli/index.js
+    browserslist-to-esbuild: ./cli/index.js
   checksum: 10/5e91b23ba5ac47412b7456bbb74ee11b35d1083163e9e8e001e48f3a975c65758a4559ab532812d8518877a1d8f68c5b649b88a08722b9543b38e633e6943f7d
   languageName: node
   linkType: hard
@@ -8196,8 +8168,8 @@ __metadata:
     tree-kill: "npm:^1.2.2"
     yargs: "npm:^17.7.2"
   bin:
-    conc: dist/bin/concurrently.js
-    concurrently: dist/bin/concurrently.js
+    conc: ./dist/bin/concurrently.js
+    concurrently: ./dist/bin/concurrently.js
   checksum: 10/1cf3d2e68841698412adb104991d1390ff6a212e6e5f2066a7e5cc837dc39287d11d57dd2ed452174e048d71de628764cd65a5fafaa620ed6f16255ab5ed14aa
   languageName: node
   linkType: hard
@@ -8280,8 +8252,8 @@ __metadata:
     "@epic-web/invariant": "npm:^1.0.0"
     cross-spawn: "npm:^7.0.6"
   bin:
-    cross-env: dist/bin/cross-env.js
-    cross-env-shell: dist/bin/cross-env-shell.js
+    cross-env: ./dist/bin/cross-env.js
+    cross-env-shell: ./dist/bin/cross-env-shell.js
   checksum: 10/1585ccc7c819ed03e0b8d385515d422b34a467404a695f9615e44178bbf2f1e38679691c691e4b8e9208ad7bf79867996ec2eadaac51b93b7e3e5edcc2c8a1e2
   languageName: node
   linkType: hard
@@ -10283,7 +10255,7 @@ __metadata:
     package-json-from-dist: "npm:^1.0.0"
     path-scurry: "npm:^1.11.1"
   bin:
-    glob: dist/esm/bin.mjs
+    glob: ./dist/esm/bin.mjs
   checksum: 10/ab3bccfefcc0afaedbd1f480cd0c4a2c0e322eb3f0aa7ceaa31b3f00b825069f17cf0f1fc8b6f256795074b903f37c0ade37ddda6a176aa57f1c2bbfe7240653
   languageName: node
   linkType: hard
@@ -10396,13 +10368,6 @@ __metadata:
   version: 0.1.4
   resolution: "globjoin@npm:0.1.4"
   checksum: 10/1e7e0f145f6572134e999b5511767698c8196e891f50db76a25189c897f355aec1b7e62f9eeaa0626db55460353470ac6bec4aa118beb710e4543037e705647a
-  languageName: node
-  linkType: hard
-
-"globrex@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "globrex@npm:0.1.2"
-  checksum: 10/81ce62ee6f800d823d6b7da7687f841676d60ee8f51f934ddd862e4057316d26665c4edc0358d4340a923ac00a514f8b67c787e28fe693aae16350f4e60d55e9
   languageName: node
   linkType: hard
 
@@ -11166,7 +11131,7 @@ __metadata:
   version: 3.0.0
   resolution: "is-docker@npm:3.0.0"
   bin:
-    is-docker: cli.js
+    is-docker: ./cli.js
   checksum: 10/b698118f04feb7eaf3338922bd79cba064ea54a1c3db6ec8c0c8d8ee7613e7e5854d802d3ef646812a8a3ace81182a085dfa0a71cc68b06f3fa794b9783b3c90
   languageName: node
   linkType: hard
@@ -11214,7 +11179,7 @@ __metadata:
   dependencies:
     is-docker: "npm:^3.0.0"
   bin:
-    is-inside-container: cli.js
+    is-inside-container: ./cli.js
   checksum: 10/c50b75a2ab66ab3e8b92b3bc534e1ea72ca25766832c0623ac22d134116a98bcf012197d1caabe1d1c4bd5f84363d4aa5c36bb4b585fbcaf57be172cd10a1a03
   languageName: node
   linkType: hard
@@ -13040,7 +13005,7 @@ __metadata:
   version: 4.2.0
   resolution: "mustache@npm:4.2.0"
   bin:
-    mustache: bin/mustache
+    mustache: ./bin/mustache
   checksum: 10/6e668bd5803255ab0779c3983b9412b5c4f4f90e822230e0e8f414f5449ed7a137eed29430e835aa689886f663385cfe05f808eb34b16e1f3a95525889b05cd3
   languageName: node
   linkType: hard
@@ -13081,7 +13046,7 @@ __metadata:
   version: 3.3.16
   resolution: "nanoid@npm:3.3.16"
   bin:
-    nanoid: bin/nanoid.cjs
+    nanoid: ./bin/nanoid.cjs
   checksum: 10/8004af92b5541af1dbd23b69845b5026f777d5b7ef07163cea1837aae86e052ced8b383cecbf8a4f1b5e77ae207df96dc45e16b9e0fa3c4b761d085f1e42851b
   languageName: node
   linkType: hard
@@ -13200,7 +13165,7 @@ __metadata:
     sass:
       optional: true
   bin:
-    next: dist/bin/next
+    next: ./dist/bin/next
   checksum: 10/29434e14b1a3026eeb2e2e719885be592319f4777cb0414017769d87c382051fb1352cb2c94b9b1b0a5f17526d8c6d731f5d425012146135a4583b09c1e7be00
   languageName: node
   linkType: hard
@@ -13236,9 +13201,9 @@ __metadata:
   version: 4.8.4
   resolution: "node-gyp-build@npm:4.8.4"
   bin:
-    node-gyp-build: bin.js
-    node-gyp-build-optional: optional.js
-    node-gyp-build-test: build-test.js
+    node-gyp-build: ./bin.js
+    node-gyp-build-optional: ./optional.js
+    node-gyp-build-test: ./build-test.js
   checksum: 10/6a7d62289d1afc419fc8fc9bd00aa4e554369e50ca0acbc215cb91446148b75ff7e2a3b53c2c5b2c09a39d416d69f3d3237937860373104b5fe429bf30ad9ac5
   languageName: node
   linkType: hard
@@ -13258,7 +13223,7 @@ __metadata:
     tinyglobby: "npm:^0.2.12"
     which: "npm:^6.0.0"
   bin:
-    node-gyp: bin/node-gyp.js
+    node-gyp: ./bin/node-gyp.js
   checksum: 10/d93079236cef1dd7fa4df683708d8708ad255c55865f6656664c8959e4d3963d908ac48e8f9f341705432e979dbbf502a40d68d65a17fe35956a5a05ba6c1cb4
   languageName: node
   linkType: hard
@@ -14011,7 +13976,7 @@ __metadata:
     sonic-boom: "npm:^4.0.1"
     thread-stream: "npm:^4.0.0"
   bin:
-    pino: bin.js
+    pino: ./bin.js
   checksum: 10/46cad7bf1859c83a8a9c43af764e5165f44057ce76d44b1b2b4390f2abccb8a579f42abfe742d88b4d8e1d339213afb46ea50fc39c50095dd1f0f9fe26ea1342
   languageName: node
   linkType: hard
@@ -14488,7 +14453,7 @@ __metadata:
   version: 2.8.8
   resolution: "prettier@npm:2.8.8"
   bin:
-    prettier: bin-prettier.js
+    prettier: ./bin-prettier.js
   checksum: 10/00cdb6ab0281f98306cd1847425c24cbaaa48a5ff03633945ab4c701901b8e96ad558eb0777364ffc312f437af9b5a07d0f45346266e8245beaf6247b9c62b24
   languageName: node
   linkType: hard
@@ -14497,7 +14462,7 @@ __metadata:
   version: 3.3.3
   resolution: "prettier@npm:3.3.3"
   bin:
-    prettier: bin/prettier.cjs
+    prettier: ./bin/prettier.cjs
   checksum: 10/5beac1f30b5b40162532b8e2f7c3a4eb650910a2695e9c8512a62ffdc09dae93190c29db9107fa7f26d1b6c71aad3628ecb9b5de1ecb0911191099be109434d7
   languageName: node
   linkType: hard
@@ -14945,13 +14910,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-refresh@npm:^0.17.0":
-  version: 0.17.0
-  resolution: "react-refresh@npm:0.17.0"
-  checksum: 10/5e94f07d43bb1cfdc9b0c6e0c8c73e754005489950dcff1edb53aa8451d1d69a47b740b195c7c80fb4eb511c56a3585dc55eddd83f0097fb5e015116a1460467
-  languageName: node
-  linkType: hard
-
 "react-resizable-panels@npm:^3.0.0":
   version: 3.0.1
   resolution: "react-resizable-panels@npm:3.0.1"
@@ -15309,7 +15267,7 @@ __metadata:
     argparse: "npm:^1.0.10"
     autolinker: "npm:^3.11.0"
   bin:
-    remarkable: bin/remarkable.js
+    remarkable: ./bin/remarkable.js
   checksum: 10/3734e9cd5105b9655a993e498890d99706a86707bccabf5d64b57f0f8ec9c5e66cdd7f06aae5fe07ca8633d93377edc803318626dd581e75f5f85aba69c350fb
   languageName: node
   linkType: hard
@@ -15394,7 +15352,7 @@ __metadata:
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
-    resolve: bin/resolve
+    resolve: ./bin/resolve
   checksum: 10/e1b2e738884a08de03f97ee71494335eba8c2b0feb1de9ae065e82c48997f349f77a2b10e8817e147cf610bfabc4b1cb7891ee8eaf5bf80d4ad514a34c4fab0a
   languageName: node
   linkType: hard
@@ -15407,7 +15365,7 @@ __metadata:
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
-    resolve: bin/resolve
+    resolve: ./bin/resolve
   checksum: 10/fd342cad25e52cd6f4f3d1716e189717f2522bfd6641109fe7aa372f32b5714a296ed7c238ddbe7ebb0c1ddfe0b7f71c9984171024c97cf1b2073e3e40ff71a8
   languageName: node
   linkType: hard
@@ -15498,7 +15456,7 @@ __metadata:
     glob: "npm:^13.0.3"
     package-json-from-dist: "npm:^1.0.1"
   bin:
-    rimraf: dist/esm/bin.mjs
+    rimraf: ./dist/esm/bin.mjs
   checksum: 10/dd98ec2ad7cd2cccae1c7110754d472eac8edb2bab8a8b057dce04edfe1433dab246a889b3fd85a66c78ca81caa1429caa0e736c7647f6832b04fd5d4dfb8ab8
   languageName: node
   linkType: hard
@@ -15746,7 +15704,7 @@ __metadata:
   version: 6.3.1
   resolution: "semver@npm:6.3.1"
   bin:
-    semver: bin/semver.js
+    semver: ./bin/semver.js
   checksum: 10/1ef3a85bd02a760c6ef76a45b8c1ce18226de40831e02a00bad78485390b98b6ccaa31046245fc63bba4a47a6a592b6c7eedc65cc47126e60489f9cc1ce3ed7e
   languageName: node
   linkType: hard
@@ -15798,7 +15756,7 @@ __metadata:
     safe-buffer: "npm:^5.2.1"
     to-buffer: "npm:^1.2.0"
   bin:
-    sha.js: bin.js
+    sha.js: ./bin.js
   checksum: 10/39c0993592c2ab34eb2daae2199a2a1d502713765aecb611fd97c0c4ab7cd53e902d628e1962aaf384bafd28f55951fef46dcc78799069ce41d74b03aa13b5a7
   languageName: node
   linkType: hard
@@ -16189,10 +16147,6 @@ __metadata:
     jsbn: "npm:~0.1.0"
     safer-buffer: "npm:^2.0.2"
     tweetnacl: "npm:~0.14.0"
-  bin:
-    sshpk-conv: bin/sshpk-conv
-    sshpk-sign: bin/sshpk-sign
-    sshpk-verify: bin/sshpk-verify
   checksum: 10/858339d43e3c6b6a848772a66f69442ce74f1a37655d9f35ba9d1f85329499ff0000af9f8ab83dbb39ad24c0c370edabe0be1e39863f70c6cded9924b8458c34
   languageName: node
   linkType: hard
@@ -16553,8 +16507,8 @@ __metadata:
     pirates: "npm:^4.0.1"
     ts-interface-checker: "npm:^0.1.9"
   bin:
-    sucrase: bin/sucrase
-    sucrase-node: bin/sucrase-node
+    sucrase: ./bin/sucrase
+    sucrase-node: ./bin/sucrase-node
   checksum: 10/bc601558a62826f1c32287d4fdfa4f2c09fe0fec4c4d39d0e257fd9116d7d6227a18309721d4185ec84c9dc1af0d5ec0e05a42a337fbb74fc293e068549aacbe
   languageName: node
   linkType: hard
@@ -16938,12 +16892,12 @@ __metadata:
   linkType: hard
 
 "tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.14, tinyglobby@npm:^0.2.15":
-  version: 0.2.15
-  resolution: "tinyglobby@npm:0.2.15"
+  version: 0.2.17
+  resolution: "tinyglobby@npm:0.2.17"
   dependencies:
     fdir: "npm:^6.5.0"
-    picomatch: "npm:^4.0.3"
-  checksum: 10/d72bd826a8b0fa5fa3929e7fe5ba48fceb2ae495df3a231b6c5408cd7d8c00b58ab5a9c2a76ba56a62ee9b5e083626f1f33599734bed1ffc4b792406408f0ca2
+    picomatch: "npm:^4.0.4"
+  checksum: 10/f85e8a217d675c3f78d5f0ad25ea4557e7e023ed13ddc2b014da10bd0312eea53a34cd52356af07ccdff777f1243012547656282a4ca70936f68bf5065fbaa71
   languageName: node
   linkType: hard
 
@@ -17178,20 +17132,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsconfck@npm:^3.0.3":
-  version: 3.1.6
-  resolution: "tsconfck@npm:3.1.6"
-  peerDependencies:
-    typescript: ^5.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  bin:
-    tsconfck: bin/tsconfck.js
-  checksum: 10/8574595286850273bf83319b4e67ca760088df3c36f7ca1425aaf797416672e854271bd31e75c9b3e1836ed5b66410c6bc38cbbda9c638a5416c6a682ed94132
-  languageName: node
-  linkType: hard
-
 "tsconfig-paths@npm:^4.2.0":
   version: 4.2.0
   resolution: "tsconfig-paths@npm:4.2.0"
@@ -17301,8 +17241,8 @@ __metadata:
   version: 6.0.2
   resolution: "typescript@npm:6.0.2"
   bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
+    tsc: ./bin/tsc
+    tsserver: ./bin/tsserver
   checksum: 10/b9fc2fcee7ee8e5ca6f5138181964550531e18e2d20ecb71b802d4d495881e3444e0ef94cbb6e84eb2ba41e913f6feae3ca33cc722b32e6e6dfadb32d23b80e6
   languageName: node
   linkType: hard
@@ -17311,8 +17251,8 @@ __metadata:
   version: 6.0.2
   resolution: "typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>::version=6.0.2&hash=5786d5"
   bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
+    tsc: ./bin/tsc
+    tsserver: ./bin/tsserver
   checksum: 10/e5501dfcf8c5b6b9a61f6fa53decc40187cebe3a2b7b2bd51c615007ad4cf6d58298461fef63294f6be9d5f2f33019b2a2e2bf02d9cb7d7f6ec94372bf24ffa2
   languageName: node
   linkType: hard
@@ -17582,7 +17522,7 @@ __metadata:
   version: 11.1.1
   resolution: "uuid@npm:11.1.1"
   bin:
-    uuid: dist/esm/bin/uuid
+    uuid: ./dist/esm/bin/uuid
   checksum: 10/16411d3dc12a08d6691616c09a75e66a7f900ba1beef6628a76fe0602f82fae2ee537b564d0b7bc95c24f58d059ca9b58c75a1e806118efb50e17822ff00ddd2
   languageName: node
   linkType: hard
@@ -17600,7 +17540,7 @@ __metadata:
   version: 8.3.2
   resolution: "uuid@npm:8.3.2"
   bin:
-    uuid: dist/bin/uuid
+    uuid: ./dist/bin/uuid
   checksum: 10/9a5f7aa1d6f56dd1e8d5f2478f855f25c645e64e26e347a98e98d95781d5ed20062d6cca2eecb58ba7c84bc3910be95c0451ef4161906abaab44f9cb68ffbdd1
   languageName: node
   linkType: hard
@@ -17721,22 +17661,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"vite-tsconfig-paths@npm:^5.1.4":
-  version: 5.1.4
-  resolution: "vite-tsconfig-paths@npm:5.1.4"
-  dependencies:
-    debug: "npm:^4.1.1"
-    globrex: "npm:^0.1.2"
-    tsconfck: "npm:^3.0.3"
-  peerDependencies:
-    vite: "*"
-  peerDependenciesMeta:
-    vite:
-      optional: true
-  checksum: 10/b409dbd17829f560021a71dba3e473b9c06dcf5fdc9d630b72c1f787145ec478b38caff1be04868971ac8bdcbf0f5af45eeece23dbc9c59c54b901f867740ae0
-  languageName: node
-  linkType: hard
-
 "vite@npm:^7.1.5":
   version: 7.3.5
   resolution: "vite@npm:7.3.5"
@@ -17792,17 +17716,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:^4.0.0":
-  version: 4.1.10
-  resolution: "vitest@npm:4.1.10"
+"vitest@npm:^4.1.7":
+  version: 4.1.7
+  resolution: "vitest@npm:4.1.7"
   dependencies:
-    "@vitest/expect": "npm:4.1.10"
-    "@vitest/mocker": "npm:4.1.10"
-    "@vitest/pretty-format": "npm:4.1.10"
-    "@vitest/runner": "npm:4.1.10"
-    "@vitest/snapshot": "npm:4.1.10"
-    "@vitest/spy": "npm:4.1.10"
-    "@vitest/utils": "npm:4.1.10"
+    "@vitest/expect": "npm:4.1.7"
+    "@vitest/mocker": "npm:4.1.7"
+    "@vitest/pretty-format": "npm:4.1.7"
+    "@vitest/runner": "npm:4.1.7"
+    "@vitest/snapshot": "npm:4.1.7"
+    "@vitest/spy": "npm:4.1.7"
+    "@vitest/utils": "npm:4.1.7"
     es-module-lexer: "npm:^2.0.0"
     expect-type: "npm:^1.3.0"
     magic-string: "npm:^0.30.21"
@@ -17820,12 +17744,12 @@ __metadata:
     "@edge-runtime/vm": "*"
     "@opentelemetry/api": ^1.9.0
     "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
-    "@vitest/browser-playwright": 4.1.10
-    "@vitest/browser-preview": 4.1.10
-    "@vitest/browser-webdriverio": 4.1.10
-    "@vitest/coverage-istanbul": 4.1.10
-    "@vitest/coverage-v8": 4.1.10
-    "@vitest/ui": 4.1.10
+    "@vitest/browser-playwright": 4.1.7
+    "@vitest/browser-preview": 4.1.7
+    "@vitest/browser-webdriverio": 4.1.7
+    "@vitest/coverage-istanbul": 4.1.7
+    "@vitest/coverage-v8": 4.1.7
+    "@vitest/ui": 4.1.7
     happy-dom: "*"
     jsdom: "*"
     vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -17856,7 +17780,7 @@ __metadata:
       optional: false
   bin:
     vitest: ./vitest.mjs
-  checksum: 10/020843460fe696c23be2a363634dde4daf54625f1c443c24066ba3f87c478b0ccfdd5124343ba30eb092f54902ffea09f4bed0af4a16a9ee805e494ee2dce34e
+  checksum: 10/23ce0ce8bf81856c1acf983c6138efda5d01b60cbdc5734abd0948f3b39cde14ea7bf0981a2ec8a6b05fe7f3658b211116997fd658fcd20c2f5740b5465502ca
   languageName: node
   linkType: hard
 
@@ -17974,7 +17898,7 @@ __metadata:
   dependencies:
     isexe: "npm:^3.1.1"
   bin:
-    node-which: bin/which.js
+    node-which: ./bin/which.js
   checksum: 10/df19b2cd8aac94b333fa29b42e8e371a21e634a742a3b156716f7752a5afe1d73fb5d8bce9b89326f453d96879e8fe626eb421e0117eb1a3ce9fd8c97f6b7db9
   languageName: node
   linkType: hard
@@ -18133,7 +18057,7 @@ __metadata:
   version: 2.8.3
   resolution: "yaml@npm:2.8.3"
   bin:
-    yaml: bin.mjs
+    yaml: ./bin.mjs
   checksum: 10/ecad41d39d34fae5cc17ea2d4b7f7f55faacd45cbce8983ba22d48d1ed1a92ed242ea49ea813a79ac39a69f75f9c5a03e7b5395fd954d55476f25e21a47c141d
   languageName: node
   linkType: hard


### PR DESCRIPTION
Moves to vite 8, vite-tsconfig-paths can be removed since it's managed by vite now.

I also took the chance to clean up our tsconfig paths and apply them consistently.