### PR TITLE
Remove outdated Button link in 'How to use' 

### DIFF
--- a/site/docs/components/button/usage.mdx
+++ b/site/docs/components/button/usage.mdx
@@ -11,7 +11,6 @@ data:
 ## Using the component
 
 - Keep the text description short, ideally one to three words and no more than five. If you’re including an icon with the text, use no more than three words.
-- For icons, use the Salt Figma icon library. If the icon you need isn’t available, follow the steps in our [Creating Salt icons](<https://www.figma.com/file/ibGX0b0CxUcZU3pn6OrqX7/Salt%3A-Icons-(Community)?type=design&node-id=490-74&mode=design>) guide.
 
 ### When to use
 


### PR DESCRIPTION
While referencing Button site docs, spotted an outdated link directing to the old UITK Icon library in Figma. Removed the line for now as internal links can go stale. 