### PR TITLE
Fix broken Calendar link 

### DIFF
--- a/site/docs/components/date-picker/accessibility.mdx
+++ b/site/docs/components/date-picker/accessibility.mdx
@@ -17,7 +17,7 @@ data:
 
 ### Focus
 
-- If the `DatePicker` uses `children` to compose other components such as [Calendar](../Calendar), move focus to the first interactive element within that overlay.
+- If the `DatePicker` uses `children` to compose other components such as [Calendar](../calendar), move focus to the first interactive element within that overlay.
 - After a date is selected, provide feedback and move focus appropriately to enhance the user experience.
 
 ### Provide instructions and feedback


### PR DESCRIPTION
A link to Calendar component in Datepicker a11y page is broken - raised by a consumer through email. 