### PR TITLE
Toolbar | Fix overflow maths

### DIFF
--- a/.changeset/major-states-hang.md
+++ b/.changeset/major-states-hang.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/lab": patch
+---
+
+Fixed `ToolbarNext` overflow calculations to preserve fractional browser measurements and avoid false overflow caused by subpixel rounding.

--- a/packages/lab/src/__tests__/__e2e__/toolbar-next/ToolbarNext.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/toolbar-next/ToolbarNext.cy.tsx
@@ -861,8 +861,61 @@ function MixedTrayCompressionTestCase() {
   );
 }
 
+const subpixelItemLabels = [
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "10",
+  "11",
+  "12",
+];
+
+function SubpixelWidthRoundingTestCase() {
+  return (
+    <div className="Flexbox" style={{ height: 220, width: 760 }}>
+      <ToolbarNext
+        appearance="transparent"
+        aria-label="Subpixel width rounding toolbar"
+      >
+        <ToolbarContentNext position="start" style={{ gap: 0 }}>
+          {subpixelItemLabels.map((label, index) => (
+            <TooltrayNext key={label} overflowPriority={index}>
+              <span
+                style={{
+                  boxSizing: "border-box",
+                  display: "inline-flex",
+                  width: 20.2,
+                }}
+              >
+                {label}
+              </span>
+            </TooltrayNext>
+          ))}
+        </ToolbarContentNext>
+      </ToolbarNext>
+    </div>
+  );
+}
+
 function setFixtureWidth(width: number) {
   cy.get(".Flexbox").invoke("css", "width", `${width}px`);
+}
+
+function getVisibleToolbarSlotWidth(toolbarName: string) {
+  return cy.findByRole("toolbar", { name: toolbarName }).then(($toolbar) => {
+    const toolbar = $toolbar[0];
+    const visibleSlotRects = getVisibleElementRects(
+      toolbar.querySelectorAll<HTMLElement>(".saltToolbarNextOverflow-slot"),
+    );
+
+    return visibleSlotRects.reduce((total, rect) => total + rect.width, 0);
+  });
 }
 
 function parsePixelValue(value: string) {
@@ -1060,6 +1113,36 @@ describe("Given ToolbarNext overflow measurements", () => {
         win as ToolbarNextGuardedResizeWindow
       ).__toolbarNextGuardedResizeTest?.restore();
     });
