### PR TITLE
Update AG Grid pagination examples

### DIFF
--- a/packages/ag-grid-theme/src/examples/Pagination.tsx
+++ b/packages/ag-grid-theme/src/examples/Pagination.tsx
@@ -1,7 +1,29 @@
+import {
+  Button,
+  CompactInput,
+  CompactPaginator,
+  Dropdown,
+  FlexLayout,
+  Option,
+  Pagination,
+  StackLayout,
+  Text,
+} from "@salt-ds/core";
+import { FirstIcon, LastIcon } from "@salt-ds/icons";
+import type { GridApi, PaginationChangedEvent } from "ag-grid-community";
 import { AgGridReact, type AgGridReactProps } from "ag-grid-react";
+import {
+  type SyntheticEvent,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import dataGridExampleColumns from "../dependencies/dataGridExampleColumns";
 import dataGridExampleData from "../dependencies/dataGridExampleData";
 import { useAgGridHelpers } from "../dependencies/useAgGridHelpers";
+
+const PAGE_SIZES = [20, 50, 100] as const;
 
 const generateData = (states: typeof dataGridExampleData) =>
   states.reduce(
@@ -16,21 +38,140 @@ const generateData = (states: typeof dataGridExampleData) =>
     [] as typeof dataGridExampleData,
   );
 
-const Pagination = (props: AgGridReactProps) => {
+const formatCount = (value: number) => value.toLocaleString("en-US");
+
+const PaginationExample = (props: AgGridReactProps) => {
+  const { onPaginationChanged: onPaginationChangedProp } = props;
   const { agGridProps, containerProps } = useAgGridHelpers();
+  const gridApiRef = useRef<GridApi | undefined>(undefined);
+  const rowData = useMemo(() => generateData(dataGridExampleData), []);
+
+  const [page, setPage] = useState(1);
+  const [pageCount, setPageCount] = useState(1);
+  const [pageSize, setPageSize] = useState(100);
+  const [rowCount, setRowCount] = useState(0);
+
+  const syncPaginationState = useCallback((api: GridApi) => {
+    gridApiRef.current = api;
+    setPage(api.paginationGetCurrentPage() + 1);
+    setPageCount(api.paginationGetTotalPages());
+    setPageSize(api.paginationGetPageSize());
+    setRowCount(api.paginationGetRowCount());
+  }, []);
+
+  const handlePaginationChanged = useCallback(
+    (event: PaginationChangedEvent) => {
+      syncPaginationState(event.api);
+      onPaginationChangedProp?.(event);
+    },
+    [onPaginationChangedProp, syncPaginationState],
+  );
+
+  const handlePageChange = useCallback(
+    (_event: SyntheticEvent, nextPage: number) => {
+      gridApiRef.current?.paginationGoToPage(nextPage - 1);
+    },
+    [],
+  );
+
+  const handlePageSizeChange = useCallback(
+    (_event: SyntheticEvent, selected: number[]) => {
+      const nextPageSize = selected[0];
+      if (nextPageSize == null) {
+        return;
+      }
+      setPageSize(nextPageSize);
+      gridApiRef.current?.setGridOption("paginationPageSize", nextPageSize);
+    },
+    [],
+  );
+
+  const firstRow = rowCount === 0 ? 0 : (page - 1) * pageSize + 1;
+  const lastRow = Math.min(page * pageSize, rowCount);
+  const rangeLabel = `${formatCount(firstRow)} to ${formatCount(lastRow)} of ${formatCount(rowCount)}`;
+
+  const isOnFirstPage = page <= 1;
+  const isOnLastPage = pageCount === 0 || page >= pageCount;
 
   return (
-    <div {...containerProps}>
-      <AgGridReact
-        {...agGridProps}
-        {...props}
-        columnDefs={dataGridExampleColumns}
-        pagination
-        paginationPageSize={100}
-        rowData={generateData(dataGridExampleData)}
-      />
-    </div>
+    <StackLayout gap={0} style={{ width: containerProps.style?.width }}>
+      <div {...containerProps}>
+        <AgGridReact
+          {...agGridProps}
+          {...props}
+          columnDefs={dataGridExampleColumns}
+          pagination
+          paginationPageSize={pageSize}
+          paginationPageSizeSelector={false}
+          suppressPaginationPanel
+          rowData={rowData}
+          onPaginationChanged={handlePaginationChanged}
+        />
+      </div>
+      <FlexLayout
+        align="center"
+        justify="end"
+        gap={3}
+        style={{
+          borderTop:
+            "var(--salt-size-fixed-100) var(--salt-borderStyle-solid) var(--salt-separable-secondary-borderColor)",
+          paddingBlock: "var(--salt-spacing-100)",
+          paddingInline: "var(--salt-spacing-100)",
+        }}
+      >
+        <FlexLayout align="center" gap={1}>
+          <Text styleAs="label">Page Size</Text>
+          <Dropdown
+            aria-label="Page Size"
+            selected={[pageSize]}
+            onSelectionChange={handlePageSizeChange}
+            bordered
+            style={{ width: "calc(var(--salt-size-base) * 3)" }}
+          >
+            {PAGE_SIZES.map((size) => (
+              <Option value={size} key={size}>
+                {size}
+              </Option>
+            ))}
+          </Dropdown>
+        </FlexLayout>
+        <Text>{rangeLabel}</Text>
+        {pageCount >= 2 && (
+          <Pagination
+            count={pageCount}
+            page={page}
+            onPageChange={handlePageChange}
+          >
+            <FlexLayout align="center" gap={0}>
+              <Button
+                appearance="transparent"
+                aria-label="First Page"
+                disabled={isOnFirstPage}
+                onClick={() => {
+                  gridApiRef.current?.paginationGoToFirstPage();
+                }}
+              >
+                <FirstIcon aria-hidden />
+              </Button>
+              <CompactPaginator>
+                <CompactInput />
+              </CompactPaginator>
+              <Button
+                appearance="transparent"
+                aria-label="Last Page"
+                disabled={isOnLastPage}
+                onClick={() => {
+                  gridApiRef.current?.paginationGoToLastPage();
+                }}
+              >
+                <LastIcon aria-hidden />
+              </Button>
+            </FlexLayout>
+          </Pagination>
+        )}
+      </FlexLayout>
+    </StackLayout>
   );
 };
 
-export default Pagination;
+export default PaginationExample;

--- a/packages/ag-grid-theme/src/examples/Pagination.tsx
+++ b/packages/ag-grid-theme/src/examples/Pagination.tsx
@@ -4,6 +4,8 @@ import {
   CompactPaginator,
   Dropdown,
   FlexLayout,
+  FormField,
+  FormFieldLabel,
   Option,
   Pagination,
   StackLayout,
@@ -13,6 +15,7 @@ import { FirstIcon, LastIcon } from "@salt-ds/icons";
 import type { GridApi, PaginationChangedEvent } from "ag-grid-community";
 import { AgGridReact, type AgGridReactProps } from "ag-grid-react";
 import {
+  type CSSProperties,
   type SyntheticEvent,
   useCallback,
   useMemo,
@@ -119,14 +122,20 @@ const PaginationExample = (props: AgGridReactProps) => {
           paddingInline: "var(--salt-spacing-100)",
         }}
       >
-        <FlexLayout align="center" gap={1}>
-          <Text styleAs="label">Page Size</Text>
+        <FormField
+          labelPlacement="left"
+          style={
+            {
+              width: "max-content",
+              "--saltFormField-label-width": "max-content",
+            } as CSSProperties
+          }
+        >
+          <FormFieldLabel>Page Size</FormFieldLabel>
           <Dropdown
-            aria-label="Page Size"
             selected={[pageSize]}
             onSelectionChange={handlePageSizeChange}
             bordered
-            style={{ width: "calc(var(--salt-size-base) * 3)" }}
           >
             {PAGE_SIZES.map((size) => (
               <Option value={size} key={size}>
@@ -134,7 +143,7 @@ const PaginationExample = (props: AgGridReactProps) => {
               </Option>
             ))}
           </Dropdown>
-        </FlexLayout>
+        </FormField>
         <Text>{rangeLabel}</Text>
         {pageCount >= 2 && (
           <Pagination

--- a/site/docs/components/ag-grid-theme/examples.mdx
+++ b/site/docs/components/ag-grid-theme/examples.mdx
@@ -150,6 +150,8 @@ This overlay tells the user that there is no information to display.
 
 Users can move between pages using the controls in the lower right.
 
+The example below suppresses AG Grid's built-in pagination panel and composes Salt components to handle pagination instead.
+
 <LivePreview componentName="ag-grid-theme" exampleName="Pagination" />
 
 ## Parent-child rows

--- a/site/src/examples/ag-grid-theme/Pagination.tsx
+++ b/site/src/examples/ag-grid-theme/Pagination.tsx
@@ -4,6 +4,8 @@ import {
   CompactPaginator,
   Dropdown,
   FlexLayout,
+  FormField,
+  FormFieldLabel,
   Option,
   Pagination as SaltPagination,
   StackLayout,
@@ -13,6 +15,7 @@ import { FirstIcon, LastIcon } from "@salt-ds/icons";
 import type { GridApi, PaginationChangedEvent } from "ag-grid-community";
 import { AgGridReact, type AgGridReactProps } from "ag-grid-react";
 import {
+  type CSSProperties,
   type SyntheticEvent,
   useCallback,
   useMemo,
@@ -121,14 +124,20 @@ export const Pagination = (props: AgGridReactProps) => {
           paddingInline: "var(--salt-spacing-100)",
         }}
       >
-        <FlexLayout align="center" gap={1}>
-          <Text styleAs="label">Page Size</Text>
+        <FormField
+          labelPlacement="left"
+          style={
+            {
+              width: "max-content",
+              "--saltFormField-label-width": "max-content",
+            } as CSSProperties
+          }
+        >
+          <FormFieldLabel>Page Size</FormFieldLabel>
           <Dropdown
-            aria-label="Page Size"
             selected={[pageSize]}
             onSelectionChange={handlePageSizeChange}
             bordered
-            style={{ width: "calc(var(--salt-size-base) * 3)" }}
           >
             {PAGE_SIZES.map((size) => (
               <Option value={size} key={size}>
@@ -136,7 +145,7 @@ export const Pagination = (props: AgGridReactProps) => {
               </Option>
             ))}
           </Dropdown>
-        </FlexLayout>
+        </FormField>
         <Text>{rangeLabel}</Text>
         {pageCount >= 2 && (
           <SaltPagination

--- a/site/src/examples/ag-grid-theme/Pagination.tsx
+++ b/site/src/examples/ag-grid-theme/Pagination.tsx
@@ -1,7 +1,29 @@
+import {
+  Button,
+  CompactInput,
+  CompactPaginator,
+  Dropdown,
+  FlexLayout,
+  Option,
+  Pagination as SaltPagination,
+  StackLayout,
+  Text,
+} from "@salt-ds/core";
+import { FirstIcon, LastIcon } from "@salt-ds/icons";
+import type { GridApi, PaginationChangedEvent } from "ag-grid-community";
 import { AgGridReact, type AgGridReactProps } from "ag-grid-react";
+import {
+  type SyntheticEvent,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 // refer to https://github.com/jpmorganchase/salt-ds/tree/main/site/src/examples/ag-grid-theme/data
 import { defaultColumns, defaultData } from "./data";
 import { useAgGridHelpers } from "./useAgGridHelpers";
+
+const PAGE_SIZES = [20, 50, 100] as const;
 
 const generateData = (states: typeof defaultData) =>
   states.reduce(
@@ -16,21 +38,140 @@ const generateData = (states: typeof defaultData) =>
     [] as typeof defaultData,
   );
 
+const formatCount = (value: number) => value.toLocaleString("en-US");
+
 export const Pagination = (props: AgGridReactProps) => {
+  const { onPaginationChanged: onPaginationChangedProp } = props;
   // We've created a local custom hook to set the rows and column sizes.
   // refer to https://github.com/jpmorganchase/salt-ds/blob/main/site/src/examples/ag-grid-theme/useAgGridHelpers.ts
   const { agGridProps, containerProps } = useAgGridHelpers();
+  const gridApiRef = useRef<GridApi | undefined>(undefined);
+  const rowData = useMemo(() => generateData(defaultData), []);
+
+  const [page, setPage] = useState(1);
+  const [pageCount, setPageCount] = useState(1);
+  const [pageSize, setPageSize] = useState(100);
+  const [rowCount, setRowCount] = useState(0);
+
+  const syncPaginationState = useCallback((api: GridApi) => {
+    gridApiRef.current = api;
+    setPage(api.paginationGetCurrentPage() + 1);
+    setPageCount(api.paginationGetTotalPages());
+    setPageSize(api.paginationGetPageSize());
+    setRowCount(api.paginationGetRowCount());
+  }, []);
+
+  const handlePaginationChanged = useCallback(
+    (event: PaginationChangedEvent) => {
+      syncPaginationState(event.api);
+      onPaginationChangedProp?.(event);
+    },
+    [onPaginationChangedProp, syncPaginationState],
+  );
+
+  const handlePageChange = useCallback(
+    (_event: SyntheticEvent, nextPage: number) => {
+      gridApiRef.current?.paginationGoToPage(nextPage - 1);
+    },
+    [],
+  );
+
+  const handlePageSizeChange = useCallback(
+    (_event: SyntheticEvent, selected: number[]) => {
+      const nextPageSize = selected[0];
+      if (nextPageSize == null) {
+        return;
+      }
+      setPageSize(nextPageSize);
+      gridApiRef.current?.setGridOption("paginationPageSize", nextPageSize);
+    },
+    [],
+  );
+
+  const firstRow = rowCount === 0 ? 0 : (page - 1) * pageSize + 1;
+  const lastRow = Math.min(page * pageSize, rowCount);
+  const rangeLabel = `${formatCount(firstRow)} to ${formatCount(lastRow)} of ${formatCount(rowCount)}`;
+
+  const isOnFirstPage = page <= 1;
+  const isOnLastPage = pageCount === 0 || page >= pageCount;
 
   return (
-    <div {...containerProps}>
-      <AgGridReact
-        columnDefs={defaultColumns}
-        pagination
-        paginationPageSize={100}
-        rowData={generateData(defaultData)}
-        {...agGridProps}
-        {...props}
-      />
-    </div>
+    <StackLayout gap={0} style={{ width: containerProps.style?.width }}>
+      <div {...containerProps}>
+        <AgGridReact
+          {...agGridProps}
+          {...props}
+          columnDefs={defaultColumns}
+          pagination
+          paginationPageSize={pageSize}
+          paginationPageSizeSelector={false}
+          suppressPaginationPanel
+          rowData={rowData}
+          onPaginationChanged={handlePaginationChanged}
+        />
+      </div>
+      <FlexLayout
+        align="center"
+        justify="end"
+        gap={3}
+        style={{
+          borderTop:
+            "var(--salt-size-fixed-100) var(--salt-borderStyle-solid) var(--salt-separable-secondary-borderColor)",
+          paddingBlock: "var(--salt-spacing-100)",
+          paddingInline: "var(--salt-spacing-100)",
+        }}
+      >
+        <FlexLayout align="center" gap={1}>
+          <Text styleAs="label">Page Size</Text>
+          <Dropdown
+            aria-label="Page Size"
+            selected={[pageSize]}
+            onSelectionChange={handlePageSizeChange}
+            bordered
+            style={{ width: "calc(var(--salt-size-base) * 3)" }}
+          >
+            {PAGE_SIZES.map((size) => (
+              <Option value={size} key={size}>
+                {size}
+              </Option>
+            ))}
+          </Dropdown>
+        </FlexLayout>
+        <Text>{rangeLabel}</Text>
+        {pageCount >= 2 && (
+          <SaltPagination
+            count={pageCount}
+            page={page}
+            onPageChange={handlePageChange}
+          >
+            <FlexLayout align="center" gap={0}>
+              <Button
+                appearance="transparent"
+                aria-label="First Page"
+                disabled={isOnFirstPage}
+                onClick={() => {
+                  gridApiRef.current?.paginationGoToFirstPage();
+                }}
+              >
+                <FirstIcon aria-hidden />
+              </Button>
+              <CompactPaginator>
+                <CompactInput />
+              </CompactPaginator>
+              <Button
+                appearance="transparent"
+                aria-label="Last Page"
+                disabled={isOnLastPage}
+                onClick={() => {
+                  gridApiRef.current?.paginationGoToLastPage();
+                }}
+              >
+                <LastIcon aria-hidden />
+              </Button>
+            </FlexLayout>
+          </SaltPagination>
+        )}
+      </FlexLayout>
+    </StackLayout>
   );
 };


### PR DESCRIPTION
- Use Salt components in the ag-grid Pagination examples
- Design chosen to be similar to the default (i would prefer to move the page size Dropdown to the left side to slightly prevent layout jumps as the label changes)