### PR TITLE
Improve App Header pattern example

### DIFF
--- a/packages/core/stories/patterns/app-header/app-header.stories.css
+++ b/packages/core/stories/patterns/app-header/app-header.stories.css
@@ -1,0 +1,75 @@
+:root {
+  --appHeaderPattern-height: calc(var(--salt-size-base) + var(--salt-spacing-200));
+}
+
+.appHeaderPattern-header {
+  position: sticky;
+  top: 0;
+  /* Sits below the drawer (`--salt-zIndex-drawer`) so the drawer and its scrim
+     overlay the header when open. */
+  z-index: var(--salt-zIndex-appHeader);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--salt-spacing-300);
+  height: var(--appHeaderPattern-height);
+  padding-inline: var(--salt-layout-page-margin);
+  background: var(--salt-container-primary-background);
+  border-bottom: var(--salt-size-fixed-100) var(--salt-borderStyle-solid) var(--salt-separable-primary-borderColor);
+}
+
+/* On small viewports the header only holds the menu button and logo, grouped
+   at the start. */
+.appHeaderPattern-header[data-small-viewport="true"] {
+  justify-content: flex-start;
+}
+
+/* The scroll shadow is applied via `position: sticky` on the header itself, so
+   it is not clipped by an `overflow` on an ancestor. */
+.appHeaderPattern-header[data-scrolled="true"] {
+  box-shadow: var(--salt-overlayable-shadow-scroll);
+}
+
+.appHeaderPattern-logo {
+  display: block;
+  height: calc(var(--salt-size-base) - var(--salt-spacing-150));
+}
+
+.appHeaderPattern-navList {
+  display: flex;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* Brand row at the top of the drawer, aligned to the app header height. */
+.appHeaderPattern-drawerHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--salt-spacing-300);
+  min-height: var(--appHeaderPattern-height);
+}
+
+/* Utility actions are pinned to the bottom of the flex-column drawer, below the
+   primary navigation. */
+.appHeaderPattern-drawerUtilities {
+  margin-top: auto;
+}
+
+.appHeaderPattern-heading {
+  margin: var(--salt-spacing-400);
+}
+
+/* Placeholder content blocks to demonstrate scrolling under the sticky header. */
+.appHeaderPattern-block {
+  margin: var(--salt-spacing-400);
+  padding: var(--salt-spacing-400);
+  background: var(--salt-container-secondary-background);
+}
+
+.appHeaderPattern-footer {
+  margin: var(--salt-spacing-200);
+  padding: var(--salt-spacing-200);
+  background: var(--salt-container-secondary-background);
+}

--- a/packages/core/stories/patterns/app-header/app-header.stories.css
+++ b/packages/core/stories/patterns/app-header/app-header.stories.css
@@ -3,15 +3,15 @@
 }
 
 .appHeaderPattern-header {
-  position: sticky;
+  position: fixed;
   top: 0;
-  /* Sits below the drawer (`--salt-zIndex-drawer`) so the drawer and its scrim
-     overlay the header when open. */
-  z-index: var(--salt-zIndex-appHeader);
+  z-index: calc(var(--salt-zIndex-drawer) + 1);
+  box-sizing: border-box;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--salt-spacing-300);
+  width: 100%;
   height: var(--appHeaderPattern-height);
   padding-inline: var(--salt-layout-page-margin);
   background: var(--salt-container-primary-background);
@@ -24,10 +24,14 @@
   justify-content: flex-start;
 }
 
-/* The scroll shadow is applied via `position: sticky` on the header itself, so
-   it is not clipped by an `overflow` on an ancestor. */
+/* The scroll shadow is applied to the fixed header itself, so it is not clipped
+   by an `overflow` on an ancestor. */
 .appHeaderPattern-header[data-scrolled="true"] {
   box-shadow: var(--salt-overlayable-shadow-scroll);
+}
+
+.appHeaderPattern-header[data-small-viewport="true"][data-scrolled="true"] {
+  box-shadow: var(--salt-shadow-1);
 }
 
 .appHeaderPattern-logo {
@@ -42,34 +46,27 @@
   list-style: none;
 }
 
