### PR TITLE
Fix empty read-only logic and align Dropdown validation precedence

### DIFF
--- a/.changeset/dropdown-validation-precedence.md
+++ b/.changeset/dropdown-validation-precedence.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": patch
+---
+
+Fixed `Dropdown` validation status precedence to align with the other form controls, so the `FormField` validation status now takes precedence over the `Dropdown`'s own `validationStatus` prop.

--- a/.changeset/input-readonly-zero-value.md
+++ b/.changeset/input-readonly-zero-value.md
@@ -1,0 +1,6 @@
+---
+"@salt-ds/core": patch
+"@salt-ds/lab": patch
+---
+
+Fixed read-only inputs so empty controlled values, empty default values, and empty selections consistently display the `emptyReadOnlyMarker` (`—` by default), while non-empty values such as numeric `0` continue to display the real value.

--- a/packages/core/src/__tests__/__e2e__/combo-box/ComboBox.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/combo-box/ComboBox.cy.tsx
@@ -7,6 +7,7 @@ import { CustomFloatingComponentProvider, FLOATING_TEST_ID } from "../common";
 const {
   Default,
   Readonly,
+  ReadonlyEmpty,
   WithDefaultSelected,
   Disabled,
   DisabledOption,
@@ -902,5 +903,17 @@ describe("Given a ComboBox", () => {
 
     cy.findByRole("combobox").should("not.have.attr", "aria-describedby");
     cy.findByRole("combobox").should("not.have.attr", "aria-labelledby");
+  });
+
+  describe("WHEN read only", () => {
+    it("THEN should show the selected value rather than the empty marker", () => {
+      cy.mount(<Readonly />);
+      cy.findByRole("textbox").should("have.value", "California");
+    });
+
+    it("THEN should show the empty marker when there is no selection", () => {
+      cy.mount(<ReadonlyEmpty />);
+      cy.findByRole("textbox").should("have.value", "—");
+    });
   });
 });

--- a/packages/core/src/__tests__/__e2e__/dropdown/Dropdown.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/dropdown/Dropdown.cy.tsx
@@ -1,4 +1,4 @@
-import { Dropdown, Option } from "@salt-ds/core";
+import { Dropdown, FormField, FormFieldLabel, Option } from "@salt-ds/core";
 import * as dropdownStories from "@stories/dropdown/dropdown.stories";
 import { composeStories } from "@storybook/react-vite";
 import { type KeyboardEventHandler, useRef, useState } from "react";
@@ -223,6 +223,36 @@ describe("Given a Dropdown", () => {
 
     cy.realType("abc");
     cy.findByRole("combobox").should("have.text", "California");
+  });
+
+  it("should show the empty marker when it is readonly with no selection", () => {
+    cy.mount(
+      <Dropdown readOnly>
+        <Option value="Alabama" />
+      </Dropdown>,
+    );
+
+    cy.findByRole("combobox").should("have.text", "—");
+  });
+
+  it("should show the empty marker when it is readonly with a controlled empty value", () => {
+    cy.mount(
+      <Dropdown readOnly value="">
+        <Option value="Alabama" />
+      </Dropdown>,
+    );
+
+    cy.findByRole("combobox").should("have.text", "—");
+  });
+
+  it("should show custom value text rather than the empty marker when it is readonly", () => {
+    cy.mount(
+      <Dropdown readOnly value="Custom value">
+        <Option value="Alabama" />
+      </Dropdown>,
+    );
+
+    cy.findByRole("combobox").should("have.text", "Custom value");
   });
 
   it("should not receive focus via tab if it is disabled", () => {
@@ -525,5 +555,32 @@ describe("Given a Dropdown", () => {
     cy.findByTestId("overlay")
       .should("exist")
       .and("have.attr", "role", "listbox");
+  });
+
+  describe("validation status", () => {
+    it("should use its own validation status when not in a FormField", () => {
+      cy.mount(
+        <Dropdown validationStatus="warning">
+          <Option value={1}>1</Option>
+        </Dropdown>,
+      );
+      cy.findByRole("combobox").should("have.class", "saltDropdown-warning");
+    });
+
+    it("should prioritize the FormField validation status over its own", () => {
+      cy.mount(
+        <FormField validationStatus="error">
+          <FormFieldLabel>Field</FormFieldLabel>
+          <Dropdown validationStatus="warning">
+            <Option value={1}>1</Option>
+          </Dropdown>
+        </FormField>,
+      );
+      cy.findByRole("combobox").should("have.class", "saltDropdown-error");
+      cy.findByRole("combobox").should(
+        "not.have.class",
+        "saltDropdown-warning",
+      );
+    });
   });
 });

