### PR TITLE
Avatar | Add --saltAvatar-size CSS API

### DIFF
--- a/.changeset/fancy-women-read.md
+++ b/.changeset/fancy-women-read.md
@@ -1,0 +1,5 @@
+---
+"@salt-ds/core": minor
+---
+
+Added `--saltAvatar-size` for sizing an Avatar from a CSS length while keeping images, fallback icons and initials proportional.

--- a/.changeset/fancy-women-read.md
+++ b/.changeset/fancy-women-read.md
@@ -2,4 +2,4 @@
 "@salt-ds/core": minor
 ---
 
-Added `--saltAvatar-size` for sizing an Avatar from a CSS length while keeping images, fallback icons and initials proportional.
+Added `--saltAvatar-size` for sizing an Avatar from a CSS length. Images, fallback icons and initials stay proportional to that length across densities, matching the existing `size` multiplier ratio.

--- a/packages/core/src/__tests__/__e2e__/avatar/Avatar.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/avatar/Avatar.cy.tsx
@@ -1,12 +1,121 @@
 import { UserGroupSolidIcon } from "@salt-ds/icons";
 import { composeStories } from "@storybook/react-vite";
+import type { CSSProperties } from "react";
 import * as avatarStories from "~stories/avatar/avatar.stories";
 import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(avatarStories);
 const { Default } = composedStories;
