### PR TITLE
Toolbar Fixes | Combobox focus behaviour

### DIFF
--- a/.changeset/empty-coins-turn.md
+++ b/.changeset/empty-coins-turn.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/lab": patch
+---
+
+Fixed `ToolbarNext` focus handling when composing multiselect `ComboBox` controls, preserving pill keyboard navigation and preventing focus flashes when restoring toolbar focus.

--- a/packages/lab/src/__tests__/__e2e__/toolbar-next/ToolbarNext.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/toolbar-next/ToolbarNext.cy.tsx
@@ -16,7 +16,7 @@ import {
 } from "@salt-ds/date-components";
 import { ToolbarContentNext, ToolbarNext, TooltrayNext } from "@salt-ds/lab";
 import { composeStories } from "@storybook/react-vite";
-import { useState } from "react";
+import { type FocusEventHandler, useState } from "react";
 import * as toolbarNextStories from "../../../../stories/toolbar-next/toolbar-next.cypress.stories";
 
 const {
@@ -37,6 +37,7 @@ const {
 } = composeStories(toolbarNextStories);
 const adapterDayjs = new AdapterDayjs();
 const toolbarHarnessStyle = { height: 220, width: 760 };
+const statusOptions = ["All", "New", "Working", "Fully Filled", "Cancelled"];
 
 function openOverflowWithKeyboard(name: string | RegExp) {
   cy.findByRole("button", { name }).focus().should("be.focused");
@@ -672,6 +673,43 @@ function SharedOverflowComboBoxFocusReentryTestCase() {
           <TooltrayNext>
             <Button appearance="transparent">Export</Button>
             <Button appearance="solid">Run</Button>
+          </TooltrayNext>
+        </ToolbarContentNext>
+      </ToolbarNext>
+      <button data-testid="toolbar-after">After toolbar</button>
+    </div>
+  );
+}
+
+function MultiselectComboBoxKeyboardTestCase({
+  onComboBoxFocus,
+}: {
+  onComboBoxFocus?: FocusEventHandler<HTMLDivElement>;
+}) {
+  return (
+    <div className="Flexbox" style={{ height: 240, width: 680 }}>
+      <button data-testid="toolbar-before">Before toolbar</button>
+      <ToolbarNext aria-label="Multiselect combo box keyboard toolbar">
+        <ToolbarContentNext position="start">
+          <TooltrayNext overflowMode="none">
+            <ComboBox
+              aria-label="Status filter"
+              bordered
+              defaultSelected={["New", "Working"]}
+              multiselect
+              onFocus={onComboBoxFocus}
+              truncate
+              style={{ width: 260 }}
+            >
+              {statusOptions.map((option) => (
+                <Option key={option} value={option} />
+              ))}
+            </ComboBox>
+          </TooltrayNext>
+        </ToolbarContentNext>
+        <ToolbarContentNext position="end">
+          <TooltrayNext overflowMode="none">
+            <Button appearance="transparent">Export</Button>
           </TooltrayNext>
         </ToolbarContentNext>
       </ToolbarNext>
@@ -1548,6 +1586,46 @@ describe("Given ToolbarNext keyboard navigation", () => {
     cy.findByRole("button", { name: "Columns" }).should("be.focused");
     cy.realPress("Tab");
     cy.findByTestId("toolbar-after").should("be.focused");
+  });
+
+  it("keeps multiselect combo box pill arrow navigation inside the combo box", () => {
+    cy.mount(<MultiselectComboBoxKeyboardTestCase />);
+
+    cy.findByTestId("toolbar-before").focus();
+    cy.realPress("Tab");
+    cy.contains("button", "New").should("be.focused");
+
+    cy.realPress("ArrowRight");
+    cy.contains("button", "Working").should("be.focused");
+
+    cy.realPress("ArrowRight");
+    cy.findByRole("combobox").should("be.focused");
+
+    cy.realPress("ArrowLeft");
+    cy.contains("button", "Working").should("be.focused");
+
+    cy.realPress("ArrowLeft");
+    cy.contains("button", "New").should("be.focused");
+  });
+
+  it("restores remembered focus without firing combo box focus on toolbar re-entry", () => {
+    const comboBoxFocusSpy = cy.stub().as("comboBoxFocus");
+
+    cy.mount(
+      <MultiselectComboBoxKeyboardTestCase
+        onComboBoxFocus={comboBoxFocusSpy}
+      />,
+    );
+
+    cy.findByRole("button", { name: "Export" })
+      .realClick()
+      .should("be.focused");
+    cy.findByTestId("toolbar-before").focus();
+    cy.get("@comboBoxFocus").should("not.have.been.called");
+
+    cy.realPress("Tab");
+    cy.findByRole("button", { name: "Export" }).should("be.focused");
+    cy.get("@comboBoxFocus").should("not.have.been.called");
   });
 
   it("uses Left and Right to move through the toolbar from a dropdown", () => {

--- a/packages/lab/src/toolbar-next/ToolbarNextOverflow.tsx
+++ b/packages/lab/src/toolbar-next/ToolbarNextOverflow.tsx
@@ -72,6 +72,7 @@ const withBaseName = makePrefixer("saltToolbarNextOverflow");
 export type ToolbarNextItemHostKind = "main" | "measurement" | "overflow";
 
 const toolbarNextStatefulFocusRootSelector = [
+  ".saltComboBox-focused",
   ".saltDateInput-focused",
   ".saltInput-focused",
 ].join(", ");
@@ -116,8 +117,10 @@ function notifyToolbarNextReparentedFocusLoss(mountNode: HTMLDivElement) {
       toolbarNextStatefulFocusRootSelector,
     ),
   )
-    .map((root) =>
-      root.querySelector<HTMLElement>(toolbarNextFocusableSelector),
+    .map(
+      (root) =>
+        root.querySelector<HTMLElement>("input") ??
+        root.querySelector<HTMLElement>(toolbarNextFocusableSelector),
     )
     .filter((target): target is HTMLElement => target != null);
 

--- a/packages/lab/src/toolbar-next/toolbarNextKeyboardUtils.ts
+++ b/packages/lab/src/toolbar-next/toolbarNextKeyboardUtils.ts
@@ -466,7 +466,8 @@ function getToolbarNextKeyboardPolicy(
   if (
     target.isContentEditable ||
     isPlainTextInput(target) ||
-    isComboBoxInput(target)
+    isComboBoxInput(target) ||
+    isPillInputPill(target)
   ) {
     return {
       preserveHorizontalArrows: true,
@@ -501,6 +502,14 @@ function isComboBoxInput(target: HTMLElement) {
   return (
     target.tagName === "INPUT" &&
     target.closest('[role="combobox"], .saltComboBox') != null
+  );
+}
+
+function isPillInputPill(target: HTMLElement) {
+  return (
+    target.tagName === "BUTTON" &&
+    target.classList.contains("saltPill") &&
+    target.closest(".saltPillInput") != null
   );
 }
 

--- a/packages/lab/src/toolbar-next/toolbarNextKeyboardUtils.ts
+++ b/packages/lab/src/toolbar-next/toolbarNextKeyboardUtils.ts
@@ -580,12 +580,38 @@ export function isToolbarNextFocusable(
   return target.getClientRects().length > 0;
 }
 
+// Composite controls whose focus root (the element toolbar focus restore lands
+// on) differs from the inner element that handles keyboard interaction.
+// Restoring focus to the root would leave ArrowDown/Enter/Space targeting a
+// non-interactive wrapper, so we redirect to the interactive element
+const toolbarNextFocusEntryOverrides = [
+  { root: ".saltComboBox", interactive: 'input[role="combobox"]' },
+] as const;
+
 export function focusToolbarNextElement(
   target: HTMLElement | null | undefined,
 ) {
-  if (target?.isConnected) {
-    target.focus({ preventScroll: true });
+  const focusTarget = resolveToolbarNextFocusEntryTarget(target);
+
+  if (focusTarget?.isConnected) {
+    focusTarget.focus({ preventScroll: true });
   }
+}
+
+function resolveToolbarNextFocusEntryTarget(
+  target: HTMLElement | null | undefined,
+) {
+  if (!target) {
+    return target;
+  }
+
+  for (const { root, interactive } of toolbarNextFocusEntryOverrides) {
+    if (target.matches(root)) {
+      return target.querySelector<HTMLElement>(interactive) ?? target;
+    }
+  }
+
+  return target;
 }
 
 export function scheduleToolbarNextFocus(

--- a/packages/lab/src/toolbar-next/useToolbarNextKeyboardNavigation.ts
+++ b/packages/lab/src/toolbar-next/useToolbarNextKeyboardNavigation.ts
@@ -4,7 +4,6 @@ import {
   type PointerEventHandler,
   type RefObject,
   useCallback,
-  useEffect,
   useRef,
 } from "react";
 import {
@@ -34,6 +33,7 @@ interface UseToolbarNextKeyboardNavigationProps {
 
 interface ToolbarNextFocusEvent {
   relatedTarget: EventTarget | null;
+  stopPropagation: () => void;
   target: EventTarget | null;
 }
 
@@ -61,7 +61,6 @@ export function useToolbarNextKeyboardNavigation({
   const rememberedFocusRef = useRef<ToolbarNextFocusMemory | null>(null);
   const pointerDownTargetRef = useRef<EventTarget | null>(null);
   const restoringEntryFocusRef = useRef(false);
-  const restoreFrameRef = useRef<number | null>(null);
 
   const shouldPreserveItemMemoryForTrigger = useCallback(
     (groupKey: string) => {
@@ -80,17 +79,6 @@ export function useToolbarNextKeyboardNavigation({
     },
     [items, overflowedIds],
   );
-
-  useEffect(() => {
-    return () => {
-      const frame = restoreFrameRef.current;
-      const win = scopeRef.current?.ownerDocument.defaultView;
-
-      if (frame != null && win) {
-        win.cancelAnimationFrame(frame);
-      }
-    };
-  }, [scopeRef]);
 
   const rememberTarget = useCallback(
     (target: HTMLElement) => {
@@ -196,24 +184,7 @@ export function useToolbarNextKeyboardNavigation({
 
   const restoreEntryFocus = useCallback((target: HTMLElement) => {
     restoringEntryFocusRef.current = true;
-
-    const restoreFocus = () => {
-      restoreFrameRef.current = null;
-
-      focusToolbarNextElement(target);
-    };
-    const win = target.ownerDocument.defaultView;
-
-    if (win?.requestAnimationFrame) {
-      const currentFrame = restoreFrameRef.current;
-      if (currentFrame != null) {
-        win.cancelAnimationFrame(currentFrame);
-      }
-
-      restoreFrameRef.current = win.requestAnimationFrame(restoreFocus);
-    } else {
-      queueMicrotask(restoreFocus);
-    }
+    focusToolbarNextElement(target);
   }, []);
 
   const handleScopeFocus = useCallback(
@@ -282,6 +253,7 @@ export function useToolbarNextKeyboardNavigation({
           );
 
           if (restoreTarget && restoreTarget !== target) {
+            event.stopPropagation();
             restoreEntryFocus(restoreTarget);
             return;
           }
@@ -302,6 +274,7 @@ export function useToolbarNextKeyboardNavigation({
       );
 
       if (restoreTarget && restoreTarget !== target) {
+        event.stopPropagation();
         restoreEntryFocus(restoreTarget);
         return;
       }

--- a/packages/lab/stories/toolbar-next/toolbar-next.stories.tsx
+++ b/packages/lab/stories/toolbar-next/toolbar-next.stories.tsx
@@ -55,13 +55,7 @@ const filterOptions = [
   "Filter: Option B",
   "Filter: Option C",
 ];
-const statusOptions = [
-  "All",
-  "New",
-  "Working",
-  "Fully Filled",
-  "Cancelled",
-];
+const statusOptions = ["All", "New", "Working", "Fully Filled", "Cancelled"];
 const toolbarVariants = ["primary", "secondary", "tertiary"] as const;
 
 /**

--- a/packages/lab/stories/toolbar-next/toolbar-next.stories.tsx
+++ b/packages/lab/stories/toolbar-next/toolbar-next.stories.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   Checkbox,
+  ComboBox,
   Divider,
   Dropdown,
   Input,
@@ -53,6 +54,13 @@ const filterOptions = [
   "Filter: Option A",
   "Filter: Option B",
   "Filter: Option C",
+];
+const statusOptions = [
+  "All",
+  "New",
+  "Working",
+  "Fully Filled",
+  "Cancelled",
 ];
 const toolbarVariants = ["primary", "secondary", "tertiary"] as const;
 
@@ -377,6 +385,66 @@ export const MixedFormControls: StoryFn<typeof ToolbarNext> = () => (
   </ToolbarNext>
 );
 MixedFormControls.globals = {
+  responsive: "wrap",
+};
+
+/**
+ * Multiselect combo box with pill selection in the toolbar.
+ *
+ * Intended behavior:
+ * - A `ComboBox` with `multiselect` shows selected options as removable pills
+ *   inside the field, which is a common filter pattern in data toolbars.
+ * - `truncate` keeps the field at toolbar height when unfocused; it expands on
+ *   focus or when the list is open so users can reach all pills.
+ * - The status filter sits in the start band; utility actions and search stay
+ *   on the end band.
+ * - The filter tray uses default shared overflow so the combo box can collapse
+ *   into the generic overflow trigger when width is constrained.
+ */
+export const MultiselectComboBoxPills: StoryFn<typeof ToolbarNext> = () => (
+  <ToolbarNext
+    aria-label="Toolbar with multiselect combo box"
+    style={{ minWidth: "20vw" }}
+  >
+    <ToolbarContentNext position="start">
+      <TooltrayNext overflowPriority={4}>
+        <ComboBox
+          aria-label="Status filter"
+          bordered
+          defaultSelected={["New", "Working"]}
+          multiselect
+          truncate
+          style={{ width: 260 }}
+        >
+          {statusOptions.map((option) => (
+            <Option key={option} value={option} />
+          ))}
+        </ComboBox>
+      </TooltrayNext>
+    </ToolbarContentNext>
+    <ToolbarContentNext position="end">
+      <TooltrayNext align="end" overflowPriority={6}>
+        <Button appearance="transparent">
+          <ExportIcon aria-hidden />
+          Export
+        </Button>
+        <Button appearance="transparent">
+          <SettingsIcon aria-hidden />
+          Settings
+        </Button>
+      </TooltrayNext>
+      <TooltrayNext align="end" overflowMode="none">
+        <Input
+          bordered
+          startAdornment={<SearchIcon aria-hidden />}
+          placeholder="Search"
+          style={{ width: 180 }}
+        />
+      </TooltrayNext>
+    </ToolbarContentNext>
+  </ToolbarNext>
+);
+MultiselectComboBoxPills.globals = {
   responsive: "wrap",
 };
 

--- a/packages/lab/stories/toolbar-next/toolbar-next.stories.tsx
+++ b/packages/lab/stories/toolbar-next/toolbar-next.stories.tsx
@@ -396,10 +396,7 @@ MixedFormControls.globals = {
  *   into the generic overflow trigger when width is constrained.
  */
 export const MultiselectComboBoxPills: StoryFn<typeof ToolbarNext> = () => (
-  <ToolbarNext
-    aria-label="Toolbar with multiselect combo box"
-    style={{ minWidth: "20vw" }}
-  >
+  <ToolbarNext aria-label="Toolbar with multiselect combo box">
     <ToolbarContentNext position="start">
       <TooltrayNext overflowPriority={4}>
         <ComboBox


### PR DESCRIPTION
- Toolbar was not respecting a multiselect combobox internal keyboard navigation; in general i don't like how its done across other input types too because it becomes brittle to change
- Use stopPropagation but only to suppress re-entry onFocus event (focus temporarily always goes to the first focusable element in the toolbar and the toolbar decides to instantly move it to the remembered focus; we (carefully and intentionally) supress bubbling here (e.g. from the PillInput inside Combobox).