--- a/packages/core/src/__tests__/__e2e__/input/Input.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/input/Input.cy.tsx
@@ -170,9 +170,31 @@ describe("GIVEN an Input", () => {
         cy.findByRole("textbox").should("have.value", "—");
       });
 
+      it("THEN should show an emdash for an empty default value", () => {
+        cy.mount(<Input defaultValue="" readOnly />);
+        cy.findByRole("textbox").should("have.value", "—");
+      });
+
+      it("THEN should show an emdash for a controlled empty value", () => {
+        cy.mount(<Input value="" readOnly />);
+        cy.findByRole("textbox").should("have.value", "—");
+      });
+
       it("THEN should cy.mount an custom marker", () => {
         cy.mount(<Input emptyReadOnlyMarker="#" readOnly />);
         cy.findByRole("textbox").should("have.value", "#");
+      });
+    });
+
+    describe("AND the value is zero", () => {
+      it("THEN should show the zero value rather than the empty marker", () => {
+        cy.mount(<Input defaultValue={0} readOnly />);
+        cy.findByRole("textbox").should("have.value", "0");
+      });
+
+      it("THEN should show a controlled zero value rather than the empty marker", () => {
+        cy.mount(<Input value={0} readOnly />);
+        cy.findByRole("textbox").should("have.value", "0");
       });
     });
   });

--- a/packages/core/src/__tests__/__e2e__/number-input/NumberInput.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/number-input/NumberInput.cy.tsx
@@ -1047,6 +1047,16 @@ describe("Number Input", () => {
       cy.findByRole("textbox").should("have.value", "—");
     });
 
