### PR TITLE
[SITE-DOCS] - add collapsible vertical navigation

### DIFF
--- a/site/docs/components/vertical-navigation/accessibility.mdx
+++ b/site/docs/components/vertical-navigation/accessibility.mdx
@@ -16,6 +16,11 @@ data:
   - If more than one vertical navigation component is present on the page, ensure that each has a unique accessible name.
   - Avoid adding the word “navigation” to the accessible name. Assistive technologies will announce it automatically due to its role.
 
+### Collapsible navigation
+
+- Give the collapse toggle an accessible name that states the action it performs, such as “Collapse navigation” or “Expand navigation”, and update it as the state changes.
+- Set `aria-expanded` on the toggle to reflect the current state.
+
 ## Keyboard interactions
 
 <KeyboardControls>

--- a/site/docs/components/vertical-navigation/accessibility.mdx
+++ b/site/docs/components/vertical-navigation/accessibility.mdx
@@ -18,7 +18,7 @@ data:
 
 ### Collapsible navigation
 
-- Give the collapse toggle an accessible name that states the action it performs, such as “Collapse navigation” or “Expand navigation”, and update it as the state changes.
+- Give the collapse toggle a stable accessible name, such as “Toggle navigation”. Avoid changing the name based on state, as `aria-expanded` already conveys whether the navigation is expanded or collapsed.
 - Set `aria-expanded` on the toggle to reflect the current state.
 
 ## Keyboard interactions

--- a/site/docs/components/vertical-navigation/accessibility.mdx
+++ b/site/docs/components/vertical-navigation/accessibility.mdx
@@ -16,11 +16,6 @@ data:
   - If more than one vertical navigation component is present on the page, ensure that each has a unique accessible name.
   - Avoid adding the word “navigation” to the accessible name. Assistive technologies will announce it automatically due to its role.
 
-### Collapsible navigation
-
-- Give the collapse toggle a stable accessible name, such as “Toggle navigation”. Avoid changing the name based on state, as `aria-expanded` already conveys whether the navigation is expanded or collapsed.
-- Set `aria-expanded` on the toggle to reflect the current state.
-
 ## Keyboard interactions
 
 <KeyboardControls>

--- a/site/docs/components/vertical-navigation/examples.mdx
+++ b/site/docs/components/vertical-navigation/examples.mdx
@@ -71,6 +71,11 @@ It's recommended to provide a skip link to bypass the vertical navigation for a 
 
 Collapse `VerticalNavigation` to an icon-only view, while keeping the navigation available at all times.
 
+### Best practices
+
+- Give the collapse toggle a stable accessible name that describes what it controls, such as “Labels”. Avoid changing the name based on state, as `aria-expanded` already conveys whether the navigation is expanded or collapsed.
+- Set `aria-expanded` on the toggle to reflect the current state.
+
 <LivePreview
   componentName="vertical-navigation"
   exampleName="CollapsibleNavigation"

--- a/site/docs/components/vertical-navigation/examples.mdx
+++ b/site/docs/components/vertical-navigation/examples.mdx
@@ -66,3 +66,12 @@ It's recommended to provide a skip link to bypass the vertical navigation for a 
 **Note:** If the navigation appears across multiple pages **and** there is no “Skip to main” link as the first item on the page, to meet WCAG 2.4.1 requirement for bypassing repeated content a skip link is required.
 
 <LivePreview componentName="vertical-navigation" exampleName="WithSkipLink" />
+
+## Collapsible navigation
+
+Collapse `VerticalNavigation` to an icon-only rail, while keeping the navigation available at all times.
+
+<LivePreview
+  componentName="vertical-navigation"
+  exampleName="CollapsibleNavigation"
+/>

--- a/site/docs/components/vertical-navigation/examples.mdx
+++ b/site/docs/components/vertical-navigation/examples.mdx
@@ -69,7 +69,7 @@ It's recommended to provide a skip link to bypass the vertical navigation for a 
 
 ## Collapsible navigation
 
