### PR TITLE
Add appearance and sentiment props to FileDropZoneTrigger

### DIFF
--- a/.changeset/file-drop-zone-trigger-sentiment-type.md
+++ b/.changeset/file-drop-zone-trigger-sentiment-type.md
@@ -1,0 +1,11 @@
+---
+"@salt-ds/core": minor
+---
+
+Added `appearance` and `sentiment` props to `FileDropZoneTrigger`. `sentiment` accepts `'accented' | 'neutral'` (defaults to `'neutral'`) and `appearance` accepts `'solid' | 'bordered' | 'transparent'` (defaults to `'solid'`).
+
+```tsx
+<FileDropZoneTrigger appearance="bordered" sentiment="accented" />
+```
+
+Also widened the props type so all native `<button>` attributes (e.g. `type`, `name`, `form`, `value`) are now accepted.

--- a/packages/core/src/file-drop-zone/FileDropZoneTrigger.tsx
+++ b/packages/core/src/file-drop-zone/FileDropZoneTrigger.tsx
@@ -1,16 +1,16 @@
 import {
   type ChangeEvent,
+  type ComponentPropsWithoutRef,
   type FocusEvent,
   forwardRef,
-  type HTMLAttributes,
   type SyntheticEvent,
   useRef,
 } from "react";
-import { Button } from "../button";
+import { Button, type ButtonProps } from "../button";
 import { useForkRef } from "../utils";
 
 export interface FileDropZoneTriggerProps
-  extends Omit<HTMLAttributes<HTMLButtonElement>, "onChange"> {
+  extends Omit<ComponentPropsWithoutRef<"button">, "onChange"> {
   /**
    * `accept` attribute for HTML <input>.
    *
@@ -29,6 +29,17 @@ export interface FileDropZoneTriggerProps
    * Callback for input change event
    */
   onChange?: (event: ChangeEvent<HTMLInputElement>, files: File[]) => void;
+  /**
+   * The appearance of the button. Options are 'solid', 'bordered', and 'transparent'.
+   * 'solid' is the default value.
+   */
+  appearance?: ButtonProps["appearance"];
+  /**
+   * The sentiment of the button. Options are 'accented' and 'neutral'.
+   * 'neutral' is the default value.
+   *
+   */
+  sentiment?: Extract<ButtonProps["sentiment"], "accented" | "neutral">;
 }
 
 export const FileDropZoneTrigger = forwardRef<

--- a/packages/core/stories/file-drop-zone/file-drop-zone.qa.stories.tsx
+++ b/packages/core/stories/file-drop-zone/file-drop-zone.qa.stories.tsx
@@ -26,6 +26,11 @@ export const AllExamplesGrid: StoryFn = () => {
         <strong>Drop files here or</strong>
         <FileDropZoneTrigger />
       </FileDropZone>
+      <FileDropZoneTrigger appearance="bordered" />
+      <FileDropZoneTrigger appearance="transparent" />
+      <FileDropZoneTrigger sentiment="accented" appearance="solid" />
+      <FileDropZoneTrigger sentiment="accented" appearance="bordered" />
+      <FileDropZoneTrigger sentiment="accented" appearance="transparent" />
     </QAContainer>
   );
 };


### PR DESCRIPTION
Closes https://github.com/jpmorganchase/salt-ds/issues/5150

I added types for all appearances but only neutral and accented sentiments for now.