### PR TITLE
Add accessible names to icon-only buttons, dialogs, drawers, and avatars in examples

### DIFF
--- a/packages/core/stories/patterns/app-header/app-header.stories.tsx
+++ b/packages/core/stories/patterns/app-header/app-header.stories.tsx
@@ -154,20 +154,22 @@ const MobileAppHeader: FC<{
         >
           {!drawerOpen && (
             <Button
+              aria-label="Open navigation"
               onClick={() => setDrawerOpen(true)}
               style={{ alignSelf: "center" }}
               appearance="transparent"
             >
-              <MenuIcon />
+              <MenuIcon aria-hidden />
             </Button>
           )}
           {drawerOpen && (
             <Button
+              aria-label="Close navigation"
               onClick={() => setDrawerOpen(false)}
               style={{ alignSelf: "center" }}
               appearance="transparent"
             >
-              <CloseIcon />
+              <CloseIcon aria-hidden />
             </Button>
           )}
         </FlexItem>
@@ -183,6 +185,7 @@ const MobileAppHeader: FC<{
         </FlexItem>
       </StackLayout>
       <Drawer
+        aria-label="Main navigation"
         style={{
           paddingTop: "calc(var(--salt-size-base) + var(--salt-spacing-200))",
           paddingLeft: "0",

--- a/packages/core/stories/patterns/breadcrumbs/breadcrumbs.stories.tsx
+++ b/packages/core/stories/patterns/breadcrumbs/breadcrumbs.stories.tsx
@@ -168,7 +168,11 @@ export const Expansion = () => {
             </StackLayout>
           </>
         ) : (
-          <Button appearance="transparent" onClick={() => setIsExpanded(true)}>
+          <Button
+            aria-label="Show all breadcrumbs"
+            appearance="transparent"
+            onClick={() => setIsExpanded(true)}
+          >
             <OverflowMenuIcon aria-hidden />
           </Button>
         )}

--- a/packages/core/stories/patterns/button-bar/button-bar.stories.tsx
+++ b/packages/core/stories/patterns/button-bar/button-bar.stories.tsx
@@ -400,6 +400,7 @@ export const DialogForm = () => {
     <>
       <Button onClick={handleRequestOpen}>Open default dialog</Button>
       <Dialog
+        aria-label="Form"
         open={open}
         onOpenChange={onOpenChange}
         style={{ width: "378px" }}

--- a/packages/core/stories/patterns/contact-details/contact-details.stories.tsx
+++ b/packages/core/stories/patterns/contact-details/contact-details.stories.tsx
@@ -380,7 +380,7 @@ export const List = () => {
       style={{ width: "266px" }}
       startAdornment={
         selectedContact.length === 1 && (
-          <Avatar src={selectedContact[0].avatarImage} size={1} />
+          <Avatar aria-hidden src={selectedContact[0].avatarImage} size={1} />
         )
       }
       onSelectionChange={handleSelectionChange}

--- a/packages/core/stories/patterns/keyboard-shortcuts/keyboard-shortcuts.stories.tsx
+++ b/packages/core/stories/patterns/keyboard-shortcuts/keyboard-shortcuts.stories.tsx
@@ -236,6 +236,7 @@ const KeyboardShortcuts: FC = () => {
         )}
       </StackLayout>
       <Dialog
+        aria-label="Keyboard shortcuts"
         open={open}
         onOpenChange={handleDialogChange}
         size="medium"

--- a/site/src/examples/avatar/Sizes.tsx
+++ b/site/src/examples/avatar/Sizes.tsx
@@ -8,7 +8,7 @@ export const Sizes = (): ReactElement => {
     <FlowLayout gap={7} align="end">
       {sizes.map((size) => (
         <StackLayout key={size} align="center">
-          <Avatar key={size} size={size} />
+          <Avatar aria-hidden key={size} size={size} />
           <Label>Size: {size}x</Label>
         </StackLayout>
       ))}

--- a/site/src/examples/button/IconOnly.tsx
+++ b/site/src/examples/button/IconOnly.tsx
@@ -10,7 +10,7 @@ export const IconOnly = (): ReactElement => (
         sentiment="accented"
         aria-label="Search document"
       >
-        <SearchIcon />
+        <SearchIcon aria-hidden />
       </Button>
     </Tooltip>
     <Tooltip placement="top" content="Print document">
@@ -19,7 +19,7 @@ export const IconOnly = (): ReactElement => (
         sentiment="accented"
         aria-label="Print document"
       >
-        <PrintIcon />
+        <PrintIcon aria-hidden />
       </Button>
     </Tooltip>
     <Tooltip placement="top" content="Share document">
@@ -28,7 +28,7 @@ export const IconOnly = (): ReactElement => (
         sentiment="accented"
         aria-label="Share document"
       >
-        <ShareIcon />
+        <ShareIcon aria-hidden />
       </Button>
     </Tooltip>
   </FlowLayout>

--- a/site/src/examples/drawer/Default.tsx
+++ b/site/src/examples/drawer/Default.tsx
@@ -10,6 +10,7 @@ export const Default = (): ReactElement => {
     <StackLayout>
       <Button onClick={() => setOpenPrimary(true)}>Open Primary Drawer</Button>
       <Drawer
+        aria-label="Primary drawer"
         open={openPrimary}
         onOpenChange={(newOpen) => setOpenPrimary(newOpen)}
         style={{ width: 200 }}
@@ -20,6 +21,7 @@ export const Default = (): ReactElement => {
         Open Secondary Drawer
       </Button>
       <Drawer
+        aria-label="Secondary drawer"
         open={openSecondary}
         onOpenChange={(newOpen) => setOpenSecondary(newOpen)}
         variant="secondary"
@@ -31,6 +33,7 @@ export const Default = (): ReactElement => {
         Open Tertiary Drawer
       </Button>
       <Drawer
+        aria-label="Tertiary drawer"
         open={openTertiary}
         onOpenChange={(newOpen) => setOpenTertiary(newOpen)}
         variant="tertiary"

--- a/site/src/examples/drawer/DisableScrim.tsx
+++ b/site/src/examples/drawer/DisableScrim.tsx
@@ -8,6 +8,7 @@ export const DisableScrim = (): ReactElement => {
     <StackLayout>
       <Button onClick={() => setOpen(true)}>Open Primary Drawer</Button>
       <Drawer
+        aria-label="Drawer without scrim"
         open={open}
         onOpenChange={(newOpen) => setOpen(newOpen)}
         style={{ width: 200 }}

--- a/site/src/examples/input/ButtonAdornments.tsx
+++ b/site/src/examples/input/ButtonAdornments.tsx
@@ -12,16 +12,16 @@ export const ButtonAdornments = (): ReactElement => (
   <FlowLayout style={{ width: "266px" }}>
     <Input
       startAdornment={
-        <Button>
-          <NoteIcon />
+        <Button aria-label="Note">
+          <NoteIcon aria-hidden />
         </Button>
       }
       defaultValue="Value"
     />
     <Input
       endAdornment={
-        <Button sentiment="accented">
-          <RefreshIcon />
+        <Button aria-label="Refresh" sentiment="accented">
+          <RefreshIcon aria-hidden />
         </Button>
       }
       defaultValue="Value"
@@ -29,11 +29,11 @@ export const ButtonAdornments = (): ReactElement => (
     <Input
       startAdornment={
         <>
-          <Button>
-            <SendIcon />
+          <Button aria-label="Send">
+            <SendIcon aria-hidden />
           </Button>
-          <Button sentiment="accented">
-            <FlagIcon />
+          <Button aria-label="Flag" sentiment="accented">
+            <FlagIcon aria-hidden />
           </Button>
         </>
       }
@@ -42,11 +42,11 @@ export const ButtonAdornments = (): ReactElement => (
     <Input
       endAdornment={
         <>
-          <Button appearance="transparent">
-            <CloseIcon />
+          <Button aria-label="Clear" appearance="transparent">
+            <CloseIcon aria-hidden />
           </Button>
-          <Button sentiment="accented">
-            <FlagIcon />
+          <Button aria-label="Flag" sentiment="accented">
+            <FlagIcon aria-hidden />
           </Button>
         </>
       }
@@ -56,14 +56,14 @@ export const ButtonAdornments = (): ReactElement => (
       disabled
       endAdornment={
         <>
-          <Button disabled>
-            <SendIcon />
+          <Button aria-label="Send" disabled>
+            <SendIcon aria-hidden />
           </Button>
-          <Button disabled appearance="transparent">
-            <CloseIcon />
+          <Button aria-label="Clear" disabled appearance="transparent">
+            <CloseIcon aria-hidden />
           </Button>
-          <Button disabled sentiment="accented">
-            <FlagIcon />
+          <Button aria-label="Flag" disabled sentiment="accented">
+            <FlagIcon aria-hidden />
           </Button>
         </>
       }
@@ -73,14 +73,14 @@ export const ButtonAdornments = (): ReactElement => (
       readOnly
       startAdornment={
         <>
-          <Button disabled>
-            <SendIcon />
+          <Button aria-label="Send" disabled>
+            <SendIcon aria-hidden />
           </Button>
-          <Button disabled appearance="transparent">
-            <CloseIcon />
+          <Button aria-label="Clear" disabled appearance="transparent">
+            <CloseIcon aria-hidden />
           </Button>
-          <Button disabled sentiment="accented">
-            <FlagIcon />
+          <Button aria-label="Flag" disabled sentiment="accented">
+            <FlagIcon aria-hidden />
           </Button>
         </>
       }
@@ -90,17 +90,17 @@ export const ButtonAdornments = (): ReactElement => (
       disabled
       startAdornment={
         <>
-          <Button disabled>
-            <CloseIcon />
+          <Button aria-label="Clear" disabled>
+            <CloseIcon aria-hidden />
           </Button>
-          <Button disabled appearance="transparent">
-            <FlagIcon />
+          <Button aria-label="Flag" disabled appearance="transparent">
+            <FlagIcon aria-hidden />
           </Button>
         </>
       }
       endAdornment={
-        <Button sentiment="accented" disabled>
-          <SendIcon />
+        <Button aria-label="Send" sentiment="accented" disabled>
+          <SendIcon aria-hidden />
         </Button>
       }
       defaultValue="Value"

--- a/site/src/examples/multiline-input/ButtonAdornment.tsx
+++ b/site/src/examples/multiline-input/ButtonAdornment.tsx
@@ -13,17 +13,17 @@ export const ButtonAdornment = (): ReactElement => (
   <FlowLayout style={{ width: "256px" }}>
     <MultilineInput
       startAdornment={
-        <Button sentiment="accented">
-          <EditSolidIcon />
+        <Button aria-label="Edit" sentiment="accented">
+          <EditSolidIcon aria-hidden />
         </Button>
       }
       endAdornment={
         <>
-          <Button appearance="transparent">
-            <HelpSolidIcon />
+          <Button aria-label="Help" appearance="transparent">
+            <HelpSolidIcon aria-hidden />
           </Button>
-          <Button sentiment="accented">
-            <SendIcon />
+          <Button aria-label="Send" sentiment="accented">
+            <SendIcon aria-hidden />
           </Button>
         </>
       }
@@ -31,8 +31,8 @@ export const ButtonAdornment = (): ReactElement => (
     />
     <MultilineInput
       endAdornment={
-        <Button>
-          <BookmarkSolidIcon />
+        <Button aria-label="Bookmark">
+          <BookmarkSolidIcon aria-hidden />
         </Button>
       }
       defaultValue="Value"
@@ -40,8 +40,8 @@ export const ButtonAdornment = (): ReactElement => (
     <MultilineInput
       disabled
       endAdornment={
-        <Button disabled>
-          <UserBadgeIcon />
+        <Button aria-label="User profile" disabled>
+          <UserBadgeIcon aria-hidden />
         </Button>
       }
       defaultValue="Disabled value"
@@ -49,8 +49,8 @@ export const ButtonAdornment = (): ReactElement => (
     <MultilineInput
       readOnly
       endAdornment={
-        <Button appearance="transparent" disabled>
-          <BankCheckSolidIcon />
+        <Button aria-label="Bank check" appearance="transparent" disabled>
+          <BankCheckSolidIcon aria-hidden />
         </Button>
       }
       defaultValue="Readonly value"

--- a/site/src/examples/parent-child-layout/PreferencesDialog.tsx
+++ b/site/src/examples/parent-child-layout/PreferencesDialog.tsx
@@ -232,6 +232,7 @@ export const PreferencesDialog = () => {
     <>
       <Button onClick={handleRequestOpen}>Open Preferences Dialog</Button>
       <Dialog
+        aria-label="Preferences"
         size={"medium"}
         open={open}
         onOpenChange={onOpenChange}

--- a/site/src/examples/skip-link/Default.tsx
+++ b/site/src/examples/skip-link/Default.tsx
@@ -54,8 +54,8 @@ export const Default = (): ReactElement => {
             </nav>
             <FlexItem align="center">
               <StackLayout direction="row" gap={1}>
-                <Button appearance="transparent">
-                  <GithubIcon />
+                <Button aria-label="GitHub" appearance="transparent">
+                  <GithubIcon aria-hidden />
                 </Button>
               </StackLayout>
             </FlexItem>

--- a/site/src/examples/toast/CustomIcon.tsx
+++ b/site/src/examples/toast/CustomIcon.tsx
@@ -21,8 +21,8 @@ export const CustomIcon = (): ReactElement => (
         </Text>
         <div>Filters have been cleared</div>
       </ToastContent>
-      <Button appearance="transparent">
-        <CloseIcon />
+      <Button aria-label="Dismiss" appearance="transparent">
+        <CloseIcon aria-hidden />
       </Button>
     </Toast>
     <Toast
@@ -36,8 +36,8 @@ export const CustomIcon = (): ReactElement => (
         </Text>
         <div>The world is connected</div>
       </ToastContent>
-      <Button appearance="transparent">
-        <CloseIcon />
+      <Button aria-label="Dismiss" appearance="transparent">
+        <CloseIcon aria-hidden />
       </Button>
     </Toast>
     <Toast
@@ -51,8 +51,8 @@ export const CustomIcon = (): ReactElement => (
         </Text>
         <div>There is not enough seasoning</div>
       </ToastContent>
-      <Button appearance="transparent">
-        <CloseIcon />
+      <Button aria-label="Dismiss" appearance="transparent">
+        <CloseIcon aria-hidden />
       </Button>
     </Toast>
     <Toast
@@ -66,8 +66,8 @@ export const CustomIcon = (): ReactElement => (
         </Text>
         <div>There is a wild animal here</div>
       </ToastContent>
-      <Button appearance="transparent">
-        <CloseIcon />
+      <Button aria-label="Dismiss" appearance="transparent">
+        <CloseIcon aria-hidden />
       </Button>
     </Toast>
   </div>

--- a/site/src/examples/vertical-navigation/MultiActionItem.tsx
+++ b/site/src/examples/vertical-navigation/MultiActionItem.tsx
@@ -32,8 +32,11 @@ function ExpandButtonItem(props: { item: Item }) {
               </VerticalNavigationItemLabel>
             </VerticalNavigationItemTrigger>
             <CollapsibleTrigger>
-              <Button appearance="transparent">
-                <VerticalNavigationItemExpansionIcon />
+              <Button
+                aria-label={`Toggle ${item.title} submenu`}
+                appearance="transparent"
+              >
+                <VerticalNavigationItemExpansionIcon aria-hidden />
               </Button>
             </CollapsibleTrigger>
           </VerticalNavigationItemContent>


### PR DESCRIPTION
Component and pattern examples were missing accessible names in several places, which would propagate to consumer code copied from the docs and Storybook.
- Add aria-label to 30 icon-only Buttons across input, multiline-input, toast, skip-link, vertical-navigation, app-header, and breadcrumbs examples, and mark the contained icons aria-hidden to match the reference IconOnly button example.
- Add aria-label to 8 Dialog/Drawer instances that had no DialogHeader or aria-labelledby (drawer/Default, drawer/DisableScrim, PreferencesDialog, app-header, button-bar, keyboard-shortcuts).
- Mark 2 decorative Avatars as aria-hidden (avatar/Sizes and the contact-details dropdown adornment) since their context already announces the relevant information.