-/* Brand row at the top of the drawer, aligned to the app header height. */
-.appHeaderPattern-drawerHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--salt-spacing-300);
-  min-height: var(--appHeaderPattern-height);
+.appHeaderPattern-drawer {
+  padding-top: calc(var(--appHeaderPattern-height) + var(--salt-spacing-300));
 }
 
-/* Utility actions are pinned to the bottom of the flex-column drawer, below the
-   primary navigation. */
-.appHeaderPattern-drawerUtilities {
-  margin-top: auto;
+.appHeaderPattern-firstUtilityItem {
+  margin-top: var(--salt-spacing-300);
 }
 
-.appHeaderPattern-heading {
-  margin: var(--salt-spacing-400);
+.appHeaderPattern-main {
+  margin-top: var(--appHeaderPattern-height);
 }
 
-/* Placeholder content blocks to demonstrate scrolling under the sticky header. */
+/* Placeholder content blocks to demonstrate scrolling under the fixed header. */
 .appHeaderPattern-block {
-  margin: var(--salt-spacing-400);
+  margin: var(--salt-spacing-400) var(--salt-layout-page-margin);
   padding: var(--salt-spacing-400);
   background: var(--salt-container-secondary-background);
 }
 
 .appHeaderPattern-footer {
-  margin: var(--salt-spacing-200);
+  margin: var(--salt-spacing-200) var(--salt-layout-page-margin);
   padding: var(--salt-spacing-200);
   background: var(--salt-container-secondary-background);
 }

--- a/packages/core/stories/patterns/app-header/app-header.stories.tsx
+++ b/packages/core/stories/patterns/app-header/app-header.stories.tsx
@@ -3,7 +3,6 @@ import {
   BorderLayout,
   Button,
   Drawer,
-  H1,
   NavigationItem,
   SkipLink,
   StackLayout,
@@ -17,10 +16,10 @@ import {
 } from "@salt-ds/core";
 import {
   CloseIcon,
-  GithubIcon,
   MenuIcon,
+  SearchIcon,
+  SettingsIcon,
   StackoverflowIcon,
-  SymphonyIcon,
 } from "@salt-ds/icons";
 import type { Meta, StoryFn } from "@storybook/react-vite";
 import { type FC, type ReactNode, useEffect, useState } from "react";
@@ -48,31 +47,28 @@ const mainContentId = "app-header-main-content";
 
 type NavItem = { href: string; label: string };
 
-const navigationItems: NavItem[] = [
-  { href: "/", label: "Home" },
-  { href: "/about", label: "About" },
-  { href: "/services", label: "Services" },
-  { href: "/contact", label: "Contact" },
-  { href: "/blog", label: "Blog" },
-];
+const navigationItems: NavItem[] = Array.from({ length: 5 }, (_, index) => ({
+  href: index === 0 ? "/" : `/item-${index + 1}`,
+  label: `Item ${index + 1}`,
+}));
 
 type Utility = { icon: ReactNode; key: string; label: string };
 
 const utilities: Utility[] = [
   {
-    icon: <SymphonyIcon aria-hidden />,
-    key: "Symphony",
-    label: "Open Symphony",
+    icon: <SearchIcon aria-hidden />,
+    key: "Utility action 1",
+    label: "Utility action 1",
   },
   {
     icon: <StackoverflowIcon aria-hidden />,
-    key: "Stack Overflow",
-    label: "Open Stack Overflow",
+    key: "Utility action 2",
+    label: "Utility action 2",
   },
   {
-    icon: <GithubIcon aria-hidden />,
-    key: "GitHub",
-    label: "Open GitHub",
+    icon: <SettingsIcon aria-hidden />,
+    key: "Utility action 3",
+    label: "Utility action 3",
   },
 ];
 
@@ -139,8 +135,9 @@ const DrawerNavigation: FC<{
   activePath: string;
   items: NavItem[];
   onNavigate: () => void;
-}> = ({ activePath, items, onNavigate }) => (
-  <VerticalNavigation aria-label="Main navigation" appearance="indicator">
+  utilities: Utility[];
+}> = ({ activePath, items, onNavigate, utilities }) => (
+  <VerticalNavigation aria-label="Main navigation">
     {items.map((item) => (
       <VerticalNavigationItem key={item.href} active={activePath === item.href}>
         <VerticalNavigationItemContent>
@@ -155,39 +152,30 @@ const DrawerNavigation: FC<{
         </VerticalNavigationItemContent>
       </VerticalNavigationItem>
     ))}
+    {utilities.map((utility, index) => (
+      <VerticalNavigationItem
+        key={utility.key}
+        className={
+          index === 0 ? "appHeaderPattern-firstUtilityItem" : undefined
+        }
+      >
+        <VerticalNavigationItemContent>
+          <VerticalNavigationItemTrigger onClick={onNavigate}>
+            {utility.icon}
+            <VerticalNavigationItemLabel>
+              {utility.key}
+            </VerticalNavigationItemLabel>
+          </VerticalNavigationItemTrigger>
+        </VerticalNavigationItemContent>
+      </VerticalNavigationItem>
+    ))}
   </VerticalNavigation>
-);
-
-const DrawerUtilities: FC<{
-  onNavigate: () => void;
-  utilities: Utility[];
-}> = ({ onNavigate, utilities }) => (
-  // Utility actions sit at the bottom of the drawer (pinned via CSS), below the
-  // primary navigation.
-  <div className="appHeaderPattern-drawerUtilities">
-    <VerticalNavigation aria-label="Utilities" appearance="indicator">
-      {utilities.map((utility) => (
-        <VerticalNavigationItem key={utility.key}>
-          <VerticalNavigationItemContent>
-            {/* Utilities are actions rather than routes, so the trigger renders
-                a button (no `href`/`render`). */}
-            <VerticalNavigationItemTrigger onClick={onNavigate}>
-              {utility.icon}
-              <VerticalNavigationItemLabel>
-                {utility.key}
-              </VerticalNavigationItemLabel>
-            </VerticalNavigationItemTrigger>
-          </VerticalNavigationItemContent>
-        </VerticalNavigationItem>
-      ))}
-    </VerticalNavigation>
-  </div>
 );
 
 // Hosts the app header within a page (BorderLayout + main + footer) so it can be
 // shown in context. The app header itself is the `<header>` region below (plus
 // its drawer on small viewports); the main/footer/placeholder content is only
-// scaffolding to demonstrate the sticky header and scroll shadow.
+// scaffolding to demonstrate the fixed header and scroll shadow.
 const AppHeaderPage: FC = () => {
   // The header collapses into a drawer on small viewports (xs and sm), matching
   // the Salt breakpoints. This is driven by viewport width, not density —
@@ -225,11 +213,15 @@ const AppHeaderPage: FC = () => {
           {isSmallViewport ? (
             <>
               <Button
-                aria-label="Open navigation"
+                aria-label={drawerOpen ? "Close navigation" : "Open navigation"}
                 appearance="transparent"
-                onClick={() => setDrawerOpen(true)}
+                onClick={() => setDrawerOpen((open) => !open)}
               >
-                <MenuIcon aria-hidden />
+                {drawerOpen ? (
+                  <CloseIcon aria-hidden />
+                ) : (
+                  <MenuIcon aria-hidden />
+                )}
               </Button>
               <LogoLink />
             </>
@@ -241,10 +233,12 @@ const AppHeaderPage: FC = () => {
             </>
           )}
         </BorderItem>
-        <BorderItem as="main" position="center">
-          <H1 id={mainContentId} className="appHeaderPattern-heading">
-            Explore our offering
-          </H1>
+        <BorderItem
+          as="main"
+          id={mainContentId}
+          position="center"
+          className="appHeaderPattern-main"
+        >
           {Array.from({ length: 12 }, (_, index) => (
             <div
               // biome-ignore lint/suspicious/noArrayIndexKey: In this case, using index as key is acceptable
@@ -259,31 +253,21 @@ const AppHeaderPage: FC = () => {
           </div>
         </BorderItem>
       </BorderLayout>
-      {/* The drawer is a modal overlay: its scrim covers and inerts everything
-          behind it (including the header), so the close control lives inside
-          the drawer rather than in the now-inert header. */}
+      {/* The drawer content is offset below the fixed app header to preserve the
+          original small-viewport example layout. */}
       {isSmallViewport && (
         <Drawer
-          aria-label="Navigation menu"
+          aria-label="Main navigation"
+          className="appHeaderPattern-drawer"
           open={drawerOpen}
           onOpenChange={setDrawerOpen}
         >
-          <div className="appHeaderPattern-drawerHeader">
-            <LogoLink onNavigate={closeDrawer} />
-            <Button
-              aria-label="Close navigation"
-              appearance="transparent"
-              onClick={closeDrawer}
-            >
-              <CloseIcon aria-hidden />
-            </Button>
-          </div>
           <DrawerNavigation
             activePath={pathname}
             items={navigationItems}
             onNavigate={closeDrawer}
+            utilities={utilities}
           />
-          <DrawerUtilities onNavigate={closeDrawer} utilities={utilities} />
         </Drawer>
       )}
     </>
@@ -307,5 +291,16 @@ export const AppHeader: StoryFn = () => <AppHeaderPage />;
 export const SmallViewport: StoryFn = AppHeader.bind({});
 
 SmallViewport.globals = {
+  viewport: { value: "xs" },
+};
+
+/**
+ * Emulates a mobile device by combining the extra small viewport with mobile
+ * density.
+ */
+export const Mobile: StoryFn = AppHeader.bind({});
+
+Mobile.globals = {
+  density: "mobile",
   viewport: { value: "xs" },
 };

--- a/packages/core/stories/patterns/app-header/app-header.stories.tsx
+++ b/packages/core/stories/patterns/app-header/app-header.stories.tsx
@@ -3,12 +3,17 @@ import {
   BorderLayout,
   Button,
   Drawer,
-  FlexItem,
-  FlexLayout,
+  H1,
   NavigationItem,
+  SkipLink,
   StackLayout,
   Text,
-  useResponsiveProp,
+  useCurrentBreakpoint,
+  VerticalNavigation,
+  VerticalNavigationItem,
+  VerticalNavigationItemContent,
+  VerticalNavigationItemLabel,
+  VerticalNavigationItemTrigger,
 } from "@salt-ds/core";
 import {
   CloseIcon,
@@ -17,285 +22,290 @@ import {
   StackoverflowIcon,
   SymphonyIcon,
 } from "@salt-ds/icons";
-import type { Meta } from "@storybook/react-vite";
+import type { Meta, StoryFn } from "@storybook/react-vite";
 import { type FC, type ReactNode, useEffect, useState } from "react";
+import { Link, MemoryRouter, useLocation } from "react-router";
 import logo from "../../assets/logo.svg";
+import "./app-header.stories.css";
 
 export default {
   title: "Patterns/App Header",
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    // A router lets the navigation items behave like real links: navigation is
+    // client-side and the active item is derived from the current location.
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
 } as Meta;
 
-const DesktopAppHeader: FC<{
-  items?: string[];
-  utilities?: { icon: ReactNode; key: string }[];
-}> = ({ items, utilities }) => {
-  const [active, setActive] = useState(items?.[0]);
-  const [offset, setOffset] = useState(0);
+const mainContentId = "app-header-main-content";
+
+type NavItem = { href: string; label: string };
+
+const navigationItems: NavItem[] = [
+  { href: "/", label: "Home" },
+  { href: "/about", label: "About" },
+  { href: "/services", label: "Services" },
+  { href: "/contact", label: "Contact" },
+  { href: "/blog", label: "Blog" },
+];
+
+type Utility = { icon: ReactNode; key: string; label: string };
+
+const utilities: Utility[] = [
+  {
+    icon: <SymphonyIcon aria-hidden />,
+    key: "Symphony",
+    label: "Open Symphony",
+  },
+  {
+    icon: <StackoverflowIcon aria-hidden />,
+    key: "Stack Overflow",
+    label: "Open Stack Overflow",
+  },
+  {
+    icon: <GithubIcon aria-hidden />,
+    key: "GitHub",
+    label: "Open GitHub",
+  },
+];
+
+const useScrolled = () => {
+  const [scrolled, setScrolled] = useState(false);
+
   useEffect(() => {
-    const setScroll = () => {
-      setOffset(window.scrollY);
+    const updateScrolled = () => {
+      setScrolled(window.scrollY > 0);
     };
 
-    window.addEventListener("scroll", setScroll);
+    updateScrolled();
+    window.addEventListener("scroll", updateScrolled, { passive: true });
     return () => {
-      window.removeEventListener("scroll", setScroll);
+      window.removeEventListener("scroll", updateScrolled);
     };
   }, []);
 
-  return (
-    <header>
-      <FlexLayout
-        style={{
-          paddingLeft: "var(--salt-spacing-300)",
-          paddingRight: "var(--salt-spacing-300)",
-          backgroundColor: "var(--salt-container-primary-background)",
-          position: "fixed",
-          width: "100%",
-          boxShadow:
-            offset > 0 ? "var(--salt-overlayable-shadow-scroll)" : "none",
-          borderBottom:
-            "var(--salt-size-fixed-100) var(--salt-borderStyle-solid) var(--salt-separable-primary-borderColor)",
-        }}
-        justify="space-between"
-        gap={3}
-      >
-        <FlexItem align="center">
-          <img
-            alt="logo"
-            src={logo}
-            style={{
-              display: "block",
-              height: "calc(var(--salt-size-base) - var(--salt-spacing-150))",
-            }}
-          />
-        </FlexItem>
-        <nav>
-          <ul
-            style={{
-              display: "flex",
-              listStyle: "none",
-              padding: "0",
-              margin: "0",
-            }}
-          >
-            {items?.map((item) => (
-              <li key={item}>
-                <NavigationItem
-                  active={active === item}
-                  href="#"
-                  onClick={() => setActive(item)}
-                >
-                  {item}
-                </NavigationItem>
-              </li>
-            ))}
-          </ul>
-        </nav>
-        <FlexItem align="center">
-          <StackLayout direction="row" gap={1}>
-            {utilities?.map((utility) => (
-              <Button key={utility.key} appearance="transparent">
-                {utility.icon}
-              </Button>
-            ))}
-          </StackLayout>
-        </FlexItem>
-      </FlexLayout>
-    </header>
-  );
+  return scrolled;
 };
 
-const MobileAppHeader: FC<{
-  items?: string[];
-  utilities?: { icon: ReactNode; key: string }[];
-}> = ({ items, utilities }) => {
+const LogoLink = ({ onNavigate }: { onNavigate?: () => void }) => (
+  <Link aria-label="Product home" to="/" onClick={onNavigate}>
+    <img alt="" className="appHeaderPattern-logo" src={logo} />
+  </Link>
+);
+
+const NavigationList: FC<{
+  activePath: string;
+  items: NavItem[];
+}> = ({ activePath, items }) => (
+  <nav aria-label="Main navigation">
+    <ul className="appHeaderPattern-navList">
+      {items.map((item) => (
+        <li key={item.href}>
+          <NavigationItem
+            active={activePath === item.href}
+            href={item.href}
+            render={<Link to={item.href} />}
+          >
+            {item.label}
+          </NavigationItem>
+        </li>
+      ))}
+    </ul>
+  </nav>
+);
+
+const UtilityButtons: FC<{ utilities: Utility[] }> = ({ utilities }) => (
+  <StackLayout direction="row" gap={1}>
+    {utilities.map((utility) => (
+      <Button
+        key={utility.key}
+        aria-label={utility.label}
+        appearance="transparent"
+      >
+        {utility.icon}
+      </Button>
+    ))}
+  </StackLayout>
+);
+
+const DrawerNavigation: FC<{
+  activePath: string;
+  items: NavItem[];
+  onNavigate: () => void;
+}> = ({ activePath, items, onNavigate }) => (
+  <VerticalNavigation aria-label="Main navigation" appearance="indicator">
+    {items.map((item) => (
+      <VerticalNavigationItem key={item.href} active={activePath === item.href}>
+        <VerticalNavigationItemContent>
+          <VerticalNavigationItemTrigger
+            render={<Link to={item.href} />}
+            onClick={onNavigate}
+          >
+            <VerticalNavigationItemLabel>
+              {item.label}
+            </VerticalNavigationItemLabel>
+          </VerticalNavigationItemTrigger>
+        </VerticalNavigationItemContent>
+      </VerticalNavigationItem>
+    ))}
+  </VerticalNavigation>
+);
+
+const DrawerUtilities: FC<{
+  onNavigate: () => void;
+  utilities: Utility[];
+}> = ({ onNavigate, utilities }) => (
+  // Utility actions sit at the bottom of the drawer (pinned via CSS), below the
+  // primary navigation.
+  <div className="appHeaderPattern-drawerUtilities">
+    <VerticalNavigation aria-label="Utilities" appearance="indicator">
+      {utilities.map((utility) => (
+        <VerticalNavigationItem key={utility.key}>
+          <VerticalNavigationItemContent>
+            {/* Utilities are actions rather than routes, so the trigger renders
+                a button (no `href`/`render`). */}
+            <VerticalNavigationItemTrigger onClick={onNavigate}>
+              {utility.icon}
+              <VerticalNavigationItemLabel>
+                {utility.key}
+              </VerticalNavigationItemLabel>
+            </VerticalNavigationItemTrigger>
+          </VerticalNavigationItemContent>
+        </VerticalNavigationItem>
+      ))}
+    </VerticalNavigation>
+  </div>
+);
+
+// Hosts the app header within a page (BorderLayout + main + footer) so it can be
+// shown in context. The app header itself is the `<header>` region below (plus
+// its drawer on small viewports); the main/footer/placeholder content is only
+// scaffolding to demonstrate the sticky header and scroll shadow.
+const AppHeaderPage: FC = () => {
+  // The header collapses into a drawer on small viewports (xs and sm), matching
+  // the Salt breakpoints. This is driven by viewport width, not density —
+  // density (e.g. "mobile") is a device/input concern and is set separately.
+  const breakpoint = useCurrentBreakpoint();
+  const isSmallViewport = breakpoint === "xs" || breakpoint === "sm";
+  const scrolled = useScrolled();
+  const { pathname } = useLocation();
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [active, setActive] = useState(items?.[0]);
 
-  const [offset, setOffset] = useState(0);
   useEffect(() => {
-    const setScroll = () => {
-      setOffset(window.scrollY);
-    };
+    if (!isSmallViewport) {
+      setDrawerOpen(false);
+    }
+  }, [isSmallViewport]);
 
-    window.addEventListener("scroll", setScroll);
-    return () => {
-      window.removeEventListener("scroll", setScroll);
-    };
-  }, []);
-
-  const handleClick = (item: string) => {
-    setActive(item);
+  const closeDrawer = () => {
     setDrawerOpen(false);
   };
 
   return (
-    <header>
-      <StackLayout
-        direction="row"
-        gap={3}
-        style={{
-          width: "100%",
-          height: "calc(var(--salt-size-base) + var(--salt-spacing-200))",
-          backgroundColor: "var(--salt-container-primary-background)",
-          zIndex: "calc(var(--salt-zIndex-drawer) + 1)",
-          position: "fixed",
-          borderBottom:
-            "var(--salt-size-fixed-100) var(--salt-borderStyle-solid) var(--salt-separable-primary-borderColor)",
-          boxShadow: offset > 0 ? "var(--salt-shadow-1)" : "none",
-        }}
-      >
-        <FlexItem
-          style={{
-            justifyContent: "center",
-            display: "flex",
-            paddingLeft: "var(--salt-spacing-100)",
-          }}
+    <>
+      {/* The skip link is the first focusable element and sits outside the
+          header so it isn't part of the banner landmark. */}
+      <SkipLink targetId={mainContentId}>Skip to main content</SkipLink>
+      <BorderLayout>
+        {/* --- App header --- */}
+        <BorderItem
+          as="header"
+          position="north"
+          className="appHeaderPattern-header"
+          data-scrolled={scrolled}
+          data-small-viewport={isSmallViewport}
         >
-          {!drawerOpen && (
-            <Button
-              aria-label="Open navigation"
-              onClick={() => setDrawerOpen(true)}
-              style={{ alignSelf: "center" }}
-              appearance="transparent"
-            >
-              <MenuIcon aria-hidden />
-            </Button>
+          {isSmallViewport ? (
+            <>
+              <Button
+                aria-label="Open navigation"
+                appearance="transparent"
+                onClick={() => setDrawerOpen(true)}
+              >
+                <MenuIcon aria-hidden />
+              </Button>
+              <LogoLink />
+            </>
+          ) : (
+            <>
+              <LogoLink />
+              <NavigationList activePath={pathname} items={navigationItems} />
+              <UtilityButtons utilities={utilities} />
+            </>
           )}
-          {drawerOpen && (
+        </BorderItem>
+        <BorderItem as="main" position="center">
+          <H1 id={mainContentId} className="appHeaderPattern-heading">
+            Explore our offering
+          </H1>
+          {Array.from({ length: 12 }, (_, index) => (
+            <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: In this case, using index as key is acceptable
+              key={index}
+              className="appHeaderPattern-block"
+            />
+          ))}
+        </BorderItem>
+        <BorderItem position="south">
+          <div className="appHeaderPattern-footer">
+            <Text>Footer</Text>
+          </div>
+        </BorderItem>
+      </BorderLayout>
+      {/* The drawer is a modal overlay: its scrim covers and inerts everything
+          behind it (including the header), so the close control lives inside
+          the drawer rather than in the now-inert header. */}
+      {isSmallViewport && (
+        <Drawer
+          aria-label="Navigation menu"
+          open={drawerOpen}
+          onOpenChange={setDrawerOpen}
+        >
+          <div className="appHeaderPattern-drawerHeader">
+            <LogoLink onNavigate={closeDrawer} />
             <Button
               aria-label="Close navigation"
-              onClick={() => setDrawerOpen(false)}
-              style={{ alignSelf: "center" }}
               appearance="transparent"
+              onClick={closeDrawer}
             >
               <CloseIcon aria-hidden />
             </Button>
-          )}
-        </FlexItem>
-        <FlexItem align="center">
-          <img
-            alt="logo"
-            src={logo}
-            style={{
-              display: "block",
-              height: "calc(var(--salt-size-base) - var(--salt-spacing-150))",
-            }}
+          </div>
+          <DrawerNavigation
+            activePath={pathname}
+            items={navigationItems}
+            onNavigate={closeDrawer}
           />
-        </FlexItem>
-      </StackLayout>
-      <Drawer
-        aria-label="Main navigation"
-        style={{
-          paddingTop: "calc(var(--salt-size-base) + var(--salt-spacing-200))",
-          paddingLeft: "0",
-        }}
-        open={drawerOpen}
-        onOpenChange={() => {
-          if (drawerOpen) {
-            setDrawerOpen(false);
-          }
-        }}
-      >
-        <nav>
-          <ul style={{ listStyle: "none", padding: "0" }}>
-            {items?.map((item) => (
-              <li key={item}>
-                <NavigationItem
-                  orientation="vertical"
-                  active={active === item}
-                  href="#"
-                  onClick={() => {
-                    handleClick(item);
-                  }}
-                >
-                  {item}
-                </NavigationItem>
-              </li>
-            ))}
-            {utilities?.map((utility) => (
-              <li key={utility.key}>
-                <NavigationItem
-                  orientation="vertical"
-                  href="#"
-                  onClick={() => {
-                    setDrawerOpen(false);
-                  }}
-                >
-                  {utility.icon}
-                  {utility.key}
-                </NavigationItem>
-              </li>
-            ))}
-          </ul>
-        </nav>
-      </Drawer>
-    </header>
+          <DrawerUtilities onNavigate={closeDrawer} utilities={utilities} />
+        </Drawer>
+      )}
+    </>
   );
 };
 
-export const AppHeader = () => {
-  const isMobile = useResponsiveProp({ xs: true, sm: false }, false);
+/**
+ * The app header is responsive to the width of the viewport. At medium
+ * breakpoints and above it shows the full horizontal navigation and utilities;
+ * resize the preview (or use the Storybook viewport toolbar) below the small
+ * breakpoint to see it collapse into a drawer.
+ */
+export const AppHeader: StoryFn = () => <AppHeaderPage />;
 
-  const items = ["Home", "About", "Services", "Contact", "Blog"];
+/**
+ * The small-viewport experience, previewed at the extra small viewport. The
+ * collapse into a drawer is driven by the viewport breakpoint, so it applies to
+ * any small viewport (e.g. a narrow desktop window), independent of density. On
+ * an actual mobile device you would additionally set the density to "mobile".
+ */
+export const SmallViewport: StoryFn = AppHeader.bind({});
 
-  const utilities = [
-    {
-      icon: <SymphonyIcon />,
-      key: "Symphony",
-    },
-    {
-      icon: <StackoverflowIcon />,
-      key: "Stack Overflow",
-    },
-    {
-      icon: <GithubIcon />,
-      key: "GitHub",
-    },
-  ];
-
-  return (
-    <BorderLayout>
-      <BorderItem position="north">
-        {isMobile ? (
-          <MobileAppHeader items={items} utilities={utilities} />
-        ) : (
-          <DesktopAppHeader items={items} utilities={utilities} />
-        )}
-      </BorderItem>
-      <BorderItem
-        style={{
-          marginTop: "calc(var(--salt-size-base) + var(--salt-spacing-200))",
-        }}
-        position="center"
-      >
-        {Array.from({ length: 12 }, (_, index) => (
-          <div
-            // biome-ignore lint/suspicious/noArrayIndexKey: In this case, using index as key is acceptable
-            key={index}
-            style={{
-              padding: "var(--salt-spacing-400)",
-              margin: "var(--salt-spacing-400)",
-              backgroundColor: "var(--salt-container-secondary-background)",
-            }}
-          />
-        ))}
-      </BorderItem>
-      <BorderItem position="south">
-        <div
-          style={{
-            padding: "var(--salt-spacing-200)",
-            margin: "var(--salt-spacing-200)",
-            backgroundColor: "var(--salt-container-secondary-background)",
-          }}
-        >
-          <Text>Footer</Text>
-        </div>
-      </BorderItem>
-    </BorderLayout>
-  );
-};
-
-AppHeader.parameters = {
-  layout: "fullscreen",
+SmallViewport.globals = {
+  viewport: { value: "xs" },
 };


### PR DESCRIPTION
- Drive the responsive collapse from viewport breakpoints (useCurrentBreakpoint), decoupled from density
- Add a SmallViewport story via the viewport global
- Use MemoryRouter + Link for realistic client-side navigation and route-derived active state
- Flatten so the <header> owns its styling; make it sticky without clipping the scroll shadow
- Move drawer utilities into their own labelled group pinned to the bottom
- Move styles into app-header.stories.css and add a skip link outside the banner landmark