+    it("should show emdash for an empty default value", () => {
+      cy.mount(<ReadOnly defaultValue="" readOnly />);
+      cy.findByRole("textbox").should("have.value", "—");
+    });
+
+    it("should show emdash for a controlled empty value", () => {
+      cy.mount(<ReadOnly value="" readOnly />);
+      cy.findByRole("textbox").should("have.value", "—");
+    });
+
     it("should show a custom marker if provided when empty", () => {
       cy.mount(
         <ReadOnly defaultValue={undefined} readOnly emptyReadOnlyMarker="#" />,

--- a/packages/core/src/dropdown/Dropdown.tsx
+++ b/packages/core/src/dropdown/Dropdown.tsx
@@ -177,7 +177,7 @@ export const Dropdown = forwardRef(function Dropdown<Item>(
 
   const disabled = Boolean(disabledProp) || formFieldDisabled;
   const readOnly = Boolean(readOnlyProp) || formFieldReadOnly;
-  const validationStatus = validationStatusProp ?? formFieldValidationStatus;
+  const validationStatus = formFieldValidationStatus ?? validationStatusProp;
   const required = formFieldRequired
     ? ["required", "asterisk"].includes(formFieldRequired)
     : requiredProp;
@@ -219,10 +219,9 @@ export const Dropdown = forwardRef(function Dropdown<Item>(
   const selectedValue = selectedState
     .map((item) => valueToString(item))
     .join(", ");
-  const isEmptyReadOnly = readOnly && selectedValue === "";
-  const valueText = isEmptyReadOnly
-    ? emptyReadOnlyMarker
-    : (value ?? selectedValue);
+  const displayedValue = value ?? selectedValue;
+  const valueText =
+    readOnly && displayedValue === "" ? emptyReadOnlyMarker : displayedValue;
 
   const handleOpenChange: UseFloatingUIProps["onOpenChange"] = (
     newOpen,

--- a/packages/core/src/input/Input.tsx
+++ b/packages/core/src/input/Input.tsx
@@ -74,6 +74,16 @@ export interface InputProps
   bordered?: boolean;
 }
 
+function isEmptyReadOnlyValue(
+  value: InputProps["value"] | InputProps["defaultValue"],
+) {
+  return (
+    value == null ||
+    value === "" ||
+    (Array.isArray(value) && value.length === 0)
+  );
+}
+
 export const Input = forwardRef<HTMLDivElement, InputProps>(
   function Input(props, ref) {
     const { className, props: finalProps } = useClassNameInjection(
@@ -134,8 +144,16 @@ export const Input = forwardRef<HTMLDivElement, InputProps>(
 
     const [focused, setFocused] = useState(false);
 
-    const isEmptyReadOnly = isReadOnly && !defaultValueProp && !valueProp;
-    const defaultValue = isEmptyReadOnly
+    const isValueEmptyReadOnly = isReadOnly && isEmptyReadOnlyValue(valueProp);
+    const isDefaultValueEmptyReadOnly =
+      isReadOnly && isEmptyReadOnlyValue(defaultValueProp);
+    const controlledValue =
+      valueProp === undefined
+        ? undefined
+        : isValueEmptyReadOnly
+          ? emptyReadOnlyMarker
+          : valueProp;
+    const defaultValue = isDefaultValueEmptyReadOnly
       ? emptyReadOnlyMarker
       : defaultValueProp;
 
@@ -154,7 +172,7 @@ export const Input = forwardRef<HTMLDivElement, InputProps>(
       : inputPropsRequired;
 
     const [value, setValue] = useControlled({
-      controlled: valueProp,
+      controlled: controlledValue,
       default: defaultValue,
       name: "Input",
       state: "value",

--- a/packages/core/src/pill-input/PillInput.tsx
+++ b/packages/core/src/pill-input/PillInput.tsx
@@ -85,6 +85,16 @@ export interface PillInputProps
   bordered?: boolean;
 }
 
+function isEmptyReadOnlyValue(
+  value: PillInputProps["value"] | PillInputProps["defaultValue"],
+) {
+  return (
+    value == null ||
+    value === "" ||
+    (Array.isArray(value) && value.length === 0)
+  );
+}
+
 export const PillInput = forwardRef(function PillInput(
   {
     "aria-activedescendant": ariaActiveDescendant,
@@ -148,8 +158,18 @@ export const PillInput = forwardRef(function PillInput(
   const [focused, setFocused] = useState(false);
   const [focusedPillIndex, setFocusedPillIndex] = useState(-1);
 
-  const isEmptyReadOnly = isReadOnly && !defaultValueProp && !valueProp;
-  const defaultValue = isEmptyReadOnly ? emptyReadOnlyMarker : defaultValueProp;
+  const isValueEmptyReadOnly = isReadOnly && isEmptyReadOnlyValue(valueProp);
+  const isDefaultValueEmptyReadOnly =
+    isReadOnly && isEmptyReadOnlyValue(defaultValueProp);
+  const controlledValue =
+    valueProp === undefined
+      ? undefined
+      : isValueEmptyReadOnly
+        ? emptyReadOnlyMarker
+        : valueProp;
+  const defaultValue = isDefaultValueEmptyReadOnly
+    ? emptyReadOnlyMarker
+    : defaultValueProp;
 
   const {
     "aria-describedby": inputDescribedBy,
@@ -167,7 +187,7 @@ export const PillInput = forwardRef(function PillInput(
     : inputPropsRequired;
 
   const [value, setValue] = useControlled({
-    controlled: valueProp,
+    controlled: controlledValue,
     default: defaultValue,
     name: "Input",
     state: "value",

--- a/packages/date-components/src/__tests__/__e2e__/date-input/DateInputRange.cy.tsx
+++ b/packages/date-components/src/__tests__/__e2e__/date-input/DateInputRange.cy.tsx
@@ -169,6 +169,29 @@ describe("GIVEN a DateInputRange", () => {
           .date,
       };
 
+      it("SHOULD show the empty marker when read-only with an empty default value", () => {
+        cy.mount(
+          <DateInputRange
+            defaultValue={{ startDate: "", endDate: "" }}
+            readOnly
+          />,
+        );
+
+        cy.findAllByRole("textbox").each(($input) => {
+          cy.wrap($input).should("have.value", "—");
+        });
+      });
+
+      it("SHOULD show the empty marker when read-only with a controlled empty value", () => {
+        cy.mount(
+          <DateInputRange value={{ startDate: "", endDate: "" }} readOnly />,
+        );
+
+        cy.findAllByRole("textbox").each(($input) => {
+          cy.wrap($input).should("have.value", "—");
+        });
+      });
+
       it("SHOULD have an accessible name via aria-labelledby when wrapped in a FormField", () => {
         cy.mount(
           <FormField>

--- a/packages/date-components/src/__tests__/__e2e__/date-input/DateInputSingle.cy.tsx
+++ b/packages/date-components/src/__tests__/__e2e__/date-input/DateInputSingle.cy.tsx
@@ -128,6 +128,16 @@ describe("GIVEN a DateInputSingle", () => {
         cy.findByRole("textbox").should("have.attr", "aria-invalid", "true");
       });
 
+      it("SHOULD show the empty marker when read-only with an empty default value", () => {
+        cy.mount(<DateInputSingle defaultValue="" readOnly />);
+        cy.findByRole("textbox").should("have.value", "—");
+      });
+
+      it("SHOULD show the empty marker when read-only with a controlled empty value", () => {
+        cy.mount(<DateInputSingle value="" readOnly />);
+        cy.findByRole("textbox").should("have.value", "—");
+      });
+
       it("SHOULD use top-level aria-label", () => {
         cy.mount(<DateInputSingle aria-label="trade date" />);
 

--- a/packages/lab/src/__tests__/__e2e__/input-legacy/InputLegacy.cy.tsx
+++ b/packages/lab/src/__tests__/__e2e__/input-legacy/InputLegacy.cy.tsx
@@ -126,6 +126,16 @@ describe("GIVEN an Input", () => {
         cy.findByRole("textbox").should("have.value", "—");
       });
 
+      it("THEN should show an emdash for an empty default value", () => {
+        cy.mount(<Input defaultValue="" readOnly />);
+        cy.findByRole("textbox").should("have.value", "—");
+      });
+
+      it("THEN should show an emdash for a controlled empty value", () => {
+        cy.mount(<Input value="" readOnly />);
+        cy.findByRole("textbox").should("have.value", "—");
+      });
+
       it("THEN should cy.mount an custom marker", () => {
         cy.mount(<Input emptyReadOnlyMarker="#" readOnly />);
         cy.findByRole("textbox").should("have.value", "#");

--- a/packages/lab/src/input-legacy/InputLegacy.tsx
+++ b/packages/lab/src/input-legacy/InputLegacy.tsx
@@ -123,6 +123,12 @@ function mergeA11yProps(
   };
 }
 
+function isEmptyReadOnlyValue(
+  value: InputLegacyProps["value"] | InputLegacyProps["defaultValue"],
+) {
+  return value == null || value === "";
+}
+
 export const InputLegacy = forwardRef<HTMLInputElement, InputLegacyProps>(
   function Input(
     {
@@ -199,13 +205,21 @@ export const InputLegacy = forwardRef<HTMLInputElement, InputLegacyProps>(
       inputPropsProp,
       misplacedAriaProps,
     );
-    const isEmptyReadOnly = isReadOnly && !defaultValueProp && !valueProp;
-    const defaultValue = isEmptyReadOnly
+    const isValueEmptyReadOnly = isReadOnly && isEmptyReadOnlyValue(valueProp);
+    const isDefaultValueEmptyReadOnly =
+      isReadOnly && isEmptyReadOnlyValue(defaultValueProp);
+    const controlledValue =
+      valueProp === undefined
+        ? undefined
+        : isValueEmptyReadOnly
+          ? emptyReadOnlyMarker
+          : valueProp;
+    const defaultValue = isDefaultValueEmptyReadOnly
       ? emptyReadOnlyMarker
       : defaultValueProp;
 
     const [value, setValue] = useControlled({
-      controlled: valueProp,
+      controlled: controlledValue,
       default: defaultValue,
       name: "Input",
       state: "value",


### PR DESCRIPTION
- Input: treat numeric 0 as a real value when read-only instead of showing the empty read-only marker
- PillInput: same read-only empty-value handling for consistency (internal)
- Dropdown: FormField validation status now takes precedence over the local validationStatus prop, matching the other form controls