+const directSizeStyle = {
+  "--saltAvatar-size": "18px",
+} as CSSProperties;
+
 describe("Given an Avatar", () => {
   checkAccessibility(composedStories);
+
+  it("should preserve the default size and font size", () => {
+    cy.mount(<Default name="Juanito Jones" />);
+
+    cy.get(".saltAvatar")
+      .should("have.css", "width", "56px")
+      .and("have.css", "height", "56px")
+      .and("have.css", "font-size", "20px");
+  });
+
+  it("should size initials from a direct size", () => {
+    cy.mount(<Default name="Juanito Jones" style={directSizeStyle} />);
+
+    cy.get(".saltAvatar")
+      .should("have.css", "width", "18px")
+      .and("have.css", "height", "18px")
+      .then(($avatar) => {
+        expect(Number.parseFloat($avatar.css("font-size"))).to.be.closeTo(
+          6.426,
+          0.01,
+        );
+      });
+  });
+
+  it("should cancel the multiplier when directly sizing initials", () => {
+    cy.mount(<Default name="Juanito Jones" size={4} style={directSizeStyle} />);
+
+    cy.get(".saltAvatar")
+      .should("have.css", "width", "18px")
+      .then(($avatar) => {
+        expect(Number.parseFloat($avatar.css("font-size"))).to.be.closeTo(
+          6.426,
+          0.01,
+        );
+      });
+  });
+
+  it("should directly size fallback icons to half the Avatar", () => {
+    cy.mount(<Default style={directSizeStyle} />);
+
+    cy.get(".saltAvatar")
+      .should("have.css", "width", "18px")
+      .find(".saltIcon")
+      .should("have.css", "width", "9px")
+      .and("have.css", "height", "9px");
+  });
+
+  it("should directly size images and custom SVGs to fill the Avatar", () => {
+    cy.mount(
+      <>
+        <Default
+          src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'><circle cx='20' cy='20' r='18' fill='blue'/></svg>"
+          style={directSizeStyle}
+        />
+        <Default style={directSizeStyle}>
+          <svg data-testid="custom-svg" viewBox="0 0 12 12" />
+        </Default>
+      </>,
+    );
+
+    cy.get(".saltAvatar")
+      .should("have.length", 2)
+      .each(($avatar) => {
+        cy.wrap($avatar)
+          .should("have.css", "width", "18px")
+          .and("have.css", "height", "18px");
+      });
+    cy.get("img")
+      .should("have.css", "width", "18px")
+      .and("have.css", "height", "18px");
+    cy.findByTestId("custom-svg")
+      .should("have.css", "width", "18px")
+      .and("have.css", "height", "18px");
+  });
+
+  it("should preserve the font size override multiplier semantics", () => {
+    cy.mount(
+      <Default
+        name="Juanito Jones"
+        style={
+          {
+            "--saltAvatar-size": "18px",
+            "--saltAvatar-fontSize": "7px",
+          } as CSSProperties
+        }
+      />,
+    );
+
+    cy.get(".saltAvatar").should("have.css", "font-size", "14px");
+  });
+
+  it("should allow a style multiplier to override the size prop", () => {
+    cy.mount(
+      <Default
+        name="Juanito Jones"
+        size={4}
+        style={{ "--saltAvatar-size-multiplier": "1" } as CSSProperties}
+      />,
+    );
+
+    cy.get(".saltAvatar")
+      .should("have.css", "width", "28px")
+      .and("have.css", "font-size", "10px");
+  });
 
   it("should show the default fallback icon when nothing is provided", () => {
     cy.mount(<Default />);

--- a/packages/core/src/__tests__/__e2e__/avatar/Avatar.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/avatar/Avatar.cy.tsx
@@ -1,121 +1,12 @@
 import { UserGroupSolidIcon } from "@salt-ds/icons";
 import { composeStories } from "@storybook/react-vite";
-import type { CSSProperties } from "react";
 import * as avatarStories from "~stories/avatar/avatar.stories";
 import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(avatarStories);
 const { Default } = composedStories;
-const directSizeStyle = {
-  "--saltAvatar-size": "18px",
-} as CSSProperties;
-
 describe("Given an Avatar", () => {
   checkAccessibility(composedStories);
-
-  it("should preserve the default size and font size", () => {
-    cy.mount(<Default name="Juanito Jones" />);
-
-    cy.get(".saltAvatar")
-      .should("have.css", "width", "56px")
-      .and("have.css", "height", "56px")
-      .and("have.css", "font-size", "20px");
-  });
-
-  it("should size initials from a direct size", () => {
-    cy.mount(<Default name="Juanito Jones" style={directSizeStyle} />);
-
-    cy.get(".saltAvatar")
-      .should("have.css", "width", "18px")
-      .and("have.css", "height", "18px")
-      .then(($avatar) => {
-        expect(Number.parseFloat($avatar.css("font-size"))).to.be.closeTo(
-          6.426,
-          0.01,
-        );
-      });
-  });
-
-  it("should cancel the multiplier when directly sizing initials", () => {
-    cy.mount(<Default name="Juanito Jones" size={4} style={directSizeStyle} />);
-
-    cy.get(".saltAvatar")
-      .should("have.css", "width", "18px")
-      .then(($avatar) => {
-        expect(Number.parseFloat($avatar.css("font-size"))).to.be.closeTo(
-          6.426,
-          0.01,
-        );
-      });
-  });
-
-  it("should directly size fallback icons to half the Avatar", () => {
-    cy.mount(<Default style={directSizeStyle} />);
-
-    cy.get(".saltAvatar")
-      .should("have.css", "width", "18px")
-      .find(".saltIcon")
-      .should("have.css", "width", "9px")
-      .and("have.css", "height", "9px");
-  });
-
-  it("should directly size images and custom SVGs to fill the Avatar", () => {
-    cy.mount(
-      <>
-        <Default
-          src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'><circle cx='20' cy='20' r='18' fill='blue'/></svg>"
-          style={directSizeStyle}
-        />
-        <Default style={directSizeStyle}>
-          <svg data-testid="custom-svg" viewBox="0 0 12 12" />
-        </Default>
-      </>,
-    );
-
-    cy.get(".saltAvatar")
-      .should("have.length", 2)
-      .each(($avatar) => {
-        cy.wrap($avatar)
-          .should("have.css", "width", "18px")
-          .and("have.css", "height", "18px");
-      });
-    cy.get("img")
-      .should("have.css", "width", "18px")
-      .and("have.css", "height", "18px");
-    cy.findByTestId("custom-svg")
-      .should("have.css", "width", "18px")
-      .and("have.css", "height", "18px");
-  });
-
-  it("should preserve the font size override multiplier semantics", () => {
-    cy.mount(
-      <Default
-        name="Juanito Jones"
-        style={
-          {
-            "--saltAvatar-size": "18px",
-            "--saltAvatar-fontSize": "7px",
-          } as CSSProperties
-        }
-      />,
-    );
-
-    cy.get(".saltAvatar").should("have.css", "font-size", "14px");
-  });
-
-  it("should allow a style multiplier to override the size prop", () => {
-    cy.mount(
-      <Default
-        name="Juanito Jones"
-        size={4}
-        style={{ "--saltAvatar-size-multiplier": "1" } as CSSProperties}
-      />,
-    );
-
-    cy.get(".saltAvatar")
-      .should("have.css", "width", "28px")
-      .and("have.css", "font-size", "10px");
-  });
 
   it("should show the default fallback icon when nothing is provided", () => {
     cy.mount(<Default />);

--- a/packages/core/src/__tests__/__e2e__/avatar/Avatar.cy.tsx
+++ b/packages/core/src/__tests__/__e2e__/avatar/Avatar.cy.tsx
@@ -1,16 +1,43 @@
 import { UserGroupSolidIcon } from "@salt-ds/icons";
 import { composeStories } from "@storybook/react-vite";
+import type { CSSProperties } from "react";
 import * as avatarStories from "~stories/avatar/avatar.stories";
 import { checkAccessibility } from "~test-utils/checkAccessibility";
 
 const composedStories = composeStories(avatarStories);
 const { Default } = composedStories;
+const directSizeStyle = {
+  "--saltAvatar-size": "18px",
+} as CSSProperties;
+
 describe("Given an Avatar", () => {
   checkAccessibility(composedStories);
 
   it("should show the default fallback icon when nothing is provided", () => {
     cy.mount(<Default />);
     cy.findByTestId("UserIcon").should("exist");
+  });
+
+  it("should keep direct sizing independent of the size multiplier", () => {
+    cy.mount(
+      <>
+        <Default name="Size one" size={1} style={directSizeStyle} />
+        <Default name="Size four" size={4} style={directSizeStyle} />
+      </>,
+    );
+
+    cy.findAllByRole("img").should(($avatars) => {
+      expect($avatars).to.have.length(2);
+
+      const sizeOne = $avatars.eq(0);
+      const sizeFour = $avatars.eq(1);
+
+      expect(sizeOne.css("width")).to.equal("18px");
+      expect(sizeOne.css("height")).to.equal("18px");
+      expect(sizeFour.css("width")).to.equal("18px");
+      expect(sizeFour.css("height")).to.equal("18px");
+      expect(sizeFour.css("font-size")).to.equal(sizeOne.css("font-size"));
+    });
   });
 
   it("should show initials if only a name is provided", () => {

--- a/packages/core/src/avatar/Avatar.css
+++ b/packages/core/src/avatar/Avatar.css
@@ -2,8 +2,10 @@
 .saltAvatar {
   --avatar-size-multiplier: var(--saltAvatar-size-multiplier, 1);
   --avatar-base-size: var(--salt-size-base);
-  --avatar-base-fontSize: var(--saltAvatar-fontSize, var(--salt-text-notation-fontSize));
-  --avatar-container-size: calc(var(--avatar-base-size) * var(--avatar-size-multiplier));
+  /* 10 / 28 (--salt-text-notation-fontSize / --salt-size-base at medium density)  preserves the initials-to-container ratio */
+  --avatar-direct-fontSize: calc(var(--saltAvatar-size) * (10 / 28) / var(--avatar-size-multiplier));
+  --avatar-base-fontSize: var(--saltAvatar-fontSize, var(--avatar-direct-fontSize, var(--salt-text-notation-fontSize)));
+  --avatar-container-size: var(--saltAvatar-size, calc(var(--avatar-base-size) * var(--avatar-size-multiplier)));
   --avatar-fontSize: calc(var(--avatar-base-fontSize) * var(--avatar-size-multiplier));
   /* Icon styling */
   --saltIcon-size: calc(var(--avatar-container-size) / 2);

--- a/packages/core/src/avatar/Avatar.css
+++ b/packages/core/src/avatar/Avatar.css
@@ -1,9 +1,29 @@
+/* TODO: Remove hardcoded values - unitless notation-fontSize / size-base because Firefox can't do unit division  */
+.salt-density-high {
+  --avatar-fontSize-ratio: calc(8 / 20);
+}
+
+.salt-density-medium {
+  --avatar-fontSize-ratio: calc(10 / 28);
+}
+
+.salt-density-low {
+  --avatar-fontSize-ratio: calc(12 / 36);
+}
+
+.salt-density-touch {
+  --avatar-fontSize-ratio: calc(14 / 44);
+}
+
+.salt-density-mobile {
+  --avatar-fontSize-ratio: calc(12 / 44);
+}
+
 /* Default variables applied to the root element */
 .saltAvatar {
   --avatar-size-multiplier: var(--saltAvatar-size-multiplier, 1);
   --avatar-base-size: var(--salt-size-base);
-  /* 10 / 28 (--salt-text-notation-fontSize / --salt-size-base at medium density)  preserves the initials-to-container ratio */
-  --avatar-direct-fontSize: calc(var(--saltAvatar-size) * (10 / 28) / var(--avatar-size-multiplier));
+  --avatar-direct-fontSize: calc(var(--saltAvatar-size) * var(--avatar-fontSize-ratio) / var(--avatar-size-multiplier));
   --avatar-base-fontSize: var(--saltAvatar-fontSize, var(--avatar-direct-fontSize, var(--salt-text-notation-fontSize)));
   --avatar-container-size: var(--saltAvatar-size, calc(var(--avatar-base-size) * var(--avatar-size-multiplier)));
   --avatar-fontSize: calc(var(--avatar-base-fontSize) * var(--avatar-size-multiplier));

--- a/packages/core/stories/avatar/avatar.qa.stories.tsx
+++ b/packages/core/stories/avatar/avatar.qa.stories.tsx
@@ -2,12 +2,17 @@ import { Avatar } from "@salt-ds/core";
 import { SaltShakerIcon } from "@salt-ds/icons";
 import type { Meta, StoryFn } from "@storybook/react-vite";
 import { QAContainer, type QAContainerProps } from "docs/components";
+import type { CSSProperties } from "react";
 import persona1 from "../assets/avatar.png";
 
 export default {
   title: "Core/Avatar/Avatar QA",
   component: Avatar,
 } as Meta<typeof Avatar>;
+
+const directSizeStyle = {
+  "--saltAvatar-size": "var(--salt-text-h3-lineHeight)",
+} as CSSProperties;
 
 export const AllVariantsGrid: StoryFn<QAContainerProps> = (props) => (
   <QAContainer height={500} width={1000} {...props}>
@@ -35,6 +40,9 @@ export const AllVariantsGrid: StoryFn<QAContainerProps> = (props) => (
     <Avatar name="Peter Piper" color="category-18" />
     <Avatar name="Peter Piper" color="category-19" />
     <Avatar name="Peter Piper" color="category-20" />
+    <Avatar src={persona1} style={directSizeStyle} />
+    <Avatar name="Alex Brailescu" style={directSizeStyle} />
+    <Avatar style={directSizeStyle} />
   </QAContainer>
 );
 

--- a/packages/core/stories/avatar/avatar.stories.tsx
+++ b/packages/core/stories/avatar/avatar.stories.tsx
@@ -1,13 +1,14 @@
 import {
   Avatar,
   FlowLayout,
+  H3,
   StackLayout,
   Text,
   useAvatarImage,
 } from "@salt-ds/core";
 import { UserGroupSolidIcon } from "@salt-ds/icons";
 import type { Meta, StoryFn } from "@storybook/react-vite";
-import type { ComponentProps, ReactNode } from "react";
+import type { ComponentProps, CSSProperties, ReactNode } from "react";
 import persona1 from "../assets/avatar.png";
 
 export default {
@@ -55,6 +56,23 @@ export const Sizes: StoryFn<typeof Avatar> = (args) => {
           <Text>size: {size}</Text>
         </StackLayout>
       ))}
+    </FlowLayout>
+  );
+};
+
+export const TypographyAlignedSize: StoryFn<typeof Avatar> = (args) => {
+  return (
+    <FlowLayout align="center" gap={1}>
+      <Avatar
+        {...args}
+        name="Alex Brailescu"
+        style={
+          {
+            "--saltAvatar-size": "var(--salt-text-h3-lineHeight)",
+          } as CSSProperties
+        }
+      />
+      <H3>Alex Brailescu</H3>
     </FlowLayout>
   );
 };

--- a/packages/core/stories/avatar/avatar.stories.tsx
+++ b/packages/core/stories/avatar/avatar.stories.tsx
@@ -1,7 +1,10 @@
 import {
   Avatar,
   FlowLayout,
+  H1,
+  H2,
   H3,
+  H4,
   StackLayout,
   Text,
   useAvatarImage,
@@ -60,20 +63,31 @@ export const Sizes: StoryFn<typeof Avatar> = (args) => {
   );
 };
 
+const typographyAlignedRows = [
+  { Heading: H1, size: "var(--salt-text-h1-lineHeight)" },
+  { Heading: H2, size: "var(--salt-text-h2-lineHeight)" },
+  { Heading: H3, size: "var(--salt-text-h3-lineHeight)" },
+  { Heading: H4, size: "var(--salt-text-h4-lineHeight)" },
+] as const;
+
 export const TypographyAlignedSize: StoryFn<typeof Avatar> = (args) => {
   return (
-    <FlowLayout align="center" gap={1}>
-      <Avatar
-        {...args}
-        name="Alex Brailescu"
-        style={
-          {
-            "--saltAvatar-size": "var(--salt-text-h3-lineHeight)",
-          } as CSSProperties
-        }
-      />
-      <H3>Alex Brailescu</H3>
-    </FlowLayout>
+    <StackLayout gap={2}>
+      {typographyAlignedRows.map(({ Heading, size }) => (
+        <FlowLayout key={size} align="center" gap={1}>
+          <Avatar
+            {...args}
+            name="Alex Brailescu"
+            style={
+              {
+                "--saltAvatar-size": size,
+              } as CSSProperties
+            }
+          />
+          <Heading>Alex Brailescu</Heading>
+        </FlowLayout>
+      ))}
+    </StackLayout>
   );
 };
 


### PR DESCRIPTION
Proposed approach to sizing and scaling Avatar so it works with typography alignment 
Hardcoding the ratios is far from ideal - very open to suggestion - the reason why the token based division wasn't used was because firefox does not support division with units