### PR TITLE
Add Overlay placement options

### DIFF
--- a/.changeset/brown-views-drive.md
+++ b/.changeset/brown-views-drive.md
@@ -1,0 +1,6 @@
+---
+"@salt-ds/core": minor
+---
+
+Expand `Overlay` placement options to include all FloatingUI placement type options (-start and -end on top, bottom, left and right).
+

--- a/.changeset/brown-views-drive.md
+++ b/.changeset/brown-views-drive.md
@@ -3,4 +3,3 @@
 ---
 
 Expand `Overlay` placement options to include all FloatingUI placement type options (-start and -end on top, bottom, left and right).
-

--- a/packages/core/src/__tests__/__e2e__/overlay/overlay.browser.test.tsx
+++ b/packages/core/src/__tests__/__e2e__/overlay/overlay.browser.test.tsx
@@ -7,16 +7,8 @@ import { renderWithSalt } from "~browser-test-utils/render";
 import * as overlayStories from "~stories/overlay/overlay.stories";
 
 const composedStories = composeStories(overlayStories);
-const {
-  Default,
-  Right,
-  Bottom,
-  Left,
-  CloseButton,
-  HideArrow,
-  LongContent,
-  WithTooltip,
-} = composedStories;
+const { Default, Placement, CloseButton, HideArrow, LongContent, WithTooltip } =
+  composedStories;
 const trigger = () => page.getByRole("button", { name: /Show Overlay/i });
 
 describe("GIVEN an Overlay", () => {
@@ -81,16 +73,16 @@ describe("GIVEN an Overlay", () => {
   });
 
   const placementCases = [
-    ["top", Default, "y", "greater"] as const,
-    ["right", Right, "x", "less"] as const,
-    ["bottom", Bottom, "y", "less"] as const,
-    ["left", Left, "x", "greater"] as const,
+    ["top", "y", "greater"] as const,
+    ["right", "x", "less"] as const,
+    ["bottom", "y", "less"] as const,
+    ["left", "x", "greater"] as const,
   ];
 
-  for (const [placement, Story, axis, comparison] of placementCases) {
+  for (const [placement, axis, comparison] of placementCases) {
     describe(`WHEN mounted ${placement}`, () => {
       it(`THEN it should appear on ${placement} of trigger element`, async () => {
-        await renderWithSalt(<Story />);
+        await renderWithSalt(<Placement placement={placement} />);
         await trigger().click();
         const dialog = page.getByRole("dialog");
         const overlayTrigger = page.getByText(/Show Overlay/i);

--- a/packages/core/src/overlay/Overlay.tsx
+++ b/packages/core/src/overlay/Overlay.tsx
@@ -10,7 +10,11 @@ import {
   useRole,
 } from "@floating-ui/react";
 import { type ReactNode, useMemo, useRef } from "react";
-import { useControlled, useFloatingUI } from "../utils";
+import {
+  type UseFloatingUIProps,
+  useControlled,
+  useFloatingUI,
+} from "../utils";
 import { OverlayContext, type OverlayContextValue } from "./OverlayContext";
 
 export interface OverlayProps {
@@ -29,7 +33,7 @@ export interface OverlayProps {
   /**
    * Set the placement of the Overlay component relative to the trigger element. Defaults to `top`.
    */
-  placement?: "top" | "bottom" | "left" | "right";
+  placement?: UseFloatingUIProps["placement"];
   /**
    * When `true`, the arrow indicator is hidden
    */

--- a/packages/core/stories/overlay/overlay.stories.tsx
+++ b/packages/core/stories/overlay/overlay.stories.tsx
@@ -20,11 +20,33 @@ import { type ChangeEvent, useState } from "react";
 import "./overlay.stories.css";
 import { CloseIcon, MicroMenuIcon } from "@salt-ds/icons";
 
+const placementOptions = [
+  "top",
+  "top-start",
+  "top-end",
+  "right",
+  "right-start",
+  "right-end",
+  "bottom",
+  "bottom-start",
+  "bottom-end",
+  "left",
+  "left-start",
+  "left-end",
+] satisfies NonNullable<OverlayProps["placement"]>[];
+
 export default {
   title: "Core/Overlay",
+  component: Overlay,
+  argTypes: {
+    placement: {
+      options: placementOptions,
+      control: { type: "select" },
+    },
+  },
 } as Meta<typeof Overlay>;
 
-export const Default: StoryFn<OverlayProps> = ({ ...args }) => {
+const OverlayTemplate = ({ ...args }: OverlayProps) => {
   const id = useId();
 
   return (
@@ -45,19 +67,21 @@ export const Default: StoryFn<OverlayProps> = ({ ...args }) => {
   );
 };
 
-export const Bottom = Default.bind({});
-Bottom.args = {
-  placement: "bottom",
-};
+export const Default: StoryFn<OverlayProps> = OverlayTemplate;
 
-export const Left = Default.bind({});
-Left.args = {
-  placement: "left",
-};
-
-export const Right = Default.bind({});
-Right.args = {
-  placement: "right",
+export const Placement: StoryFn<OverlayProps> = (args) => (
+  <div
+    style={{
+      display: "grid",
+      minHeight: 300,
+      placeItems: "center",
+    }}
+  >
+    <OverlayTemplate {...args} />
+  </div>
+);
+Placement.args = {
+  placement: "bottom-start",
 };
 
 export const HideArrow = Default.bind({});

--- a/site/docs/components/overlay/examples.mdx
+++ b/site/docs/components/overlay/examples.mdx
@@ -16,7 +16,7 @@ The basic overlay component allows the user to expose and interact with suppleme
 
 ## Placement
 
-Use the `placement` prop to position overlay content to the `top`, `bottom`, `left` or `right` of the trigger element.
+Use the `placement` prop to position overlay content relative to the trigger. The default placement is `top`.
 
 <LivePreview componentName="overlay" exampleName="Placement" />
 


### PR DESCRIPTION
Add -start and -end placement options per FloatingUIs `placement` type. Shouldn't be breaking since they are a superset of the previous prop options