-Collapse `VerticalNavigation` to an icon-only rail, while keeping the navigation available at all times.
+Collapse `VerticalNavigation` to an icon-only view, while keeping the navigation available at all times.
 
 <LivePreview
   componentName="vertical-navigation"

--- a/site/src/examples/vertical-navigation/CollapsibleNavigation.module.css
+++ b/site/src/examples/vertical-navigation/CollapsibleNavigation.module.css
@@ -1,3 +1,4 @@
+/*TODO: add that file to the site example by linking to github*/
 .nav {
   --collapsibleNavigation-expandedWidth: 30ch;
   --collapsibleNavigation-collapsedWidth: calc(var(--salt-size-icon) + var(--salt-spacing-100) * 2 + var(--salt-size-fixed-100) * 2);
@@ -13,7 +14,6 @@
 .nav :global(.saltVerticalNavigationItemContent) {
   min-width: 0;
 }
-
 
 @media (prefers-reduced-motion: reduce) {
   .nav {

--- a/site/src/examples/vertical-navigation/CollapsibleNavigation.module.css
+++ b/site/src/examples/vertical-navigation/CollapsibleNavigation.module.css
@@ -2,6 +2,7 @@
   --collapsibleNavigation-expandedWidth: 30ch;
   --collapsibleNavigation-collapsedWidth: calc(var(--salt-size-icon) + var(--salt-spacing-100) * 2 + var(--salt-size-fixed-100) * 2);
   width: var(--collapsibleNavigation-expandedWidth);
+  overflow-x: hidden;
   transition: width var(--salt-duration-perceptible) var(--salt-animation-timing-function);
 }
 

--- a/site/src/examples/vertical-navigation/CollapsibleNavigation.module.css
+++ b/site/src/examples/vertical-navigation/CollapsibleNavigation.module.css
@@ -1,0 +1,27 @@
+.nav {
+  --collapsibleNavigation-expandedWidth: 30ch;
+  --collapsibleNavigation-collapsedWidth: calc(var(--salt-size-icon) + var(--salt-spacing-100) * 2 + var(--salt-size-fixed-100) * 2);
+  width: var(--collapsibleNavigation-expandedWidth);
+  transition: width var(--salt-duration-perceptible) var(--salt-animation-timing-function);
+}
+
+.nav.collapsed {
+  width: var(--collapsibleNavigation-collapsedWidth);
+}
+
+/* Lets an item narrow to the width of its icon, past its default minimum. */
+.nav :global(.saltVerticalNavigationItemContent) {
+  min-width: 0;
+}
+
+/* Keeps labels on one line so the closing rail clips them, rather than
+   rewrapping them as the items narrow. */
+.nav :global(.saltVerticalNavigationItemLabel) {
+  white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nav {
+    transition: none;
+  }
+}

--- a/site/src/examples/vertical-navigation/CollapsibleNavigation.module.css
+++ b/site/src/examples/vertical-navigation/CollapsibleNavigation.module.css
@@ -14,11 +14,6 @@
   min-width: 0;
 }
 
-/* Keeps labels on one line so the closing rail clips them, rather than
-   rewrapping them as the items narrow. */
-.nav :global(.saltVerticalNavigationItemLabel) {
-  white-space: nowrap;
-}
 
 @media (prefers-reduced-motion: reduce) {
   .nav {

--- a/site/src/examples/vertical-navigation/CollapsibleNavigation.module.css
+++ b/site/src/examples/vertical-navigation/CollapsibleNavigation.module.css
@@ -15,8 +15,18 @@
   min-width: 0;
 }
 
+.nav :global(.saltVerticalNavigationItemLabel) {
+  white-space: nowrap;
+  transition: opacity var(--salt-duration-perceptible) var(--salt-animation-timing-function);
+}
+
+.nav.collapsed :global(.saltVerticalNavigationItemLabel) {
+  opacity: 0;
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .nav {
+  .nav,
+  .nav :global(.saltVerticalNavigationItemLabel) {
     transition: none;
   }
 }

--- a/site/src/examples/vertical-navigation/CollapsibleNavigation.module.css
+++ b/site/src/examples/vertical-navigation/CollapsibleNavigation.module.css
@@ -1,4 +1,3 @@
-/*TODO: add that file to the site example by linking to github*/
 .nav {
   --collapsibleNavigation-expandedWidth: 30ch;
   --collapsibleNavigation-collapsedWidth: calc(var(--salt-size-icon) + var(--salt-spacing-100) * 2 + var(--salt-size-fixed-100) * 2);

--- a/site/src/examples/vertical-navigation/CollapsibleNavigation.tsx
+++ b/site/src/examples/vertical-navigation/CollapsibleNavigation.tsx
@@ -30,7 +30,11 @@ function NavItem({ item, collapsed }: { item: Item; collapsed: boolean }) {
         <Tooltip content={item.title} disabled={!collapsed} placement="right">
           <VerticalNavigationItemTrigger render={<Link to={item.href} />}>
             {item.icon}
-            <VerticalNavigationItemLabel>
+            {/* Hidden once collapsed, but kept in the DOM for the item's
+                accessible name. */}
+            <VerticalNavigationItemLabel
+              className={collapsed ? "salt-visuallyHidden" : undefined}
+            >
               {item.title}
             </VerticalNavigationItemLabel>
           </VerticalNavigationItemTrigger>

--- a/site/src/examples/vertical-navigation/CollapsibleNavigation.tsx
+++ b/site/src/examples/vertical-navigation/CollapsibleNavigation.tsx
@@ -67,9 +67,6 @@ export const CollapsibleNavigation = () => {
                 appearance="transparent"
                 aria-controls={navId}
                 aria-expanded={!collapsed}
-                aria-label={
-                  collapsed ? "Expand navigation" : "Collapse navigation"
-                }
                 onClick={() => setCollapsed(!collapsed)}
               >
                 {collapsed ? (
@@ -93,7 +90,6 @@ export const CollapsibleNavigation = () => {
         </BorderItem>
         <BorderItem position="center">
           <StackLayout direction="column" gap={1}>
-            {/* The heading levels in this example are demonstrational only */}
             <H3 styleAs="h1">Collapsible navigation</H3>
             <Text>
               Collapse the navigation to give the main content more room. While

--- a/site/src/examples/vertical-navigation/CollapsibleNavigation.tsx
+++ b/site/src/examples/vertical-navigation/CollapsibleNavigation.tsx
@@ -6,7 +6,6 @@ import {
   StackLayout,
   Text,
   Tooltip,
-  useId,
   VerticalNavigation,
   VerticalNavigationItem,
   VerticalNavigationItemContent,
@@ -28,7 +27,13 @@ function NavItem({ item, collapsed }: { item: Item; collapsed: boolean }) {
   return (
     <VerticalNavigationItem active={location.pathname === item.href}>
       <VerticalNavigationItemContent>
-        <Tooltip content={item.title} disabled={!collapsed} placement="right">
+        {/* aria-hidden so the tooltip isn't announced as a duplicate of the
+            item's accessible name. */}
+        <Tooltip
+          content={<span aria-hidden>{item.title}</span>}
+          disabled={!collapsed}
+          placement="right"
+        >
           <VerticalNavigationItemTrigger render={<Link to={item.href} />}>
             {item.icon}
             {/* Hidden once collapsed, but kept in the DOM for the item's
@@ -46,8 +51,10 @@ function NavItem({ item, collapsed }: { item: Item; collapsed: boolean }) {
 }
 
 export const CollapsibleNavigation = () => {
-  const navId = useId();
   const [collapsed, setCollapsed] = useState(false);
+
+  // Static so it isn't re-announced on toggle; aria-expanded conveys the state.
+  const toggleLabel = "Labels";
 
   return (
     <MockHistory>
@@ -63,15 +70,22 @@ export const CollapsibleNavigation = () => {
           />
         </BorderItem>
         <BorderItem position="west">
-          <StackLayout align="start" gap={1}>
+          {/* The sidebar is the navigation landmark, so the toggle is part of
+              it. */}
+          <StackLayout
+            as="nav"
+            aria-label="Collapsible sidebar"
+            align="start"
+            gap={1}
+          >
             <Tooltip
-              content={collapsed ? "Expand navigation" : "Collapse navigation"}
+              content={<span aria-hidden>{toggleLabel}</span>}
               placement="right"
             >
               <Button
                 appearance="transparent"
-                aria-controls={navId}
                 aria-expanded={!collapsed}
+                aria-label={toggleLabel}
                 onClick={() => setCollapsed(!collapsed)}
               >
                 {collapsed ? (
@@ -81,11 +95,11 @@ export const CollapsibleNavigation = () => {
                 )}
               </Button>
             </Tooltip>
+            {/* Demoted to avoid a nested landmark inside the sidebar nav. */}
             <VerticalNavigation
-              aria-label="Collapsible sidebar"
+              role="presentation"
               appearance="bordered"
               className={clsx(styles.nav, { [styles.collapsed]: collapsed })}
-              id={navId}
             >
               {flatNavData.map((item) => (
                 <NavItem key={item.href} item={item} collapsed={collapsed} />

--- a/site/src/examples/vertical-navigation/CollapsibleNavigation.tsx
+++ b/site/src/examples/vertical-navigation/CollapsibleNavigation.tsx
@@ -36,11 +36,9 @@ function NavItem({ item, collapsed }: { item: Item; collapsed: boolean }) {
         >
           <VerticalNavigationItemTrigger render={<Link to={item.href} />}>
             {item.icon}
-            {/* Hidden once collapsed, but kept in the DOM for the item's
-                accessible name. */}
-            <VerticalNavigationItemLabel
-              className={collapsed ? "salt-visuallyHidden" : undefined}
-            >
+            {/* Faded out and clipped by CSS once collapsed, but kept in the
+                DOM for the item's accessible name. */}
+            <VerticalNavigationItemLabel>
               {item.title}
             </VerticalNavigationItemLabel>
           </VerticalNavigationItemTrigger>

--- a/site/src/examples/vertical-navigation/CollapsibleNavigation.tsx
+++ b/site/src/examples/vertical-navigation/CollapsibleNavigation.tsx
@@ -17,6 +17,7 @@ import { DoubleChevronLeftIcon, DoubleChevronRightIcon } from "@salt-ds/icons";
 import { clsx } from "clsx";
 import { useState } from "react";
 import { Link, useLocation } from "react-router";
+// refer to https://github.com/jpmorganchase/salt-ds/blob/main/site/src/examples/vertical-navigation/CollapsibleNavigation.module.css
 import styles from "./CollapsibleNavigation.module.css";
 import { flatNavData, type Item } from "./data";
 import { MockHistory } from "./MockHistory";

--- a/site/src/examples/vertical-navigation/CollapsibleNavigation.tsx
+++ b/site/src/examples/vertical-navigation/CollapsibleNavigation.tsx
@@ -1,0 +1,115 @@
+import {
+  BorderItem,
+  BorderLayout,
+  Button,
+  H3,
+  StackLayout,
+  Text,
+  Tooltip,
+  useId,
+  VerticalNavigation,
+  VerticalNavigationItem,
+  VerticalNavigationItemContent,
+  VerticalNavigationItemLabel,
+  VerticalNavigationItemTrigger,
+} from "@salt-ds/core";
+import { DoubleChevronLeftIcon, DoubleChevronRightIcon } from "@salt-ds/icons";
+import { clsx } from "clsx";
+import { useState } from "react";
+import { Link, useLocation } from "react-router";
+import styles from "./CollapsibleNavigation.module.css";
+import { flatNavData, type Item } from "./data";
+import { MockHistory } from "./MockHistory";
+
+function NavItem({ item, collapsed }: { item: Item; collapsed: boolean }) {
+  const location = useLocation();
+
+  return (
+    <VerticalNavigationItem active={location.pathname === item.href}>
+      <VerticalNavigationItemContent>
+        <Tooltip content={item.title} disabled={!collapsed} placement="right">
+          <VerticalNavigationItemTrigger render={<Link to={item.href} />}>
+            {item.icon}
+            <VerticalNavigationItemLabel>
+              {item.title}
+            </VerticalNavigationItemLabel>
+          </VerticalNavigationItemTrigger>
+        </Tooltip>
+      </VerticalNavigationItemContent>
+    </VerticalNavigationItem>
+  );
+}
+
+export const CollapsibleNavigation = () => {
+  const navId = useId();
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <MockHistory>
+      <BorderLayout columnGap={2} rowGap={2}>
+        <BorderItem position="north">
+          <div
+            style={{
+              background: "var(--salt-container-secondary-background)",
+              borderBottom:
+                "var(--salt-size-fixed-100) var(--salt-separable-borderStyle) var(--salt-separable-primary-borderColor)",
+              height: "calc(var(--salt-size-base) + var(--salt-spacing-200))",
+            }}
+          />
+        </BorderItem>
+        <BorderItem position="west">
+          <StackLayout align="start" gap={1}>
+            <Tooltip
+              content={collapsed ? "Expand navigation" : "Collapse navigation"}
+              placement="right"
+            >
+              <Button
+                appearance="transparent"
+                aria-controls={navId}
+                aria-expanded={!collapsed}
+                aria-label={
+                  collapsed ? "Expand navigation" : "Collapse navigation"
+                }
+                onClick={() => setCollapsed(!collapsed)}
+              >
+                {collapsed ? (
+                  <DoubleChevronRightIcon aria-hidden />
+                ) : (
+                  <DoubleChevronLeftIcon aria-hidden />
+                )}
+              </Button>
+            </Tooltip>
+            <VerticalNavigation
+              aria-label="Collapsible sidebar"
+              appearance="bordered"
+              className={clsx(styles.nav, { [styles.collapsed]: collapsed })}
+              id={navId}
+            >
+              {flatNavData.map((item) => (
+                <NavItem key={item.href} item={item} collapsed={collapsed} />
+              ))}
+            </VerticalNavigation>
+          </StackLayout>
+        </BorderItem>
+        <BorderItem position="center">
+          <StackLayout direction="column" gap={1}>
+            {/* The heading levels in this example are demonstrational only */}
+            <H3 styleAs="h1">Collapsible navigation</H3>
+            <Text>
+              Collapse the navigation to give the main content more room. While
+              collapsed, each item is identified by its icon and a tooltip.
+            </Text>
+            <Text>
+              This placeholder text is provided to illustrate how content will
+              appear within the component. The sentences are intended for
+              demonstration only and do not convey specific information. Generic
+              examples like this help review layout, spacing, and overall
+              design. Adjust the wording as needed to fit your use case or
+              display requirements.
+            </Text>
+          </StackLayout>
+        </BorderItem>
+      </BorderLayout>
+    </MockHistory>
+  );
+};

--- a/site/src/examples/vertical-navigation/data.tsx
+++ b/site/src/examples/vertical-navigation/data.tsx
@@ -289,3 +289,31 @@ export const navData: Item[] = [
     ],
   },
 ];
+
+export const flatNavData: Item[] = [
+  {
+    title: "Home",
+    href: "/",
+    icon: <HomeIcon aria-hidden />,
+  },
+  {
+    title: "Solutions",
+    href: "/solutions",
+    icon: <JigsawIcon aria-hidden />,
+  },
+  {
+    title: "Who we serve",
+    href: "/who-we-serve",
+    icon: <HandshakeIcon aria-hidden />,
+  },
+  {
+    title: "Insights",
+    href: "/insights",
+    icon: <LightbulbIcon aria-hidden />,
+  },
+  {
+    title: "About us",
+    href: "/about-us",
+    icon: <GlobeIcon aria-hidden />,
+  },
+];

--- a/site/src/examples/vertical-navigation/index.ts
+++ b/site/src/examples/vertical-navigation/index.ts
@@ -1,4 +1,5 @@
 export * from "./Basic";
+export * from "./CollapsibleNavigation";
 export * from "./CollapsibleSubmenu";
 export * from "./MultiActionItem";
 export * from "./Submenu";


### PR DESCRIPTION
Add and example with Collapsible Vertical Navigation to docs - example only, no new components
needs to be merged after https://github.com/jpmorganchase/salt-ds/pull/6884