+  });
+
+  it("does not falsely overflow fractional widths that fit within epsilon", () => {
+    cy.mount(<SubpixelWidthRoundingTestCase />);
+
+    cy.findByRole("button", { name: /Overflow\./i }).should("not.exist");
+    for (const label of subpixelItemLabels) {
+      cy.findByText(label).should("be.visible");
+    }
+    expectToolbarFits("Subpixel width rounding toolbar");
+
+    getVisibleToolbarSlotWidth("Subpixel width rounding toolbar").then(
+      (contentWidth) => {
+        setFixtureWidth(contentWidth - 0.4);
+        cy.findByRole("button", { name: /Overflow\./i }).should("not.exist");
+        for (const label of subpixelItemLabels) {
+          cy.findByText(label).should("be.visible");
+        }
+        expectToolbarFits("Subpixel width rounding toolbar");
+
+        setFixtureWidth(contentWidth - 1);
+        cy.findByRole("button", { name: /Overflow\./i }).should("be.visible");
+        cy.findByRole("toolbar", {
+          name: "Subpixel width rounding toolbar",
+        }).within(() => {
+          cy.findByText("12").should("not.be.visible");
+        });
+        expectToolbarFits("Subpixel width rounding toolbar");
+      },
+    );
   });
 
   it("collapses the first shared tray as soon as measured content exceeds the container", () => {

--- a/packages/lab/src/toolbar-next/useToolbarNextOverflow.ts
+++ b/packages/lab/src/toolbar-next/useToolbarNextOverflow.ts
@@ -71,6 +71,11 @@ const emptyOverflowState: OverflowState = {
 };
 
 const bandPositions: ToolbarContentNextPosition[] = ["start", "center", "end"];
+// Tolerance for comparing measured content against the available width.
+// `getBoundingClientRect` reports fractional pixels, so summed item, gap, and
+// container measurements can differ by sub-pixel amounts that never visibly
+// overflow. Treating differences below half a CSS pixel as "fits" prevents
+// false overflow. Matches the epsilon used by core Tabs for consistency.
 const WIDTH_EPSILON = 0.5;
 
 function measureWidth(element: HTMLElement | null) {

--- a/packages/lab/src/toolbar-next/useToolbarNextOverflow.ts
+++ b/packages/lab/src/toolbar-next/useToolbarNextOverflow.ts
@@ -71,6 +71,7 @@ const emptyOverflowState: OverflowState = {
 };
 
 const bandPositions: ToolbarContentNextPosition[] = ["start", "center", "end"];
+const WIDTH_EPSILON = 0.5;
 
 function measureWidth(element: HTMLElement | null) {
   if (!element) {
@@ -78,7 +79,7 @@ function measureWidth(element: HTMLElement | null) {
   }
 
   const { width } = element.getBoundingClientRect();
-  return Math.ceil(width);
+  return width;
 }
 
 function isVisibleMeasurementElement(element: Element): element is HTMLElement {
@@ -116,7 +117,11 @@ function measureOverflowItemWidth(element: HTMLElement | null) {
     right = Math.max(right, descendantRect.right);
   }
 
-  return Math.ceil(Math.max(rect.width, right - left));
+  return Math.max(rect.width, right - left);
+}
+
+function exceedsAvailableWidth(measuredWidth: number, availableWidth: number) {
+  return measuredWidth - availableWidth > WIDTH_EPSILON;
 }
 
 function readGap(gapValue: string) {
@@ -410,7 +415,7 @@ function computeToolbarNextOverflowState({
     return emptyOverflowState;
   }
 
-  if (initialWidth > containerWidth) {
+  if (exceedsAvailableWidth(initialWidth, containerWidth)) {
     for (const unit of collapseUnits) {
       for (const itemId of unit.itemIds) {
         overflowedIds.add(itemId);
@@ -424,7 +429,7 @@ function computeToolbarNextOverflowState({
         return emptyOverflowState;
       }
 
-      if (nextWidth <= containerWidth) {
+      if (!exceedsAvailableWidth(nextWidth, containerWidth)) {
         break;
       }
     }
@@ -549,13 +554,12 @@ export function useToolbarNextOverflow({
       Number.parseFloat(containerStyles.borderLeftWidth || "0") || 0;
     const borderRight =
       Number.parseFloat(containerStyles.borderRightWidth || "0") || 0;
-    const containerWidth = Math.floor(
+    const containerWidth =
       container.getBoundingClientRect().width -
-        paddingLeft -
-        paddingRight -
-        borderLeft -
-        borderRight,
-    );
+      paddingLeft -
+      paddingRight -
+      borderLeft -
+      borderRight;
 
     if (containerWidth <= 0) {
       return emptyOverflowState;

--- a/packages/lab/stories/toolbar-next/toolbar-next-edge-cases.stories.tsx
+++ b/packages/lab/stories/toolbar-next/toolbar-next-edge-cases.stories.tsx
@@ -1,4 +1,4 @@
-import { Button, Dropdown, Input, Option, Text } from "@salt-ds/core";
+import { Button, Divider, Dropdown, Input, Option, Text } from "@salt-ds/core";
 import { DateInputSingle } from "@salt-ds/date-components";
 import {
   AddIcon,
@@ -10,7 +10,7 @@ import {
 } from "@salt-ds/icons";
 import { ToolbarContentNext, ToolbarNext, TooltrayNext } from "@salt-ds/lab";
 import type { Meta, StoryFn } from "@storybook/react-vite";
-import { useState } from "react";
+import { Fragment, useState } from "react";
 
 export default {
   title: "Lab/Toolbar Next/Edge Cases",
@@ -19,6 +19,8 @@ export default {
     "DynamicElements",
     "HiddenOverflowRemeasurement",
     "OverflowMenuInClippingContainer",
+    "SubpixelWidthRounding",
+    "SubpixelWidthRoundingWithGapsAndDividers",
   ],
   parameters: {
     layout: "padded",
@@ -109,6 +111,67 @@ const clippingValidationToolbarDockStyle = {
 
 const clippingValidationNoteStyle = {
   marginTop: "var(--salt-spacing-200)",
+};
+
+const subpixelItemWidth = 20.2;
+const subpixelItemLabels = [
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "10",
+  "11",
+  "12",
+];
+const subpixelToolbarWidth = subpixelItemWidth * subpixelItemLabels.length;
+const subpixelSliderFitWidth = Math.floor(subpixelToolbarWidth);
+const subpixelSliderOverflowWidth = subpixelSliderFitWidth - 1;
+
+const subpixelRoundingShellStyle = {
+  display: "flex" as const,
+  flexDirection: "column" as const,
+  gap: "var(--salt-spacing-150)",
+  maxWidth: 560,
+};
+
+const subpixelRoundingFrameStyle = {
+  outline:
+    "var(--salt-size-fixed-100) var(--salt-borderStyle-solid) var(--salt-container-primary-borderColor)",
+  width: "100%",
+};
+
+const subpixelRoundingContentStyle = {
+  gap: 0,
+};
+
+const subpixelRoundingItemStyle = {
+  alignItems: "center",
+  background: "var(--salt-container-secondary-background)",
+  border:
+    "var(--salt-size-fixed-100) var(--salt-borderStyle-solid) var(--salt-container-primary-borderColor)",
+  boxSizing: "border-box" as const,
+  display: "flex" as const,
+  fontSize: 10,
+  height: "var(--salt-size-base)",
+  justifyContent: "center",
+  width: subpixelItemWidth,
+};
+
+const subpixelDecoratedItemWidth = 32.2;
+const subpixelDecoratedItemLabels = ["A", "B", "C", "D", "E", "F", "G", "H"];
+
+const subpixelDecoratedItemStyle = {
+  ...subpixelRoundingItemStyle,
+  width: subpixelDecoratedItemWidth,
+};
+
+const subpixelDividerStyle = {
+  height: "var(--salt-size-base)",
 };
 
 /**
@@ -202,6 +265,107 @@ export const DynamicElements: StoryFn<typeof ToolbarNext> = () => {
   );
 };
 DynamicElements.globals = {
+  responsive: "wrap",
+};
+
+/**
+ * Subpixel width rounding validation.
+ *
+ * Intended behavior:
+ * - Twelve items at `20.2px` each exactly fit in a `242.4px` toolbar.
+ * - The toolbar content gap is set to zero so this isolates the item-width
+ *   arithmetic.
+ * - The Storybook width slider uses whole pixels. Set it to `242px` to validate
+ *   the epsilon tolerance for the fractional rendered width, then set it to
+ *   `241px` to verify narrower widths still intentionally collapse items.
+ */
+export const SubpixelWidthRounding: StoryFn<typeof ToolbarNext> = () => (
+  <div style={subpixelRoundingShellStyle}>
+    <Text>
+      <strong>Expected:</strong> all {subpixelItemLabels.length} labelled items
+      fit when the integer Storybook width slider is set to{" "}
+      {subpixelSliderFitWidth}px. Each item is {subpixelItemWidth}px wide, so
+      the rendered total is fractional.
+    </Text>
+    <Text>
+      <strong>Bug indicator:</strong> if {subpixelSliderFitWidth}px shows only
+      the overflow trigger, fractional widths are still being rounded into a
+      false overflow. At {subpixelSliderOverflowWidth}px, items should overflow.
+    </Text>
+    <div style={subpixelRoundingFrameStyle}>
+      <ToolbarNext
+        appearance="transparent"
+        aria-label="Subpixel width rounding toolbar"
+      >
+        <ToolbarContentNext
+          position="start"
+          style={subpixelRoundingContentStyle}
+        >
+          {subpixelItemLabels.map((label, index) => (
+            <TooltrayNext key={label} overflowPriority={index}>
+              <span style={subpixelRoundingItemStyle}>{label}</span>
+            </TooltrayNext>
+          ))}
+        </ToolbarContentNext>
+      </ToolbarNext>
+    </div>
+  </div>
+);
+SubpixelWidthRounding.globals = {
+  responsive: "wrap",
+};
+
+/**
+ * Subpixel width rounding with normal gaps and dividers.
+ *
+ * Intended behavior:
+ * - Items still use fractional widths, but this variant keeps the toolbar's
+ *   normal content gaps instead of forcing `gap: 0`.
+ * - Vertical dividers are included as toolbar decorations, so the measurement
+ *   log should show decorated item widths and non-zero `contentGaps`.
+ * - Use the Storybook width slider around the logged `initialWidth` value:
+ *   exact-or-wider widths should fit, while narrower widths should overflow.
+ */
+export const SubpixelWidthRoundingWithGapsAndDividers: StoryFn<
+  typeof ToolbarNext
+> = () => (
+  <div style={subpixelRoundingShellStyle}>
+    <Text>
+      <strong>Expected:</strong> this version keeps the default toolbar spacing
+      and includes vertical dividers. The debug log should show a non-zero
+      content gap and item widths that include adjacent divider decorations.
+    </Text>
+    <Text>
+      <strong>Bug indicator:</strong> if the slider width is at or above the
+      logged initial width but items still overflow, the measurement is not
+      accounting for gaps or divider decorations correctly.
+    </Text>
+    <div style={subpixelRoundingFrameStyle}>
+      <ToolbarNext
+        appearance="transparent"
+        aria-label="Subpixel gaps and dividers toolbar"
+      >
+        <ToolbarContentNext position="start">
+          {subpixelDecoratedItemLabels.map((label, index) => (
+            <Fragment key={label}>
+              {index === 3 || index === 6 ? (
+                <Divider
+                  orientation="vertical"
+                  style={subpixelDividerStyle}
+                  variant="secondary"
+                />
+              ) : null}
+              <TooltrayNext overflowPriority={index}>
+                <span style={subpixelDecoratedItemStyle}>{label}</span>
+              </TooltrayNext>
+            </Fragment>
+          ))}
+        </ToolbarContentNext>
+      </ToolbarNext>
+    </div>
+  </div>
+);
+SubpixelWidthRoundingWithGapsAndDividers.globals = {
   responsive: "wrap",
 };
 


### PR DESCRIPTION
The rounding issue caused by converting fractional browser measurements into whole pixels before comparing content width against available width: item widths were rounded up while the container width was rounded down. this exaggerated the difference enough to trigger overflow even when the toolbar visually fit. 

The fix keeps the fractional getBoundingClientRect() measurements and only treats content as overflowing when it exceeds the available width by more than 0.5px, matching the tolerance pattern already used in Tabs. 

Storybook file in there temporarily to help with testing
